### PR TITLE
Don't pass size ints through pyqtSignal/pyqtSlot

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -238,7 +238,7 @@ class Model(QStandardItemModel):
             naturaltime(datetime.now() - datetime.fromtimestamp(mtime)))
         item.setToolTip("Last modified: {}".format(time.ctime(mtime)))
 
-    @pyqtSlot(str, int)
+    @pyqtSlot(str, object)
     def set_size(self, name, size):
         item = self.item(self.findItems(name)[0].row(), 3)
         item.setText(naturalsize(size))

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -17,7 +17,7 @@ class Monitor(QObject):
     data_updated = pyqtSignal(str, object)
     status_updated = pyqtSignal(str, int)
     mtime_updated = pyqtSignal(str, int)
-    size_updated = pyqtSignal(str, int)
+    size_updated = pyqtSignal(str, object)
     member_added = pyqtSignal(str, str)
     first_sync_started = pyqtSignal(str)
     sync_started = pyqtSignal(str)


### PR DESCRIPTION
Otherwise, since PyQt uses C++ types, this can cause overflows

Fixes #78