### PR TITLE
Purge legacy code

### DIFF
--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -38,19 +38,18 @@ class Core():
         self.gui = None
         self.gateways = []
         self.executable = None
-        self.multi_folder_support = None
         self.operations = []
 
     @inlineCallbacks
     def select_executable(self):
-        self.executable, self.multi_folder_support = yield select_executable()
-        logging.debug("Selected executable: %s (multi_folder_support=%s)",
-                      self.executable, self.multi_folder_support)
+        self.executable = yield select_executable()
+        logging.debug("Selected executable: %s", self.executable)
         if not self.executable:
             msg.critical(
                 "Tahoe-LAFS not found",
                 "Could not find a suitable 'tahoe' executable in your PATH. "
-                "Please install Tahoe-LAFS (version >= 1.12) and try again.")
+                "Please install Tahoe-LAFS version 1.13.0 or greater and try "
+                "again.")
             reactor.stop()
 
     @inlineCallbacks
@@ -64,11 +63,7 @@ class Core():
             tor_available = yield get_tor(reactor)
             logging.debug("Starting Tahoe-LAFS gateway(s)...")
             for nodedir in nodedirs:
-                gateway = Tahoe(
-                    nodedir,
-                    executable=self.executable,
-                    multi_folder_support=self.multi_folder_support
-                )
+                gateway = Tahoe(nodedir, executable=self.executable)
                 tcp = gateway.config_get('connections', 'tcp')
                 if tcp == 'tor' and not tor_available:
                     msg.error(

--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
     QProgressBar, QPushButton, QSizePolicy, QSpacerItem, QToolButton, QWidget)
 from twisted.internet import reactor
 from twisted.internet.defer import (
-    CancelledError, gatherResults, inlineCallbacks, returnValue)
+    CancelledError, gatherResults, inlineCallbacks)
 import wormhole.errors
 
 from gridsync import resource, config_dir
@@ -290,7 +290,7 @@ class ShareWidget(QDialog):
             self.wormhole.close()
             error(self, "Invite Error", str(err))
             self.close()
-        returnValue((folder, member_id, code))
+        return folder, member_id, code
 
     @inlineCallbacks
     def get_folder_invites(self):
@@ -303,7 +303,7 @@ class ShareWidget(QDialog):
         for folder, member_id, code in results:
             folders_data[folder] = {'code': code}
             self.pending_invites.append((folder, member_id))
-        returnValue(folders_data)
+        return folders_data
 
     @inlineCallbacks
     def go(self):

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -175,9 +175,8 @@ class View(QTreeView):
         self.share_widgets.append(share_widget)  # TODO: Remove on close
         share_widget.show()
 
-    def maybe_restart_gateway(self, _):
-        if self.gateway.multi_folder_support:
-            self.gateway.restart()
+    def restart_gateway(self, _):
+        self.gateway.restart()
 
     def select_download_location(self, folders):
         dest = QFileDialog.getExistingDirectory(
@@ -196,7 +195,7 @@ class View(QTreeView):
                 self.gateway.create_magic_folder(path, join_code, admin_dircap)
             )
         d = DeferredList(tasks)
-        d.addCallback(self.maybe_restart_gateway)
+        d.addCallback(self.restart_gateway)
 
     def show_failure(self, failure):
         msg = QMessageBox(self)
@@ -409,7 +408,7 @@ class View(QTreeView):
                 self.model().add_folder(path)
                 tasks.append(self.gateway.create_magic_folder(path))
             d = DeferredList(tasks)
-            d.addCallback(self.maybe_restart_gateway)
+            d.addCallback(self.restart_gateway)
 
     def select_folder(self):
         dialog = QFileDialog(self, "Please select a folder")

--- a/gridsync/setup.py
+++ b/gridsync/setup.py
@@ -213,13 +213,9 @@ class SetupRunner(QObject):
             except Exception as e:  # pylint: disable=broad-except
                 log.warning("Error fetching service icon: %s", str(e))
 
-        executable, multi_folder_support = yield select_executable()
+        executable = yield select_executable()
         nodedir = os.path.join(config_dir, nickname)
-        self.gateway = Tahoe(
-            nodedir,
-            executable=executable,
-            multi_folder_support=multi_folder_support
-        )
+        self.gateway = Tahoe(nodedir, executable=executable)
         yield self.gateway.create_client(**settings)
 
         if icon_path:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -28,7 +28,6 @@ from gridsync import pkgdir
 from gridsync.config import Config
 from gridsync.errors import TahoeError, TahoeCommandError, TahoeWebError
 from gridsync.preferences import set_preference, get_preference
