### PR TITLE
Fix grid name confilct issues

### DIFF
--- a/gridsync/gui/setup.py
+++ b/gridsync/gui/setup.py
@@ -270,7 +270,7 @@ class SetupForm(QStackedWidget):
     def on_already_joined(self, grid_name):
         QMessageBox.information(
             self,
-            "Already connected", 
+            "Already connected",
             'You are already connected to "{}"'.format(grid_name)
         )
         self.close()

--- a/gridsync/gui/setup.py
+++ b/gridsync/gui/setup.py
@@ -267,6 +267,14 @@ class SetupForm(QStackedWidget):
         self.page_2.progressbar.setValue(self.page_2.progressbar.maximum())
         self.finish_button.show()
 
+    def on_already_joined(self, grid_name):
+        QMessageBox.information(
+            self,
+            "Already connected", 
+            'You are already connected to "{}"'.format(grid_name)
+        )
+        self.close()
+
     def verify_settings(self, settings):
         nickname = settings['nickname']
         if os.path.isdir(os.path.join(config_dir, nickname)):
@@ -291,6 +299,7 @@ class SetupForm(QStackedWidget):
         self.setup_runner = SetupRunner(self.known_gateways)
         steps = self.setup_runner.calculate_total_steps(settings) + 2
         self.page_2.progressbar.setMaximum(steps)
+        self.setup_runner.grid_already_joined.connect(self.on_already_joined)
         self.setup_runner.update_progress.connect(self.update_progress)
         self.setup_runner.got_icon.connect(self.load_service_icon)
         self.setup_runner.done.connect(self.on_done)

--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -408,6 +408,15 @@ class InviteReceiver(QWidget):
                 'Successfully joined {}!\n{} are now available for '
                 'download'.format(target, target))
 
+    def on_grid_already_joined(self, grid_name):
+        QMessageBox.information(
+            self,
+            "Already connected",
+            'You are already connected to "{}"'.format(grid_name)
+        )
+        self.wormhole.close()
+        self.close()
+
     def got_message(self, message):
         self.update_progress("Reading invitation...")  # 3
         if 'rootcap' in message:
@@ -436,6 +445,9 @@ class InviteReceiver(QWidget):
                             message['magic-folders'][target] = data
                             del message['magic-folders'][folder]
         self.setup_runner = SetupRunner(self.gateways)
+        if not message.get('magic-folders'):
+            self.setup_runner.grid_already_joined.connect(
+                self.on_grid_already_joined)
         self.setup_runner.update_progress.connect(self.update_progress)
         self.setup_runner.joined_folders.connect(self.set_joined_folders)
         self.setup_runner.done.connect(self.on_done)

--- a/gridsync/setup.py
+++ b/gridsync/setup.py
@@ -18,6 +18,7 @@ from gridsync.tahoe import Tahoe, select_executable
 
 class SetupRunner(QObject):
 
+    grid_already_joined = pyqtSignal(str)
     update_progress = pyqtSignal(str)
     joined_folders = pyqtSignal(list)
     got_icon = pyqtSignal(str)
@@ -173,6 +174,8 @@ class SetupRunner(QObject):
         self.gateway = self.get_gateway(settings.get('introducer'))
         if not self.gateway:
             yield self.join_grid(settings)
+        else:
+            self.grid_already_joined.emit(settings.get('nickname'))
 
         yield self.ensure_recovery(settings)
 


### PR DESCRIPTION
Previously, when accepting grid invites through the initial setup dialog, Gridsync would always prompt for a rename if the target nodedir existed, leading to the problems described in Issue #68. This PR updates post-invite/pre-setup behavior to prompt for a grid rename if and only if the target nodedir already exists but the introducer fURL differs (thereby re-using the existing client instance unless the introducer is actually different) and shows an informational message to users to inform them that that they have already joined the grid in question.

Fixes #68 