### PR TITLE
Deploy PyInstaller binaries on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ frozen-tahoe:
 install:
 	pip3 install --upgrade .
 
-frozen:
+pyinstaller:
 	if [ -f dist/Tahoe-LAFS.zip ] ; then \
 		python -m zipfile -e dist/Tahoe-LAFS.zip dist ; \
 	else  \
@@ -272,9 +272,6 @@ frozen:
 	export PYTHONHASHSEED=1 && \
 	pyinstaller -y misc/gridsync.spec
 
-app: frozen
-	#cp misc/Info.plist dist/Gridsync.app/Contents  # TODO: write out on build
-
 py2app:
 	if [ -f dist/Tahoe-LAFS.zip ] ; then \
 		python -m zipfile -e dist/Tahoe-LAFS.zip dist ; \
@@ -300,7 +297,7 @@ py2app:
 	cp -r dist/Tahoe-LAFS dist/Gridsync.app/Contents/MacOS
 	touch dist/Gridsync.app
 
-dmg: py2app
+dmg: pyinstaller
 	python3 -m virtualenv --clear --python=python2 build/venv-dmg
 	source build/venv-dmg/bin/activate && \
 	pip install dmgbuild && \
@@ -319,7 +316,7 @@ dmg: py2app
 all:
 	@case `uname` in \
 		Darwin)	$(MAKE) dmg ;; \
-		*) $(MAKE) frozen ;; \
+		*) $(MAKE) pyinstaller ;; \
 	esac
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -250,14 +250,24 @@ frozen:
 	source build/venv-gridsync/bin/activate && \
 	pip install --upgrade pip && \
 	pip install -r requirements/requirements-hashes.txt && \
+	pip install . && \
 	case `uname` in \
 		Darwin) \
 			python scripts/maybe_rebuild_libsodium.py && \
-			python scripts/maybe_downgrade_pyqt.py \
+			python scripts/maybe_downgrade_pyqt.py && \
+			git clone https://github.com/pyinstaller/pyinstaller.git build/pyinstaller && \
+			pushd build/pyinstaller && \
+			git checkout 355f0c76b2ee5af0cb2f7cb5512a060d2ed02b2b && \
+			pushd bootloader && \
+			python ./waf all && \
+			popd && \
+			pip install . && \
+			popd \
+		;; \
+		*) \
+			pip install pyinstaller==3.3.1 \
 		;; \
 	esac &&	\
-	pip install . && \
-	pip install pyinstaller==3.3.1 && \
 	pip list && \
 	export PYTHONHASHSEED=1 && \
 	pyinstaller -y misc/gridsync.spec

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ pyinstaller:
 	esac &&	\
 	pip list && \
 	export PYTHONHASHSEED=1 && \
-	pyinstaller -y misc/gridsync.spec
+	python -m PyInstaller -y misc/gridsync.spec
 
 py2app:
 	if [ -f dist/Tahoe-LAFS.zip ] ; then \

--- a/misc/gridsync.spec
+++ b/misc/gridsync.spec
@@ -35,46 +35,54 @@ if sys.platform == "win32":
     paths.append(os.path.join(os.path.abspath(os.sep), 'Program Files', 'Windows Kits', '10', 'bin', 'x86'))
     paths.append(os.path.join(os.path.abspath(os.sep), 'Program Files', 'Windows Kits', '10', 'Redist', 'ucrt', 'DLLs', 'x86'))
 
-a = Analysis(['../gridsync/cli.py'],
-             pathex=paths,
-             binaries=None,
-             datas=[
-                ('../gridsync/resources/*', 'resources'),
-                ('../gridsync/resources/providers/*', 'resources/providers')
-             ],
-             hiddenimports=['cffi', 'PyQt5.sip'],
-             hookspath=[],
-             runtime_hooks=[],
-             excludes=[],
-             win_no_prefer_redirects=False,
-             win_private_assemblies=False,
-             cipher=None)
+
+a = Analysis(
+    ['../gridsync/cli.py'],
+    pathex=paths,
+    binaries=None,
+    datas=[
+        ('../gridsync/resources/*', 'resources'),
+        ('../gridsync/resources/providers/*', 'resources/providers')
+    ],
+    hiddenimports=['cffi', 'PyQt5.sip'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=None
+)
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
-exe = EXE(pyz,
-          a.scripts,
-          exclude_binaries=True,
-          name=app_name,
-          debug=False,
-          strip=False,
-          upx=False,
-          console=False,
-          icon=settings['build']['win_icon'])
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=False,
-               name=app_name)
-app = BUNDLE(coll,
-             name=(app_name + '.app'),
-             icon=settings['build']['mac_icon'],
-             bundle_identifier=settings['build']['mac_bundle_identifier'],
-             info_plist={
-                'LSBackgroundOnly': True,
-                'LSUIElement': True,
-                }
-             )
+exe = EXE(
+    pyz,
+    a.scripts,
+    exclude_binaries=True,
+    name=app_name,
+    debug=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=settings['build']['win_icon']
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name=app_name
+)
+app = BUNDLE(
+    coll,
+    name=(app_name + '.app'),
+    icon=settings['build']['mac_icon'],
+    bundle_identifier=settings['build']['mac_bundle_identifier'],
+    info_plist={
+        'LSBackgroundOnly': True,
+        'LSUIElement': True,
+    }
+)
 
 
 tahoe_bundle_path = os.path.join('dist', 'Tahoe-LAFS')

--- a/misc/gridsync.spec
+++ b/misc/gridsync.spec
@@ -69,7 +69,12 @@ coll = COLLECT(exe,
 app = BUNDLE(coll,
              name=(app_name + '.app'),
              icon=settings['build']['mac_icon'],
-             bundle_identifier=settings['build']['mac_bundle_identifier'])
+             bundle_identifier=settings['build']['mac_bundle_identifier'],
+             info_plist={
+                'LSBackgroundOnly': True,
+                'LSUIElement': True,
+                }
+             )
 
 
 tahoe_bundle_path = os.path.join('dist', 'Tahoe-LAFS')

--- a/misc/gridsync.spec
+++ b/misc/gridsync.spec
@@ -9,8 +9,13 @@ except ImportError:
 from distutils.sysconfig import get_python_lib
 import hashlib
 import os
+import re
 import shutil
 import sys
+
+
+version_file = open("gridsync/_version.py").read()
+version = re.findall("__version__\s*=\s*'([^']+)'", version_file)[0]
 
 
 config = RawConfigParser(allow_no_value=True)
@@ -79,6 +84,7 @@ app = BUNDLE(
     icon=settings['build']['mac_icon'],
     bundle_identifier=settings['build']['mac_bundle_identifier'],
     info_plist={
+        'CFBundleShortVersionString': version,
         'LSBackgroundOnly': True,
         'LSUIElement': True,
     }


### PR DESCRIPTION
Now that PyInstaller [respects Info.plist options](https://github.com/pyinstaller/pyinstaller/pull/3566), it can be used to deploy Gridsync binaries which properly launch as "agent"/background processes. Accordingly, this PR compiles the appropriate PyInstaller bootloaders on macOS at build time to enable this functionality, and creates the appropriate "Gridsync.app" bundle using PyInstaller (replacing "py2app"). I've kept the "py2app" setup options in place for now in the event that a "py2app" bundle is still needed/wanted (however, these may be removed at a future date).