-from gridsync.util import dehumanized_size
 
 
 def is_valid_furl(furl):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -746,26 +746,29 @@ class Tahoe():  # pylint: disable=too-many-public-methods
     def get_collective_dircap(self, name):
         if name not in self.magic_folders:
             self.load_magic_folders()
-        try:
-            return self.magic_folders[name]['collective_dircap']
-        except KeyError:
-            return None
+        if name in self.magic_folders:
+            try:
+                return self.magic_folders[name]['collective_dircap']
+            except KeyError:
+                return None
 
     def get_magic_folder_dircap(self, name):
         if name not in self.magic_folders:
             self.load_magic_folders()
-        try:
-            return self.magic_folders[name]['upload_dircap']
-        except KeyError:
-            return None
+        if name in self.magic_folders:
+            try:
+                return self.magic_folders[name]['upload_dircap']
+            except KeyError:
+                return None
 
     def get_magic_folder_directory(self, name):
         if name not in self.magic_folders:
             self.load_magic_folders()
-        try:
-            return self.magic_folders[name]['directory']
-        except KeyError:
-            return None
+        if name in self.magic_folders:
+            try:
+                return self.magic_folders[name]['directory']
+            except KeyError:
+                return None
 
     @inlineCallbacks
     def get_magic_folders_from_rootcap(self, content=None):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -743,32 +743,23 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         self.magic_folders[name]['admin_dircap'] = cap
         return cap
 
-    def get_collective_dircap(self, name):
-        if name not in self.magic_folders:
+    def _get_magic_folder_setting(self, folder_name, setting_name):
+        if folder_name not in self.magic_folders:
             self.load_magic_folders()
-        if name in self.magic_folders:
+        if folder_name in self.magic_folders:
             try:
-                return self.magic_folders[name]['collective_dircap']
+                return self.magic_folders[folder_name][setting_name]
             except KeyError:
                 return None
+
+    def get_collective_dircap(self, name):
+        return self._get_magic_folder_setting(name, 'collective_dircap')
 
     def get_magic_folder_dircap(self, name):
-        if name not in self.magic_folders:
-            self.load_magic_folders()
-        if name in self.magic_folders:
-            try:
-                return self.magic_folders[name]['upload_dircap']
-            except KeyError:
-                return None
+        return self._get_magic_folder_setting(name, 'upload_dircap')
 
     def get_magic_folder_directory(self, name):
-        if name not in self.magic_folders:
-            self.load_magic_folders()
-        if name in self.magic_folders:
-            try:
-                return self.magic_folders[name]['directory']
-            except KeyError:
-                return None
+        return self._get_magic_folder_setting(name, 'directory')
 
     @inlineCallbacks
     def get_magic_folders_from_rootcap(self, content=None):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -679,15 +679,9 @@ class Tahoe():  # pylint: disable=too-many-public-methods
     @inlineCallbacks
     def remove_magic_folder(self, name):
         if name in self.magic_folders:
-            client = self.magic_folders[name].get('client')
             del self.magic_folders[name]
-            if client:
-                yield client.command(['magic-folder', 'leave'])
-                yield client.stop()
-                shutil.rmtree(client.nodedir, ignore_errors=True)
-            else:
-                yield self.command(['magic-folder', 'leave', '-n', name])
-                self.remove_alias(hashlib.sha256(name.encode()).hexdigest())
+            yield self.command(['magic-folder', 'leave', '-n', name])
+            self.remove_alias(hashlib.sha256(name.encode()).hexdigest())
 
     @inlineCallbacks
     def get_magic_folder_status(self, name):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -499,7 +499,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         if not self.nodeurl:
             return
         try:
-            resp = yield treq.get(self.nodeurl + '?t=json')  # not yet released
+            resp = yield treq.get(self.nodeurl + '?t=json')
         except ConnectError:
             return
         if resp.code == 200:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -350,6 +350,20 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         if storage_servers and isinstance(storage_servers, dict):
             self.add_storage_servers(storage_servers)
 
