### PR TITLE
65.introducerless mode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ disable=
     too-few-public-methods,
     too-many-instance-attributes,
     too-many-branches,
+    too-many-lines,
     too-many-locals,
     too-many-public-methods,
     too-many-statements,

--- a/gridsync/setup.py
+++ b/gridsync/setup.py
@@ -143,6 +143,15 @@ class SetupRunner(QObject):
         else:
             log.warning("Error fetching service icon: %i", resp.code)
 
+    def add_storage_servers(self, storage_servers):
+        for server_id, data in storage_servers.items():
+            nickname = data.get('nickname')
+            furl = data.get('anonymous-storage-FURL')
+            if furl:
+                self.gateway.add_storage_server(server_id, furl, nickname)
+            else:
+                log.warning("No storage fURL provided for %s!", server_id)
+
     @inlineCallbacks  # noqa: max-complexity=13 XXX
     def join_grid(self, settings):
         if 'nickname' in settings:
@@ -182,6 +191,10 @@ class SetupRunner(QObject):
             multi_folder_support=multi_folder_support
         )
         yield self.gateway.create_client(**settings)
+
+        storage_servers = settings.get('storage')
+        if storage_servers and isinstance(storage_servers, dict):
+            self.add_storage_servers(storage_servers)
 
         if icon_path:
             try:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -123,11 +123,13 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
     def get_settings(self, include_rootcap=False):
         settings = {
             'nickname': self.name,
-            'introducer': self.config_get('client', 'introducer.furl'),
             'shares-needed': self.config_get('client', 'shares.needed'),
             'shares-happy': self.config_get('client', 'shares.happy'),
             'shares-total': self.config_get('client', 'shares.total')
         }
+        introducer = self.config_get('client', 'introducer.furl')
+        if introducer:
+            settings['introducer'] = introducer
         storage_servers = self.get_storage_servers()
         if storage_servers:
             settings['storage'] = storage_servers

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -203,7 +203,7 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
                 data = yaml.safe_load(f)
         except OSError:
             data = {}
-        if not 'storage' in data:
+        if 'storage' not in data:
             data['storage'] = {}
         data['storage'][server_id] = {
             'ann': {'anonymous-storage-FURL': furl, 'nickname': nickname}

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -196,6 +196,22 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
     def remove_alias(self, alias):
         self._set_alias(alias)
 
+    def add_storage_server(self, server_id, furl, nickname=''):
+        yaml_path = os.path.join(self.nodedir, 'private', 'servers.yaml')
+        try:
+            with open(yaml_path) as f:
+                data = yaml.safe_load(f)
+        except OSError:
+            data = {}
+        if not 'storage' in data:
+            data['storage'] = {}
+        data['storage'][server_id] = {
+            'ann': {'anonymous-storage-FURL': furl, 'nickname': nickname}
+        }
+        with open(yaml_path + '.tmp', 'w') as f:
+            f.write(yaml.safe_dump(data, default_flow_style=False))
+        shutil.move(yaml_path + '.tmp', yaml_path)
+
     def load_magic_folders(self):
         data = {}
         yaml_path = os.path.join(self.nodedir, 'private', 'magic_folders.yaml')

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -224,6 +224,7 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
         return results
 
     def add_storage_server(self, server_id, furl, nickname=''):
+        log.debug("Adding storage server: %s...", server_id)
         yaml_data = self._read_servers_yaml()
         if not yaml_data or not yaml_data.get('storage'):
             yaml_data['storage'] = {}
@@ -233,6 +234,7 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
         with open(self.servers_yaml_path + '.tmp', 'w') as f:
             f.write(yaml.safe_dump(yaml_data, default_flow_style=False))
         shutil.move(self.servers_yaml_path + '.tmp', self.servers_yaml_path)
+        log.debug("Added storage server: %s", server_id)
 
     def load_magic_folders(self):
         data = {}

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -128,6 +128,9 @@ class Tahoe(object):  # pylint: disable=too-many-public-methods
             'shares-happy': self.config_get('client', 'shares.happy'),
             'shares-total': self.config_get('client', 'shares.total')
         }
+        storage_servers = self.get_storage_servers()
+        if storage_servers:
+            settings['storage'] = storage_servers
         icon_path = os.path.join(self.nodedir, 'icon')
         icon_url_path = icon_path + '.url'
         if os.path.exists(icon_url_path):

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -178,6 +178,21 @@ def test_remove_alias_idempotent(tahoe):
     assert not tahoe.get_alias('added_alias')
 
 
+def test_add_storage_server(tahoe):
+    tahoe.add_storage_server('v0-test', 'pb://test@test/test', 'Test')
+    with open(os.path.join(tahoe.nodedir, 'private', 'servers.yaml')) as f:
+        data = yaml.safe_load(f)
+    assert data == {
+        'storage': {
+            'v0-test': {
+                'ann': {
+                    'anonymous-storage-FURL': 'pb://test@test/test',
+                    'nickname': 'Test'}
+            }
+        }
+    }
+
+
 def test_load_magic_folders(tahoe):
     tahoe.load_magic_folders()
     assert tahoe.magic_folders['test_folder']['directory'] == 'test_dir'

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -187,7 +187,8 @@ def test_add_storage_server(tahoe):
             'v0-test': {
                 'ann': {
                     'anonymous-storage-FURL': 'pb://test@test/test',
-                    'nickname': 'Test'}
+                    'nickname': 'Test'
+                }
             }
         }
     }

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -178,19 +178,32 @@ def test_remove_alias_idempotent(tahoe):
     assert not tahoe.get_alias('added_alias')
 
 
-def test_add_storage_server(tahoe):
-    tahoe.add_storage_server('v0-test', 'pb://test@test/test', 'Test')
-    with open(os.path.join(tahoe.nodedir, 'private', 'servers.yaml')) as f:
-        data = yaml.safe_load(f)
-    assert data == {
+def test_get_storage_servers_empty(tahoe):
+    assert tahoe.get_storage_servers() == {}
+
+
+def test_get_storage_servers_non_empty(tahoe):
+    data = {
         'storage': {
-            'v0-test': {
+            'v0-aaa': {
                 'ann': {
-                    'anonymous-storage-FURL': 'pb://test@test/test',
-                    'nickname': 'Test'
+                    'anonymous-storage-FURL': 'pb://a.a',
+                    'nickname': 'alice'
                 }
             }
         }
+    }
+    with open(tahoe.servers_yaml_path, 'w') as f:
+        f.write(yaml.safe_dump(data, default_flow_style=False))
+    assert tahoe.get_storage_servers() == {
+        'v0-aaa': {'anonymous-storage-FURL': 'pb://a.a', 'nickname': 'alice'}
+    }
+
+
+def test_add_storage_server(tahoe):
+    tahoe.add_storage_server('v0-bbb', 'pb://b.b', 'bob')
+    assert tahoe.get_storage_servers().get('v0-bbb') == {
+        'anonymous-storage-FURL': 'pb://b.b', 'nickname': 'bob'
     }
 
 


### PR DESCRIPTION
This PR adds support for reading/writing storage fURLs from/to `$nodedir/private/servers.yaml` directly and allows for grids to be joined via invite codes without the need to specify an introducer fURL.

Closes #65 