+    def kill(self):
+        try:
+            with open(self.pidfile, 'r') as f:
+                pid = int(f.read())
+        except (EnvironmentError, ValueError) as err:
+            log.warning("Error loading pid from pidfile: %s", str(err))
+            return
+        log.debug("Trying to kill PID %d...", pid)
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError as err:
+            if err.errno not in (errno.ESRCH, errno.EINVAL):
+                log.error(err)
+
     @inlineCallbacks
     def stop(self):
         if not os.path.isfile(self.pidfile):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -494,25 +494,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         set_preference('notifications', 'connection', pref)
         log.debug("Finished restarting %s client.", self.name)
 
-    @staticmethod
-    def _parse_welcome_page(html):
-        # XXX: This can be removed once a new, stable version of
-        # Tahoe-LAFS is released with Trac ticket #2476 resolved.
-        # See: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2476
-        match = re.search('Connected to <span>(.+?)</span>', html)
-        servers_connected = (int(match.group(1)) if match else 0)
-        match = re.search("of <span>(.+?)</span> known storage servers", html)
-        servers_known = (int(match.group(1)) if match else 0)
-        available_space = 0
-        for s in re.findall('"service-available-space">(.+?)</td>', html):
-            try:
-                size = dehumanized_size(s)
-            except ValueError:  # "N/A"
-                continue
-            available_space += size
-        return servers_connected, servers_known, available_space
-
-    @inlineCallbacks  # noqa: max-complexity=11 XXX
+    @inlineCallbacks
     def get_grid_status(self):
         if not self.nodeurl:
             return
@@ -522,13 +504,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
             return
         if resp.code == 200:
             content = yield treq.content(resp)
-            content = content.decode('utf-8')
-            try:
-                content = json.loads(content)
-            except json.decoder.JSONDecodeError:
-                # See: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2476
-                connected, known, space = self._parse_welcome_page(content)
-                returnValue((connected, known, space))
+            content = json.loads(content.decode('utf-8'))
             servers_connected = 0
             servers_known = 0
             available_space = 0

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -654,12 +654,6 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         self.load_magic_folders()
         yield self.link_magic_folder_to_rootcap(name)
 
-    def get_magic_folder_client(self, name):
-        for folder, settings in self.magic_folders.items():
-            if folder == name:
-                return settings.get('client')
-        return None
-
     def local_magic_folder_exists(self, folder_name):
         if folder_name in self.magic_folders:
             return True
@@ -692,12 +686,8 @@ class Tahoe():  # pylint: disable=too-many-public-methods
     @inlineCallbacks
     def magic_folder_uninvite(self, name, nickname):
         log.debug('Uninviting "%s" from "%s"...', nickname, name)
-        client = self.get_magic_folder_client(name)
-        if client:
-            yield client.unlink(client.get_alias('magic'), nickname)
-        else:
-            alias = hashlib.sha256(name.encode()).hexdigest()
-            yield self.unlink(self.get_alias(alias), nickname)
+        alias = hashlib.sha256(name.encode()).hexdigest()
+        yield self.unlink(self.get_alias(alias), nickname)
         log.debug('Uninvited "%s" from "%s"...', nickname, name)
 
     @inlineCallbacks
@@ -718,13 +708,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         nodeurl = self.nodeurl
         token = self.api_token
         if name:
-            gateway = self.get_magic_folder_client(name)
-            if gateway:
-                nodeurl = gateway.nodeurl
-                token = gateway.api_token
-                data = {'token': token, 't': 'json'}
-            else:
-                data = {'token': token, 'name': name, 't': 'json'}
+            data = {'token': token, 'name': name, 't': 'json'}
         else:
             data = {'token': token, 't': 'json'}
         if not nodeurl or not token:
@@ -770,14 +754,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 return self.magic_folders[name]['admin_dircap']
             except KeyError:
                 pass
-        if self.multi_folder_support:
-            cap = self.get_alias(hashlib.sha256(name.encode()).hexdigest())
-        else:
-            client = self.get_magic_folder_client(name)
-            if client:
-                cap = client.get_alias('magic')
-            else:
-                cap = None
+        cap = self.get_alias(hashlib.sha256(name.encode()).hexdigest())
         self.magic_folders[name]['admin_dircap'] = cap
         return cap
 
@@ -787,13 +764,8 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 return self.magic_folders[name]['collective_dircap']
             except KeyError:
                 pass
-        gateway = self.get_magic_folder_client(name)
-        if gateway:
-            path = os.path.join(self.magic_folders_dir, name, 'private',
-                                'collective_dircap')
-        else:
-            path = os.path.join(self.nodedir, 'private', 'collective_dircap')
-            name = 'default'
+        path = os.path.join(self.nodedir, 'private', 'collective_dircap')
+        name = 'default'
         cap = self.read_cap_from_file(path)
         self.magic_folders[name]['collective_dircap'] = cap
         return cap
@@ -804,13 +776,8 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 return self.magic_folders[name]['upload_dircap']
             except KeyError:
                 pass
-        gateway = self.get_magic_folder_client(name)
-        if gateway:
-            path = os.path.join(self.magic_folders_dir, name, 'private',
-                                'magic_folder_dircap')
-        else:
-            path = os.path.join(self.nodedir, 'private', 'magic_folder_dircap')
-            name = 'default'
+        path = os.path.join(self.nodedir, 'private', 'magic_folder_dircap')
+        name = 'default'
         cap = self.read_cap_from_file(path)
         if cap:
             self.magic_folders[name]['upload_dircap'] = cap
@@ -822,11 +789,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 return self.magic_folders[name]['directory']
             except KeyError:
                 pass
-        gateway = self.get_magic_folder_client(name)
-        if gateway:
-            directory = gateway.config_get('magic_folder', 'local.directory')
-        else:
-            directory = self.config_get('magic_folder', 'local.directory')
+        directory = self.config_get('magic_folder', 'local.directory')
         self.magic_folders[name]['directory'] = directory
         return directory
 

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -745,6 +745,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 return self.magic_folders[folder_name][setting_name]
             except KeyError:
                 return None
+        return None
 
     def get_collective_dircap(self, name):
         return self._get_magic_folder_setting(name, 'collective_dircap')

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -16,8 +16,7 @@ from io import BytesIO
 import treq
 from twisted.internet import reactor
 from twisted.internet.defer import (
-    Deferred, DeferredList, DeferredLock, gatherResults, inlineCallbacks,
-    returnValue)
+    Deferred, DeferredList, DeferredLock, inlineCallbacks, returnValue)
 from twisted.internet.error import ConnectError, ProcessDone
 from twisted.internet.protocol import ProcessProtocol
 from twisted.internet.task import deferLater

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -255,14 +255,6 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         if folders_data:
             for key, value in folders_data.items():  # to preserve defaultdict
                 self.magic_folders[key] = value
-        for nodedir in get_nodedirs(self.magic_folders_dir):
-            folder_name = os.path.basename(nodedir)
-            if folder_name not in self.magic_folders:
-                config = Config(os.path.join(nodedir, 'tahoe.cfg'))
-                self.magic_folders[folder_name] = {
-                    'nodedir': nodedir,
-                    'directory': config.get('magic_folder', 'local.directory')
-                }
         for folder in self.magic_folders:
             admin_dircap = self.get_admin_dircap(folder)
             if admin_dircap:

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -57,18 +57,3 @@ def humanized_list(list_, kind='files'):
         return "{}, {}, and {}".format(*list_)
     return "{}, {}, and {} other {}".format(list_[0], list_[1],
                                             len(list_) - 2, kind)
-
-
-def dehumanized_size(s):
-    if not s:
-        return 0
-    if not s[0].isdigit():
-        raise ValueError("Prefix must be a digit (received '{}')".format(s))
-    string = s.upper()
-    if string.endswith('BYTES'):
-        return int(s[:-5])
-    suffixes = ('KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
-    for i, suffix in enumerate(suffixes, start=1):
-        if string.endswith(suffix):
-            return int(float(s[:-2].strip()) * 1024 ** i)
-    raise ValueError("Unknown suffix for '{}'".format(s))

--- a/gridsync/wormhole_.py
+++ b/gridsync/wormhole_.py
@@ -8,7 +8,7 @@ import logging
 
 from PyQt5.QtCore import pyqtSignal, QObject
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from wormhole import wormhole
 from wormhole.errors import WormholeError
 from wormhole.tor_manager import get_tor
@@ -95,7 +95,7 @@ class Wormhole(QObject):
         logging.debug("Received message: %s", msg)
         self.got_message.emit(msg)
         yield self.close()
-        returnValue(msg)
+        return msg
 
     @inlineCallbacks
     def send(self, msg, code=None):
@@ -131,7 +131,7 @@ class Wormhole(QObject):
 def wormhole_receive(code, use_tor=False):
     w = Wormhole(use_tor)
     msg = yield w.receive(code)
-    returnValue(msg)
+    return msg
 
 
 @inlineCallbacks

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -63,10 +63,6 @@ def tahoe(tmpdir_factory):
         f.write('test_alias: test_cap')
     with open(os.path.join(private_dir, 'magic_folders.yaml'), 'w') as f:
         f.write("magic-folders:\n  test_folder: {directory: test_dir}")
-    magic_folder_subdir = os.path.join(client.nodedir, 'magic-folders', 'Test')
-    os.makedirs(magic_folder_subdir)
-    with open(os.path.join(magic_folder_subdir, 'tahoe.cfg'), 'w') as f:
-        f.write('[magic_folder]\nlocal.directory = /Test')
     client.nodeurl = 'http://127.0.0.1:65536/'
     return client
 
@@ -235,11 +231,6 @@ def test_add_storage_servers_no_add_missing_furl(tmpdir):
 def test_load_magic_folders(tahoe):
     tahoe.load_magic_folders()
     assert tahoe.magic_folders['test_folder']['directory'] == 'test_dir'
-
-
-def test_load_magic_folders_from_subdir(tahoe):
-    tahoe.load_magic_folders()
-    assert tahoe.magic_folders['Test']['directory'] == '/Test'
 
 
 @pytest.inlineCallbacks

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -550,15 +550,6 @@ def test_tahoe_unlink_fail_code_500(tahoe, monkeypatch):
         yield tahoe.unlink('test_dircap', 'test_childname')
 
 
-def test_tahoe_get_magic_folder_client(tahoe):
-    tahoe.magic_folders['Test Documents']['client'] = 'test_object'
-    assert tahoe.get_magic_folder_client('Test Documents') == 'test_object'
-
-
-def test_tahoe_get_magic_folder_client_none(tahoe):
-    assert tahoe.get_magic_folder_client('Non-existent Folder') is None
-
-
 def test_local_magic_folder_exists_true(tahoe):
     tahoe.magic_folders['LocalTestFolder'] = {}
     assert tahoe.local_magic_folder_exists('LocalTestFolder')

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -364,17 +364,6 @@ def test_tahoe_stop_linux_monkeypatch(tahoe, monkeypatch):
     assert output == ['stop']
 
 
-def test_parse_welcome_page(tahoe):  # tahoe-lafs=<1.12.1
-    html = '''
-        Connected to <span>3</span>of <span>10</span> known storage servers
-        <td class="service-available-space">N/A</td>
-        <td class="service-available-space">1kB</td>
-        <td class="service-available-space">1kB</td>
-    '''
-    connected, known, space = tahoe._parse_welcome_page(html)
-    assert (connected, known, space) == (3, 10, 2048)
-
-
 @pytest.inlineCallbacks
 def test_get_grid_status(tahoe, monkeypatch):
     json_content = b'''{

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,8 +4,7 @@ from binascii import hexlify, unhexlify
 
 import pytest
 
-from gridsync.util import (
-    b58encode, b58decode, humanized_list, dehumanized_size)
+from gridsync.util import b58encode, b58decode, humanized_list
 
 
 # From https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
@@ -49,23 +48,3 @@ def test_b58decode_value_error():
 ])
 def test_humanized_list(items, kind, humanized):
     assert humanized_list(items, kind) == humanized
-
-
-@pytest.mark.parametrize("s,dehumanized", [
-    [None, 0],
-    ['32 Bytes', 32],
-    ['1KB', 1024],
-    ['256GB', 274877906944],
-])
-def test_dehumanized_size(s, dehumanized):
-    assert dehumanized_size(s) == dehumanized
-
-
-def test_dehumanized_size_value_error_prefix_not_digit():
-    with pytest.raises(ValueError):
-        assert dehumanized_size('two bytes') == 2
-
-
-def test_dehumanized_size_value_error_unknown_suffix():
-    with pytest.raises(ValueError):
-        assert dehumanized_size('3 ninjas') == 3


### PR DESCRIPTION
This PR removes a number of hacks that are no longer necessary with the release of Tahoe-LAFS 1.13.0 (in particular, workarounds relating multi-magic-folder support and welcome page parsing on older clients) and provides other misc. refactorings, updates, and cleanups (such as removing the usage of Twisted's `returnValue` which is no longer necessary in python3).