### PR TITLE
Monitor improvements

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -49,7 +49,6 @@ class Model(QStandardItemModel):
         self.monitor.disconnected.connect(self.on_disconnected)
         self.monitor.nodes_updated.connect(self.on_nodes_updated)
         self.monitor.space_updated.connect(self.on_space_updated)
-        self.monitor.data_updated.connect(self.set_data)
         self.monitor.status_updated.connect(self.set_status)
         self.monitor.mtime_updated.connect(self.set_mtime)
         self.monitor.size_updated.connect(self.set_size)

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -220,6 +220,11 @@ class Model(QStandardItemModel):
                 'This folder is stored remotely on the "{}" grid.\n'
                 'Right-click and select "Download" to sync it with your '
                 'local computer.'.format(self.gateway.name))
+        elif status == 99:
+            item.setIcon(self.icon_blank)
+            item.setText("Scanning")
+            item.setToolTip(
+                "This folder is being scanned for changes.")
         item.setData(status, Qt.UserRole)
         self.status_dict[name] = status
 

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -13,7 +13,6 @@ from PyQt5.QtWidgets import QAction, QFileIconProvider, QToolBar
 
 from gridsync import resource, config_dir
 from gridsync.gui.widgets import CompositePixmap
-from gridsync.monitor import Monitor
 from gridsync.preferences import get_preference
 from gridsync.util import humanized_list
 
@@ -24,7 +23,7 @@ class Model(QStandardItemModel):
         self.view = view
         self.gui = self.view.gui
         self.gateway = self.view.gateway
-        self.monitor = Monitor(self.gateway)
+        self.monitor = self.gateway.monitor
         self.status_dict = {}
         self.members_dict = {}
         self.grid_status = ''

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -52,7 +52,6 @@ class Model(QStandardItemModel):
         self.monitor.mtime_updated.connect(self.set_mtime)
         self.monitor.size_updated.connect(self.set_size)
         self.monitor.member_added.connect(self.add_member)
-        self.monitor.first_sync_started.connect(self.on_first_sync)
         self.monitor.sync_started.connect(self.on_sync_started)
         self.monitor.sync_finished.connect(self.on_sync_finished)
         self.monitor.files_updated.connect(self.on_updated_files)
@@ -264,12 +263,6 @@ class Model(QStandardItemModel):
             font.setItalic(False)
             item.setFont(font)
             item.setForeground(default_foreground)
-
-    @pyqtSlot(str)
-    def on_first_sync(self, folder_name):
-        self.unfade_row(folder_name)
-        self.update_folder_icon(
-            folder_name, self.gateway.get_magic_folder_directory(folder_name))
 
     @pyqtSlot(str)
     def on_sync_started(self, folder_name):

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -79,17 +79,19 @@ class Model(QStandardItemModel):
             )
         self.gui.main_window.set_current_grid_status()  # TODO: Use pyqtSignal?
 
-    @pyqtSlot(str)
-    def on_connected(self, grid_name):
+    @pyqtSlot()
+    def on_connected(self):
         if get_preference('notifications', 'connection') != 'false':
             self.gui.show_message(
-                grid_name, "Connected to {}".format(grid_name))
+                self.gateway.name, "Connected to {}".format(self.gateway.name))
 
-    @pyqtSlot(str)
-    def on_disconnected(self, grid_name):
+    @pyqtSlot()
+    def on_disconnected(self):
         if get_preference('notifications', 'connection') != 'false':
             self.gui.show_message(
-                grid_name, "Disconnected from {}".format(grid_name))
+                self.gateway.name,
+                "Disconnected from {}".format(self.gateway.name)
+            )
 
     @pyqtSlot(str, list)
     def on_updated_files(self, folder_name, files_list):

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -58,6 +58,8 @@ class Model(QStandardItemModel):
         self.monitor.files_updated.connect(self.on_updated_files)
         self.monitor.check_finished.connect(self.update_natural_times)
         self.monitor.remote_folder_added.connect(self.add_remote_folder)
+        self.monitor.transfer_progress_updated.connect(
+            self.set_transfer_progress)
 
     def on_space_updated(self, size):
         self.available_space = size
@@ -227,6 +229,14 @@ class Model(QStandardItemModel):
                 "This folder is being scanned for changes.")
         item.setData(status, Qt.UserRole)
         self.status_dict[name] = status
+
+    @pyqtSlot(str, object, object)
+    def set_transfer_progress(self, folder_name, transferred, total):
+        items = self.findItems(folder_name)
+        if not items:
+            return
+        item = self.item(items[0].row(), 1)
+        item.setText("Syncing ({}%)".format(int(transferred / total * 100)))
 
     def fade_row(self, folder_name, overlay_file=None):
         folder_item = self.findItems(folder_name)[0]

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -184,12 +184,6 @@ class Model(QStandardItemModel):
         else:
             self.set_status_private(folder_name)
 
-    @pyqtSlot(str, object)
-    def set_data(self, folder_name, data):
-        items = self.findItems(folder_name)
-        if items:
-            items[0].setData(data, Qt.UserRole)
-
     @pyqtSlot(str, int)
     def set_status(self, name, status):
         items = self.findItems(name)

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -93,12 +93,16 @@ class Model(QStandardItemModel):
                 "Disconnected from {}".format(self.gateway.name)
             )
 
-    @pyqtSlot(str, list)
-    def on_updated_files(self, folder_name, files_list):
+    @pyqtSlot(str, list, str, str)
+    def on_updated_files(self, folder_name, files_list, action, author):
         if get_preference('notifications', 'folder') != 'false':
             self.gui.show_message(
                 folder_name + " folder updated",
-                "Updated " + humanized_list(files_list))
+                "{} {}".format(
+                    author + " " + action if author else action.capitalize(),
+                    humanized_list(files_list)
+                )
+            )
 
     def data(self, index, role):
         value = super(Model, self).data(index, role)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -46,7 +46,7 @@ class Delegate(QStyledItemDelegate):
             if not status:  # "Loading..."
                 self.waiting_movie.setPaused(False)
                 pixmap = self.waiting_movie.currentPixmap().scaled(20, 20)
-            elif status == 1 or status == 99:  # "Syncing"; "Scanning"
+            elif status in (1, 99):  # "Syncing", "Scanning"
                 self.sync_movie.setPaused(False)
                 pixmap = self.sync_movie.currentPixmap().scaled(20, 20)
             if pixmap:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -32,7 +32,7 @@ class Delegate(QStyledItemDelegate):
 
     def on_frame_changed(self):
         values = self.parent.model().status_dict.values()
-        if 0 in values or 1 in values:
+        if 0 in values or 1 in values or 99 in values:
             self.parent.viewport().update()
         else:
             self.waiting_movie.setPaused(True)
@@ -46,7 +46,7 @@ class Delegate(QStyledItemDelegate):
             if not status:  # "Loading..."
                 self.waiting_movie.setPaused(False)
                 pixmap = self.waiting_movie.currentPixmap().scaled(20, 20)
-            elif status == 1:  # "Syncing"
+            elif status == 1 or status == 99:  # "Syncing"; "Scanning"
                 self.sync_movie.setPaused(False)
                 pixmap = self.sync_movie.currentPixmap().scaled(20, 20)
             if pixmap:

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -127,13 +127,17 @@ class MagicFolderChecker(QObject):
                     logging.debug("%sing %s...", kind, filepath)
                     # TODO: Emit uploading/downloading signal?
                 self.emit_transfer_signals(bytes_transferred, bytes_total)
-            elif state == 2 and self.state == 1:  # Sync just finished
-                logging.debug("Sync complete (%s)", self.name)
-                self.sync_finished.emit()
-            elif state == 2 and self.updated_files:
-                self.notify_updated_files()
-            if state in (1, 2) and self.state != 2:
                 remote_scan_needed = True
+            elif state == 2:
+                if self.state == 1:  # Sync just finished
+                    logging.debug(
+                        "Sync complete (%s); doing final scan...", self.name)
+                    remote_scan_needed = True
+                    state = 99
+                elif self.state == 99:  # Final scan just finished
+                    logging.debug("Final scan complete (%s)", self.name)
+                    self.sync_finished.emit()
+                    self.notify_updated_files()
             if state != self.state:
                 self.status_updated.emit(state)
         else:

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -39,13 +39,6 @@ class MagicFolderChecker(QObject):
 
         self.updated_files = []
 
-    def add_updated_file(self, path):
-        if path in self.updated_files or path.endswith('/') \
-                or path.endswith('~') or path.isdigit():
-            return
-        self.updated_files.append(path)
-        logging.debug("Added %s to updated_files list", path)
-
     def notify_updated_files(self):
         updated_files = []
         for update in self.updated_files:
@@ -95,9 +88,7 @@ class MagicFolderChecker(QObject):
                 elif self.state == 1:  # Sync started earlier; still going
                     logging.debug("Sync in progress (%s)", self.name)
                     logging.debug("%sing %s...", kind, filepath)
-                    #for item in status:
-                    #    if item not in self.status:
-                    #        self.add_updated_file(item['path'])
+                    # TODO: Emit uploading/downloading signal?
             elif state == 2 and self.state == 1:  # Sync just finished
                 logging.debug("Sync complete (%s)", self.name)
                 self.sync_finished.emit()

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -22,7 +22,7 @@ class MagicFolderChecker(QObject):
     member_removed = pyqtSignal(str)
 
     file_updated = pyqtSignal(object)
-    files_updated = pyqtSignal(list)
+    files_updated = pyqtSignal(list, str, str)
 
     def __init__(self, gateway, name, remote=False):
         super(MagicFolderChecker, self).__init__()
@@ -53,7 +53,7 @@ class MagicFolderChecker(QObject):
                 notifications[action].append(path)
             for action, files, in notifications.items():
                 logging.debug("%s %s %s", author, action, files)
-                self.files_updated.emit(files)
+                self.files_updated.emit(files, action, author)
 
     @staticmethod
     def parse_status(status):
@@ -216,7 +216,7 @@ class Monitor(QObject):
     member_removed = pyqtSignal(str, str)
 
     file_updated = pyqtSignal(str, object)
-    files_updated = pyqtSignal(str, list)
+    files_updated = pyqtSignal(str, list, str, str)
 
     check_finished = pyqtSignal()
 
@@ -249,7 +249,8 @@ class Monitor(QObject):
         mfc.member_removed.connect(lambda x: self.member_removed.emit(name, x))
 
         mfc.file_updated.connect(lambda x: self.file_updated.emit(name, x))
-        mfc.files_updated.connect(lambda x: self.files_updated.emit(name, x))
+        mfc.files_updated.connect(
+            lambda x, y, z: self.files_updated.emit(name, x, y, z))
 
         self.magic_folder_checkers[name] = mfc
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -11,7 +11,6 @@ from twisted.internet.task import LoopingCall
 
 class MagicFolderChecker(QObject):
 
-    first_sync_started = pyqtSignal()
     sync_started = pyqtSignal()
     sync_finished = pyqtSignal()
 
@@ -240,7 +239,6 @@ class Monitor(QObject):
 
     remote_folder_added = pyqtSignal(str, str)
 
-    first_sync_started = pyqtSignal(str)
     sync_started = pyqtSignal(str)
     sync_finished = pyqtSignal(str)
 
@@ -276,8 +274,6 @@ class Monitor(QObject):
     def add_magic_folder_checker(self, name, remote=False):
         mfc = MagicFolderChecker(self.gateway, name, remote)
 
-        mfc.first_sync_started.connect(
-            lambda: self.first_sync_started.emit(name))
         mfc.sync_started.connect(lambda: self.sync_started.emit(name))
         mfc.sync_finished.connect(lambda: self.sync_finished.emit(name))
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -114,20 +114,11 @@ class Monitor(QObject):
         # TODO: Notify failures/conflicts
         return remote_scan_needed
 
-    #def handle_deleted(self, name, data):
-
     def compare_states(self, name, current, previous):
-        created = []
-        added = []
-        updated = []
-        deleted = []
-        restored = []
         for mtime, data in current.items():
             if mtime not in previous:
                 if data['deleted']:
                     self.file_deleted.emit(name, data)
-                    print('DELETED: ', data)
-                    deleted.append(data)
                 else:
                     path = data['path']
                     prev_entry = None
@@ -137,21 +128,12 @@ class Monitor(QObject):
                     if prev_entry:
                         if prev_entry['deleted']:
                             self.file_restored.emit(name, data)
-                            print('RESTORED: ', data)
-                            restored.append(data)
                         else:
                             self.file_updated.emit(name, data)
-                            print('UPDATED: ', data)
-                            updated.append(data)
                     elif path.endswith('/'):
                         self.directory_created.emit(name, data)
-                        print('CREATED: ', data)
-                        created.append(data)
                     else:
                         self.file_added.emit(name, data)
-                        print('ADDED: ', data)
-                        added.append(data)
-        # XXX
 
     @inlineCallbacks
     def do_remote_scan(self, name, members=None):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -54,6 +54,9 @@ class MagicFolderChecker(QObject):
                     notifications[action].append(path)
             for action, files, in notifications.items():
                 logging.debug("%s %s %s", author, action, files)
+                # Currently, for non-'admin' members, member/author names are 
+                # random non-human-meaningful strings, so omit them for now.
+                author = ""  # XXX
                 self.files_updated.emit(files, action, author)
 
     @staticmethod

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -55,8 +55,8 @@ class MagicFolderChecker(QObject):
                     notifications[action].append(path)
             for action, files, in notifications.items():
                 logging.debug("%s %s %s", author, action, files)
-                # Currently, for non-'admin' members, member/author names are 
-                # random non-human-meaningful strings, so omit them for now.
+                # Currently, for non-'admin' members, member/author names are
+                # random/non-human-meaningful strings, so omit them for now.
                 author = ""  # XXX
                 self.files_updated.emit(files, action, author)
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -90,11 +90,14 @@ class MagicFolderChecker(QObject):
             if state == 1:
                 for task in status:
                     if task['queued_at'] >= self.sync_time_started:
+                        size = task['size']
+                        if not size:
+                            continue
                         if task['status'] in ('queued', 'started', 'success'):
-                            bytes_total += task['size']
+                            bytes_total += size
                         if task['status'] in ('started', 'success'):
                             bytes_transferred += \
-                                task['size'] * task['percent_done'] / 100
+                                size * task['percent_done'] / 100
             if not state:
                 state = 2  # "Up to date"
                 self.sync_time_started = 0

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -67,13 +67,33 @@ class MagicFolderChecker(QObject):
                 author = ""  # XXX
                 self.files_updated.emit(files, action, author)
 
+    def emit_transfer_signals(self, status):
+        # XXX This does not take into account erasure coding overhead
+        bytes_transferred = 0
+        bytes_total = 0
+        for task in status:
+            if task['queued_at'] >= self.sync_time_started:
+                size = task['size']
+                if not size:
+                    continue
+                if task['status'] in ('queued', 'started', 'success'):
+                    bytes_total += size
+                if task['status'] in ('started', 'success'):
+                    bytes_transferred += size * task['percent_done'] / 100
+        self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
+        if bytes_transferred:
+            duration = time.time() - self.sync_time_started
+            speed = bytes_transferred / duration
+            self.transfer_speed_updated.emit(speed)
+            bytes_remaining = bytes_total - bytes_transferred
+            seconds_remaining = bytes_remaining / speed
+            self.transfer_seconds_remaining_updated.emit(seconds_remaining)
+
     def parse_status(self, status):
         state = 0
         kind = ''
         path = ''
         failures = []
-        bytes_transferred = 0
-        bytes_total = 0
         if status is not None:
             for task in status:
                 if task['status'] in ('queued', 'started'):
@@ -87,37 +107,14 @@ class MagicFolderChecker(QObject):
                         path = task['path']
                 elif task['status'] == 'failure':
                     failures.append(task)
-            if state == 1:
-                for task in status:
-                    if task['queued_at'] >= self.sync_time_started:
-                        size = task['size']
-                        if not size:
-                            continue
-                        if task['status'] in ('queued', 'started', 'success'):
-                            bytes_total += size
-                        if task['status'] in ('started', 'success'):
-                            bytes_transferred += \
-                                size * task['percent_done'] / 100
             if not state:
                 state = 2  # "Up to date"
                 self.sync_time_started = 0
-        return state, kind, path, failures, bytes_transferred, bytes_total
-
-    def emit_transfer_signals(self, bytes_transferred, bytes_total):
-        # XXX This does not take into account erasure coding overhead
-        self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
-        if bytes_transferred:
-            duration = time.time() - self.sync_time_started
-            speed = bytes_transferred / duration
-            self.transfer_speed_updated.emit(speed)
-            bytes_remaining = bytes_total - bytes_transferred
-            seconds_remaining = bytes_remaining / speed
-            self.transfer_seconds_remaining_updated.emit(seconds_remaining)
+        return state, kind, path, failures
 
     def process_status(self, status):
         remote_scan_needed = False
-        res = self.parse_status(status)
-        state, kind, filepath, _, bytes_transferred, bytes_total = res
+        state, kind, filepath, _ = self.parse_status(status)
         if status and self.state:
             if state == 1:  # "Syncing"
                 if self.state == 0:  # First sync after restoring
@@ -129,7 +126,7 @@ class MagicFolderChecker(QObject):
                     logging.debug("Sync in progress (%s)", self.name)
                     logging.debug("%sing %s...", kind, filepath)
                     # TODO: Emit uploading/downloading signal?
-                self.emit_transfer_signals(bytes_transferred, bytes_total)
+                self.emit_transfer_signals(status)
                 remote_scan_needed = True
             elif state == 2:
                 if self.state == 1:  # Sync just finished

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -43,12 +43,17 @@ class MagicFolderChecker(QObject):
     def notify_updated_files(self):
         changes = defaultdict(list)
         for item in self.updated_files:
-            changes[item['member']].insert(int(item['mtime']), item['path'])
+            changes[item['member']].insert(
+                int(item['mtime']), (item['action'], item['path'])
+            )
         self.updated_files = []
-        for _, files in changes.items():
-            self.files_updated.emit(files)
-
-    # TODO: Handle added/deleted/restored
+        for author, change in changes.items():
+            notifications = defaultdict(list)
+            for action, path in change:
+                notifications[action].append(path)
+            for action, files, in notifications.items():
+                logging.debug("%s %s %s", author, action, files)
+                self.files_updated.emit(files)
 
     @staticmethod
     def parse_status(status):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -14,7 +14,6 @@ class Monitor(QObject):
     disconnected = pyqtSignal(str)
     nodes_updated = pyqtSignal(int, int)
     space_updated = pyqtSignal(object)
-    data_updated = pyqtSignal(str, object)
     status_updated = pyqtSignal(str, int)
     mtime_updated = pyqtSignal(str, int)
     size_updated = pyqtSignal(str, object)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -130,6 +130,7 @@ class MagicFolderChecker(QObject):
             elif state == 2 and self.state == 1:  # Sync just finished
                 logging.debug("Sync complete (%s)", self.name)
                 self.sync_finished.emit()
+            elif state == 2 and self.updated_files:
                 self.notify_updated_files()
             if state in (1, 2) and self.state != 2:
                 remote_scan_needed = True

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -110,6 +110,7 @@ class Monitor(QObject):
         return remote_scan_needed
 
     def compare_states(self, name, current, previous):
+        created = []
         added = []
         updated = []
         deleted = []
@@ -132,6 +133,9 @@ class Monitor(QObject):
                         else:
                             print('UPDATED: ', data)
                             updated.append(data)
+                    elif path.endswith('/'):
+                        print('CREATED: ', data)
+                        created.append(data)
                     else:
                         print('ADDED: ', data)
                         added.append(data)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -81,7 +81,7 @@ class MagicFolderChecker(QObject):
                 if task['status'] in ('started', 'success'):
                     bytes_transferred += size * task['percent_done'] / 100
         self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
-        if bytes_transferred:
+        if bytes_transferred and bytes_total:
             duration = time.time() - self.sync_time_started
             speed = bytes_transferred / duration
             self.transfer_speed_updated.emit(speed)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -10,8 +10,8 @@ from twisted.internet.task import LoopingCall
 
 class Monitor(QObject):
 
-    connected = pyqtSignal(str)
-    disconnected = pyqtSignal(str)
+    connected = pyqtSignal()
+    disconnected = pyqtSignal()
     nodes_updated = pyqtSignal(int, int)
     space_updated = pyqtSignal(object)
     status_updated = pyqtSignal(str, int)
@@ -155,12 +155,12 @@ class Monitor(QObject):
             if num_happy and num_connected >= num_happy:
                 if not self.is_connected:
                     self.is_connected = True
-                    self.connected.emit(self.gateway.name)
+                    self.connected.emit()
                     yield self.scan_rootcap()  # TODO: Move to Monitor?
             elif num_happy and num_connected < num_happy:
                 if self.is_connected:
                     self.is_connected = False
-                    self.disconnected.emit(self.gateway.name)
+                    self.disconnected.emit()
             self.num_connected = num_connected
             self.num_happy = num_happy
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collections import defaultdict
 import logging
 
 from PyQt5.QtCore import pyqtSignal, QObject
@@ -40,18 +41,14 @@ class MagicFolderChecker(QObject):
         self.updated_files = []
 
     def notify_updated_files(self):
-        updated_files = []
-        for update in self.updated_files:
-            path = update['path']
-            if path not in updated_files:
-                updated_files.append(path)
-        if updated_files:
-            self.updated_files = []
-            logging.debug("Cleared updated_files list")
-            self.files_updated.emit(updated_files)
+        changes = defaultdict(list)
+        for item in self.updated_files:
+            changes[item['member']].insert(int(item['mtime']), item['path'])
+        self.updated_files = []
+        for _, files in changes.items():
+            self.files_updated.emit(files)
 
     # TODO: Handle added/deleted/restored
-    # TODO: Batch by author?
 
     @staticmethod
     def parse_status(status):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -1,64 +1,78 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from collections import defaultdict
 
 from PyQt5.QtCore import pyqtSignal, QObject
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import LoopingCall
 
 
-class Monitor(QObject):
+class MagicFolderChecker(QObject):
 
-    connected = pyqtSignal()
-    disconnected = pyqtSignal()
-    nodes_updated = pyqtSignal(int, int)
-    space_updated = pyqtSignal(object)
-    status_updated = pyqtSignal(str, int)
-    mtime_updated = pyqtSignal(str, int)
-    size_updated = pyqtSignal(str, object)
-    member_added = pyqtSignal(str, str)
-    first_sync_started = pyqtSignal(str)
-    sync_started = pyqtSignal(str)
-    sync_finished = pyqtSignal(str)
-    files_updated = pyqtSignal(str, list)
-    check_finished = pyqtSignal()
-    remote_folder_added = pyqtSignal(str, str)
-    directory_created = pyqtSignal(str, object)
-    file_added = pyqtSignal(str, object)
-    file_updated = pyqtSignal(str, object)
-    file_deleted = pyqtSignal(str, object)
-    file_restored = pyqtSignal(str, object)
+    first_sync_started = pyqtSignal()
+    sync_started = pyqtSignal()
+    sync_finished = pyqtSignal()
 
-    def __init__(self, gateway):
-        super(Monitor, self).__init__()
+    status_updated = pyqtSignal(int)
+    mtime_updated = pyqtSignal(int)
+    size_updated = pyqtSignal(object)
+
+    member_added = pyqtSignal(str)
+    member_removed = pyqtSignal(str)
+
+    directory_created = pyqtSignal(object)
+    file_added = pyqtSignal(object)
+    file_updated = pyqtSignal(object)
+    file_deleted = pyqtSignal(object)
+    file_restored = pyqtSignal(object)
+
+    directories_created = pyqtSignal(list)
+    files_added = pyqtSignal(list)
+    files_updated = pyqtSignal(list)
+    files_deleted = pyqtSignal(list)
+    files_restored = pyqtSignal(list)
+
+    def __init__(self, gateway, name, remote=False):
+        super(MagicFolderChecker, self).__init__()
         self.gateway = gateway
-        self.status = defaultdict(dict)
+        self.name = name
+        self.remote = remote
+
+        self.state = None
+        self.status = {}
+        self.mtime = 0
+        self.size = 0
+
         self.members = []
         self.history = {}
-        self.timer = LoopingCall(self.check_status)
-        self.num_connected = 0
-        self.num_happy = 0
-        self.is_connected = False
-        self.available_space = 0
 
-    def add_updated_file(self, folder_name, path):
-        if 'updated_files' not in self.status[folder_name]:
-            self.status[folder_name]['updated_files'] = []
-        if path in self.status[folder_name]['updated_files']:
+        self.created_directories = []
+        self.added_files = []
+        self.updated_files = []
+        self.deleted_files = []
+        self.restored_files = []
+
+        #self.file_added.connect(print)
+        #self.file_updated.connect(print)
+        #self.file_deleted.connect(print)
+        #self.file_restored.connect(print)
+
+    def add_updated_file(self, path):
+        if path in self.updated_files or path.endswith('/') \
+                or path.endswith('~') or path.isdigit():
             return
-        if path.endswith('/') or path.endswith('~') or path.isdigit():
-            return
-        self.status[folder_name]['updated_files'].append(path)
+        self.updated_files.append(path)
         logging.debug("Added %s to updated_files list", path)
 
-    def notify_updated_files(self, folder_name):
-        if 'updated_files' in self.status[folder_name]:
-            updated_files = self.status[folder_name]['updated_files']
-            if updated_files:
-                self.status[folder_name]['updated_files'] = []
-                logging.debug("Cleared updated_files list")
-                self.files_updated.emit(folder_name, updated_files)
+    def notify_updated_files(self):
+        updated_files = self.updated_files
+        if updated_files:
+            self.updated_files = []
+            logging.debug("Cleared updated_files list")
+            self.files_updated.emit(updated_files)
+
+    # TODO: Handle added/deleted/restored
+    # TODO: Batch by author?
 
     @staticmethod
     def parse_status(status):
@@ -82,43 +96,42 @@ class Monitor(QObject):
                 state = 2  # "Up to date"
         return state, kind, path, failures
 
-    def process_magic_folder_status(self, name, status):  # noqa: max-complexit=11
+    def process_status(self, status):  # noqa: max-complexit=11
         remote_scan_needed = False
-        prev = self.status[name]
         state, kind, filepath, _ = self.parse_status(status)
-        if status and prev:
+        if status and self.state:
             if state == 1:  # "Syncing"
-                if prev['state'] == 0:  # First sync after restoring
-                    self.first_sync_started.emit(name)
-                if prev['state'] != 1:  # Sync just started
-                    logging.debug("Sync started (%s)", name)
-                    self.sync_started.emit(name)
-                elif prev['state'] == 1:  # Sync started earlier; still going
-                    logging.debug("Sync in progress (%s)", name)
+                if self.state == 0:  # First sync after restoring
+                    self.first_sync_started.emit()
+                if self.state != 1:  # Sync just started
+                    logging.debug("Sync started (%s)", self.name)
+                    self.sync_started.emit()
+                elif self.state == 1:  # Sync started earlier; still going
+                    logging.debug("Sync in progress (%s)", self.name)
                     logging.debug("%sing %s...", kind, filepath)
                     for item in status:
-                        if item not in prev['status']:
-                            self.add_updated_file(name, item['path'])
-            elif state == 2 and prev['state'] == 1:  # Sync just finished
-                logging.debug("Sync complete (%s)", name)
-                self.sync_finished.emit(name)
-                self.notify_updated_files(name)
-            if state in (1, 2) and prev['state'] != 2:
+                        if item not in self.status:
+                            self.add_updated_file(item['path'])
+            elif state == 2 and self.state == 1:  # Sync just finished
+                logging.debug("Sync complete (%s)", self.name)
+                self.sync_finished.emit()
+                self.notify_updated_files()
+            if state in (1, 2) and self.state != 2:
                 remote_scan_needed = True
-            if state != prev['state']:
-                self.status_updated.emit(name, state)
+            if state != self.state:
+                self.status_updated.emit(state)
         else:
-            self.status_updated.emit(name, state)
-        self.status[name]['status'] = status
-        self.status[name]['state'] = state
+            self.status_updated.emit(state)
+        self.status = status
+        self.state = state
         # TODO: Notify failures/conflicts
         return remote_scan_needed
 
-    def compare_states(self, name, current, previous):
+    def compare_states(self, current, previous):
         for mtime, data in current.items():
             if mtime not in previous:
                 if data['deleted']:
-                    self.file_deleted.emit(name, data)
+                    self.file_deleted.emit(data)
                 else:
                     path = data['path']
                     prev_entry = None
@@ -127,48 +140,53 @@ class Monitor(QObject):
                             prev_entry = prev_data
                     if prev_entry:
                         if prev_entry['deleted']:
-                            self.file_restored.emit(name, data)
+                            self.file_restored.emit(data)
                         else:
-                            self.file_updated.emit(name, data)
+                            self.file_updated.emit(data)
                     elif path.endswith('/'):
-                        self.directory_created.emit(name, data)
+                        self.directory_created.emit(data)
                     else:
-                        self.file_added.emit(name, data)
+                        self.file_added.emit(data)
 
     @inlineCallbacks
-    def do_remote_scan(self, name, members=None):
-        mems, size, t, history = yield self.gateway.get_magic_folder_state(
-            name, members)
-        if name not in self.history:
-            self.history[name] = {}
-        self.compare_states(name, history, self.history[name])
-        self.history[name] = history
-        if mems:
-            for member in mems:
+    def do_remote_scan(self, members=None):
+        members, size, t, history = yield self.gateway.get_magic_folder_state(
+            self.name, members)
+        if members:
+            for member in members:
                 if member not in self.members:
-                    self.member_added.emit(name, member[0])
+                    self.member_added.emit(member[0])
                     self.members.append(member)
-        self.size_updated.emit(name, size)
-        self.mtime_updated.emit(name, t)
+        self.size_updated.emit(size)
+        self.mtime_updated.emit(t)
+        self.compare_states(history, self.history)
+        self.history = history
 
     @inlineCallbacks
-    def scan_rootcap(self, overlay_file=None):
-        logging.debug("Scanning %s rootcap...", self.gateway.name)
-        yield self.gateway.await_ready()
-        folders = yield self.gateway.get_magic_folders_from_rootcap()
-        if not folders:
-            return
-        for name, caps in folders.items():
-            if name not in self.gateway.magic_folders.keys():
-                logging.debug(
-                    "Found new folder '%s' in rootcap; adding...", name)
-                self.remote_folder_added.emit(name, overlay_file)
-                c = yield self.gateway.get_json(caps['collective_dircap'])
-                members = yield self.gateway.get_magic_folder_members(name, c)
-                yield self.do_remote_scan(name, members)
+    def do_check(self):
+        status = yield self.gateway.get_magic_folder_status(self.name)
+        scan_needed = self.process_status(status)
+        if scan_needed:
+            yield self.do_remote_scan()
+
+
+class GridChecker(QObject):
+
+    connected = pyqtSignal()
+    disconnected = pyqtSignal()
+    nodes_updated = pyqtSignal(int, int)
+    space_updated = pyqtSignal(object)
+
+    def __init__(self, gateway):
+        super(GridChecker, self).__init__()
+        self.gateway = gateway
+        self.num_connected = 0
+        self.num_happy = 0
+        self.is_connected = False
+        self.available_space = 0
 
     @inlineCallbacks
-    def check_grid_status(self):
+    def do_check(self):
         results = yield self.gateway.get_grid_status()
         if results:
             num_connected, _, available_space = results
@@ -187,7 +205,6 @@ class Monitor(QObject):
                 if not self.is_connected:
                     self.is_connected = True
                     self.connected.emit()
-                    yield self.scan_rootcap()  # TODO: Move to Monitor?
             elif num_happy and num_connected < num_happy:
                 if self.is_connected:
                     self.is_connected = False
@@ -195,14 +212,104 @@ class Monitor(QObject):
             self.num_connected = num_connected
             self.num_happy = num_happy
 
+
+class Monitor(QObject):
+
+    connected = pyqtSignal()
+    disconnected = pyqtSignal()
+    nodes_updated = pyqtSignal(int, int)
+    space_updated = pyqtSignal(object)
+
+    remote_folder_added = pyqtSignal(str, str)
+
+    first_sync_started = pyqtSignal(str)
+    sync_started = pyqtSignal(str)
+    sync_finished = pyqtSignal(str)
+
+    status_updated = pyqtSignal(str, int)
+    mtime_updated = pyqtSignal(str, int)
+    size_updated = pyqtSignal(str, object)
+
+    member_added = pyqtSignal(str, str)
+    member_removed = pyqtSignal(str, str)
+
+    directory_created = pyqtSignal(str, object)
+    file_added = pyqtSignal(str, object)
+    file_updated = pyqtSignal(str, object)
+    file_deleted = pyqtSignal(str, object)
+    file_restored = pyqtSignal(str, object)
+
+    files_updated = pyqtSignal(str, list)
+
+    check_finished = pyqtSignal()
+
+    def __init__(self, gateway):
+        super(Monitor, self).__init__()
+        self.gateway = gateway
+        self.timer = LoopingCall(self.do_checks)
+
+        self.grid_checker = GridChecker(self.gateway)
+        self.grid_checker.connected.connect(self.connected.emit)
+        self.grid_checker.connected.connect(self.scan_rootcap)  # XXX
+        self.grid_checker.disconnected.connect(self.connected.emit)
+        self.grid_checker.nodes_updated.connect(self.nodes_updated.emit)
+        self.grid_checker.space_updated.connect(self.space_updated.emit)
+        self.magic_folder_checkers = {}
+
+    def add_magic_folder_checker(self, name, remote=False):
+        mfc = MagicFolderChecker(self.gateway, name, remote)
+
+        mfc.first_sync_started.connect(
+            lambda: self.first_sync_started.emit(name))
+        mfc.sync_started.connect(lambda: self.sync_started.emit(name))
+        mfc.sync_finished.connect(lambda: self.sync_finished.emit(name))
+
+        mfc.status_updated.connect(lambda x: self.status_updated.emit(name, x))
+        mfc.mtime_updated.connect(lambda x: self.mtime_updated.emit(name, x))
+        mfc.size_updated.connect(lambda x: self.size_updated.emit(name, x))
+
+        mfc.member_added.connect(lambda x: self.member_added.emit(name, x))
+        mfc.member_removed.connect(lambda x: self.member_removed.emit(name, x))
+
+        mfc.directory_created.connect(
+            lambda x: self.directory_created.emit(name, x))
+        mfc.file_added.connect(lambda x: self.file_added.emit(name, x))
+        mfc.file_updated.connect(lambda x: self.file_updated.emit(name, x))
+        mfc.file_deleted.connect(lambda x: self.file_deleted.emit(name, x))
+        mfc.file_restored.connect(lambda x: self.file_restored.emit(name, x))
+
+        mfc.files_updated.connect(lambda x: self.files_updated.emit(name, x))
+        # XXX
+
+        self.magic_folder_checkers[name] = mfc
+
     @inlineCallbacks
-    def check_status(self):
-        yield self.check_grid_status()
+    def scan_rootcap(self, overlay_file=None):
+        logging.debug("Scanning %s rootcap...", self.gateway.name)
+        yield self.gateway.await_ready()
+        folders = yield self.gateway.get_magic_folders_from_rootcap()
+        if not folders:
+            return
+        for name, caps in folders.items():
+            if name not in self.gateway.magic_folders.keys():
+                logging.debug(
+                    "Found new folder '%s' in rootcap; adding...", name)
+                self.add_magic_folder_checker(name, remote=True)
+                self.remote_folder_added.emit(name, overlay_file)
+                c = yield self.gateway.get_json(caps['collective_dircap'])
+                members = yield self.gateway.get_magic_folder_members(name, c)
+                yield self.magic_folder_checkers[name].do_remote_scan(members)
+
+    @inlineCallbacks
+    def do_checks(self):
+        yield self.grid_checker.do_check()
         for folder in list(self.gateway.magic_folders.keys()):
-            status = yield self.gateway.get_magic_folder_status(folder)
-            scan_needed = self.process_magic_folder_status(folder, status)
-            if scan_needed:
-                yield self.do_remote_scan(folder)
+            if folder not in self.magic_folder_checkers:
+                self.add_magic_folder_checker(folder)
+            # TODO: Handle newly-restored folders; set remote=False
+        for magic_folder_checker in self.magic_folder_checkers.values():
+            if not magic_folder_checker.remote:
+                yield magic_folder_checker.do_check()
         self.check_finished.emit()
 
     def start(self, interval=2):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -36,7 +36,6 @@ class MagicFolderChecker(QObject):
         self.remote = remote
 
         self.state = None
-        self.status = {}
         self.mtime = 0
         self.size = 0
 
@@ -142,7 +141,6 @@ class MagicFolderChecker(QObject):
                 self.status_updated.emit(state)
         else:
             self.status_updated.emit(state)
-        self.status = status
         self.state = state
         # TODO: Notify failures/conflicts
         return remote_scan_needed

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -110,7 +110,7 @@ class Monitor(QObject):
 
     @inlineCallbacks
     def do_remote_scan(self, name, members=None):
-        mems, size, t, _ = yield self.gateway.get_magic_folder_info(
+        mems, size, t, _ = yield self.gateway.get_magic_folder_state(
             name, members)
         if mems:
             for member in mems:

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -123,7 +123,7 @@ class Monitor(QObject):
                 else:
                     path = data['path']
                     prev_entry = None
-                    for prev_mtime, prev_data in previous.items():
+                    for prev_data in previous.values():
                         if prev_data['path'] == path:
                             prev_entry = prev_data
                     if prev_entry:

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -116,8 +116,6 @@ class MagicFolderChecker(QObject):
         state, kind, filepath, _ = self.parse_status(status)
         if status and self.state:
             if state == 1:  # "Syncing"
-                if self.state == 0:  # First sync after restoring
-                    self.first_sync_started.emit()
                 if self.state != 1:  # Sync just started
                     logging.debug("Sync started (%s)", self.name)
                     self.sync_started.emit()

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -331,8 +331,9 @@ class Monitor(QObject):
         for folder in list(self.gateway.magic_folders.keys()):
             if folder not in self.magic_folder_checkers:
                 self.add_magic_folder_checker(folder)
-            # TODO: Handle newly-restored folders; set remote=False
-        for magic_folder_checker in self.magic_folder_checkers.values():
+            elif self.magic_folder_checkers[folder].remote:
+                self.magic_folder_checkers[folder].remote = False
+        for magic_folder_checker in list(self.magic_folder_checkers.values()):
             if not magic_folder_checker.remote:
                 yield magic_folder_checker.do_check()
         self.check_finished.emit()

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -79,8 +79,8 @@ class MagicFolderChecker(QObject):
                     bytes_total += size
                 if task['status'] in ('started', 'success'):
                     bytes_transferred += size * task['percent_done'] / 100
-        self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
         if bytes_transferred and bytes_total:
+            self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
             duration = time.time() - self.sync_time_started
             speed = bytes_transferred / duration
             self.transfer_speed_updated.emit(speed)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -50,7 +50,8 @@ class MagicFolderChecker(QObject):
         for author, change in changes.items():
             notifications = defaultdict(list)
             for action, path in change:
-                notifications[action].append(path)
+                if path not in notifications[action]:
+                    notifications[action].append(path)
             for action, files, in notifications.items():
                 logging.debug("%s %s %s", author, action, files)
                 self.files_updated.emit(files, action, author)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -24,6 +24,11 @@ class Monitor(QObject):
     files_updated = pyqtSignal(str, list)
     check_finished = pyqtSignal()
     remote_folder_added = pyqtSignal(str, str)
+    directory_created = pyqtSignal(str, object)
+    file_added = pyqtSignal(str, object)
+    file_updated = pyqtSignal(str, object)
+    file_deleted = pyqtSignal(str, object)
+    file_restored = pyqtSignal(str, object)
 
     def __init__(self, gateway):
         super(Monitor, self).__init__()
@@ -109,6 +114,8 @@ class Monitor(QObject):
         # TODO: Notify failures/conflicts
         return remote_scan_needed
 
+    #def handle_deleted(self, name, data):
+
     def compare_states(self, name, current, previous):
         created = []
         added = []
@@ -118,6 +125,7 @@ class Monitor(QObject):
         for mtime, data in current.items():
             if mtime not in previous:
                 if data['deleted']:
+                    self.file_deleted.emit(name, data)
                     print('DELETED: ', data)
                     deleted.append(data)
                 else:
@@ -128,15 +136,19 @@ class Monitor(QObject):
                             prev_entry = prev_data
                     if prev_entry:
                         if prev_entry['deleted']:
+                            self.file_restored.emit(name, data)
                             print('RESTORED: ', data)
                             restored.append(data)
                         else:
+                            self.file_updated.emit(name, data)
                             print('UPDATED: ', data)
                             updated.append(data)
                     elif path.endswith('/'):
+                        self.directory_created.emit(name, data)
                         print('CREATED: ', data)
                         created.append(data)
                     else:
+                        self.file_added.emit(name, data)
                         print('ADDED: ', data)
                         added.append(data)
         # XXX

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -101,6 +101,7 @@ class MagicFolderChecker(QObject):
         return state, kind, path, failures, bytes_transferred, bytes_total
 
     def emit_transfer_signals(self, bytes_transferred, bytes_total):
+        # XXX This does not take into account erasure coding overhead
         self.transfer_progress_updated.emit(bytes_transferred, bytes_total)
         if bytes_transferred:
             duration = time.time() - self.sync_time_started

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -133,7 +133,6 @@ class MagicFolderChecker(QObject):
                         data['action'] = 'added'
                 self.file_updated.emit(data)
                 self.updated_files.append(data)
-                print(data)
 
     @inlineCallbacks
     def do_remote_scan(self, members=None):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -871,7 +871,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                     metadata['path'] = filenode.replace('@_', os.path.sep)
                     history_dict[metadata['mtime']] = metadata
                     total_size += metadata['size']
-        history_od = OrderedDict(sorted(history_dict.items(), reverse=True))
+        history_od = OrderedDict(sorted(history_dict.items()))
         if history_od:
             latest_mtime = next(iter(history_od))  # pylint: disable=stop-iteration-return
         else:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -869,6 +869,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                     except KeyError:
                         continue
                     metadata['path'] = filenode.replace('@_', os.path.sep)
+                    metadata['member'] = member
                     history_dict[metadata['mtime']] = metadata
                     total_size += metadata['size']
         history_od = OrderedDict(sorted(history_dict.items()))

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -79,7 +79,7 @@ class CommandProtocol(ProcessProtocol):
                     self.output.getvalue().decode('utf-8').strip()))
 
 
-class Tahoe():  # pylint: disable=too-many-public-methods
+class Tahoe():
     def __init__(self, nodedir=None, executable=None):
         self.executable = executable
         self.multi_folder_support = True
@@ -815,22 +815,6 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                 else:
                     members.append((member, readcap))
             return members
-        return None
-
-    @staticmethod
-    def size_from_content(content):
-        size = 0
-        filenodes = content[1]['children']
-        for filenode in filenodes:
-            size += int(filenodes[filenode][1]['size'])
-        return size
-
-    @inlineCallbacks
-    def get_magic_folder_size(self, name, content=None):
-        if not content:
-            content = yield self.get_json(self.get_magic_folder_dircap(name))
-        if content:
-            return self.size_from_content(content)
         return None
 
     @staticmethod

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -873,10 +873,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                     history_dict[metadata['mtime']] = metadata
                     total_size += metadata['size']
         history_od = OrderedDict(sorted(history_dict.items()))
-        if history_od:
-            latest_mtime = next(reversed(history_od))
-        else:
-            latest_mtime = 0
+        latest_mtime = next(reversed(history_od), 0)
         return members, total_size, latest_mtime, history_od
 
 

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -13,6 +13,7 @@ import tempfile
 from collections import defaultdict
 from io import BytesIO
 
+
 import treq
 from twisted.internet import reactor
 from twisted.internet.defer import (
@@ -26,6 +27,7 @@ import yaml
 from gridsync import pkgdir
 from gridsync.config import Config
 from gridsync.errors import TahoeError, TahoeCommandError, TahoeWebError
+from gridsync.monitor import Monitor
 from gridsync.preferences import set_preference, get_preference
 
 
@@ -100,6 +102,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
         self.magic_folders = defaultdict(dict)
         self.remote_magic_folders = defaultdict(dict)
         self.use_tor = False
+        self.monitor = Monitor(self)
 
     def config_set(self, section, option, value):
         self.config.set(section, option, value)

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -833,38 +833,6 @@ class Tahoe():  # pylint: disable=too-many-public-methods
             return self.size_from_content(content)
         return None
 
-    @inlineCallbacks  # noqa: max-complexity=12 XXX
-    def get_magic_folder_info(self, name, members=None):
-        total_size = 0
-        sizes_dict = {}
-        latest_mtime = 0
-        if not members:
-            members = yield self.get_magic_folder_members(name)
-        if members:
-            for member, dircap in reversed(members):
-                sizes_dict[member] = {}
-                json_data = yield self.get_json(dircap)
-                try:
-                    children = json_data[1]['children']
-                except TypeError:
-                    continue
-                for filenode, data in children.items():
-                    filepath = filenode.replace('@_', os.path.sep)
-                    metadata = data[1]
-                    try:
-                        size = int(metadata['size'])
-                    except KeyError:  # if linked manually
-                        continue
-                    sizes_dict[member][filepath] = size
-                    total_size += size
-                    try:
-                        mt = int(metadata['metadata']['tahoe']['linkmotime'])
-                    except KeyError:
-                        continue
-                    if mt > latest_mtime:
-                        latest_mtime = mt
-        return members, total_size, latest_mtime, sizes_dict
-
     @staticmethod
     def _extract_metadata(metadata):
         size = int(metadata['size'])

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -874,7 +874,7 @@ class Tahoe():  # pylint: disable=too-many-public-methods
                     total_size += metadata['size']
         history_od = OrderedDict(sorted(history_dict.items()))
         if history_od:
-            latest_mtime = next(iter(history_od))  # pylint: disable=stop-iteration-return
+            latest_mtime = next(reversed(history_od))
         else:
             latest_mtime = 0
         return members, total_size, latest_mtime, history_od

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from gridsync.monitor import MagicFolderChecker
+
+
+@pytest.fixture(scope='function')
+def mfc():
+    return MagicFolderChecker(None, 'TestFolder')
+
+
+def test_magic_folder_checker_name(mfc):
+    assert mfc.name == 'TestFolder'
+
+
+def test_magic_folder_checker_remote_default_false(mfc):
+    assert mfc.remote is False
+
+
+status_data = [
+    {
+        'kind': 'upload',
+        'path': 'file_4',
+        'percent_done': 0,
+        'queued_at': 1,
+        'size': 2560,
+        'status': 'queued'
+    },
+    {
+        'kind': 'upload',
+        'path': 'file_3',
+        'percent_done': 0,
+        'queued_at': 1,
+        'size': None,
+        'status': 'queued'
+    },
+    {
+        'kind': 'upload',
+        'path': 'file_2',
+        'percent_done': 50.0,
+        'queued_at': 1,
+        'size': 1024,
+        'started_at': 1,
+        'status': 'started'
+    },
+    {
+        'kind': 'upload',
+        'path': 'file_1',
+        'percent_done': 100.0,
+        'queued_at': 1,
+        'size': 512,
+        'started_at': 1,
+        'status': 'success',
+        'success_at': 1
+    }
+]
+
+
+def test_emit_transfer_progress_updated(mfc, qtbot):
+    with qtbot.wait_signal(mfc.transfer_progress_updated) as blocker:
+        mfc.emit_transfer_signals(status_data)
+    assert blocker.args == [1024, 4096]  # bytes transferred, bytes total
+
+
+def test_emit_transfer_speed_updated(mfc, monkeypatch, qtbot):
+    mfc.sync_time_started = 1
+    monkeypatch.setattr('time.time', lambda: 2)  # One second has passed
+    with qtbot.wait_signal(mfc.transfer_speed_updated) as blocker:
+        mfc.emit_transfer_signals(status_data)
+    assert blocker.args == [1024]  # bytes per second
+
+
+def test_emit_transfer_seconds_remaining_updated(mfc, monkeypatch, qtbot):
+    mfc.sync_time_started = 1
+    monkeypatch.setattr('time.time', lambda: 2)  # One second has passed
+    with qtbot.wait_signal(mfc.transfer_seconds_remaining_updated) as blocker:
+        mfc.emit_transfer_signals(status_data)
+    assert blocker.args == [3]  # seconds remaining
+
+
+def test_parse_status_set_sync_time_started_by_earliest_time(mfc):
+    mfc.parse_status([
+        {'kind': 'upload', 'path': 'two', 'status': 'queued', 'queued_at': 2},
+        {'kind': 'upload', 'path': 'one', 'status': 'queued', 'queued_at': 1}
+    ])
+    assert mfc.sync_time_started == 1
+
+
+def test_parse_status_return_values_syncing(mfc):
+    state, kind, path, failures = mfc.parse_status(status_data)
+    assert (state, kind, path, failures) == (1, 'upload', 'file_2', [])
+
+
+def test_parse_status_state_up_to_date(mfc):
+    state, _, _, _ = mfc.parse_status({})
+    assert state == 2
+
+
+def test_parse_status_append_failure(mfc):
+    task = {'kind': 'upload', 'status': 'failure'}
+    _, _, _, failures = mfc.parse_status([task])
+    assert failures == [task]
+
+
+def test_process_status_remote_scan_needed(mfc):
+    mfc.state = 1
+    assert mfc.process_status(status_data) is True
+
+
+def test_process_status_emit_status_updated_syncing(mfc, monkeypatch, qtbot):
+    with qtbot.wait_signal(mfc.status_updated) as blocker:
+        mfc.process_status(status_data)
+    assert blocker.args == [1]
+
+
+def test_process_status_still_syncing_no_emit_status_updated(mfc, qtbot):
+    mfc.state = 1
+    with qtbot.assertNotEmitted(mfc.status_updated):
+        mfc.process_status(status_data)
+
+
+def test_process_status_emit_status_updated_scanning(mfc, monkeypatch, qtbot):
+    mfc.state = 1
+    monkeypatch.setattr(
+        'gridsync.monitor.MagicFolderChecker.parse_status',
+        lambda x, y: (2, 'upload', 'file_0', [])
+    )
+    with qtbot.wait_signal(mfc.status_updated) as blocker:
+        mfc.process_status(status_data)
+    assert blocker.args == [99]
+
+
+def test_process_status_emit_status_updated_up_to_date(
+        mfc, monkeypatch, qtbot):
+    mfc.state = 99
+    monkeypatch.setattr(
+        'gridsync.monitor.MagicFolderChecker.parse_status',
+        lambda x, y: (2, 'upload', 'file_0', [])
+    )
+    with qtbot.wait_signal(mfc.status_updated) as blocker:
+        mfc.process_status(status_data)
+    assert blocker.args == [2]
+
+
+def test_process_status_emit_sync_finished(mfc, monkeypatch, qtbot):
+    mfc.state = 99
+    monkeypatch.setattr(
+        'gridsync.monitor.MagicFolderChecker.parse_status',
+        lambda x, y: (2, 'upload', 'file_0', [])
+    )
+    with qtbot.wait_signal(mfc.sync_finished):
+        mfc.process_status(status_data)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -29,7 +29,7 @@ def test_notify_updated_files(mfc, qtbot):
             'member': 'admin',
             'mtime': 1,
             'path': 'file_1.txt',
-            'size': 0, 
+            'size': 0,
         },
         {
             'action': 'added',
@@ -38,7 +38,7 @@ def test_notify_updated_files(mfc, qtbot):
             'member': 'admin',
             'mtime': 2,
             'path': 'file_2.txt',
-            'size': 0, 
+            'size': 0,
         }
     ]
     with qtbot.wait_signal(mfc.files_updated) as blocker:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -20,6 +20,32 @@ def test_magic_folder_checker_remote_default_false(mfc):
     assert mfc.remote is False
 
 
+def test_notify_updated_files(mfc, qtbot):
+    mfc.updated_files = [
+        {
+            'action': 'added',
+            'cap': 'URI:LIT',
+            'deleted': False,
+            'member': 'admin',
+            'mtime': 1,
+            'path': 'file_1.txt',
+            'size': 0, 
+        },
+        {
+            'action': 'added',
+            'cap': 'URI:LIT',
+            'deleted': False,
+            'member': 'admin',
+            'mtime': 2,
+            'path': 'file_2.txt',
+            'size': 0, 
+        }
+    ]
+    with qtbot.wait_signal(mfc.files_updated) as blocker:
+        mfc.notify_updated_files()
+    assert blocker.args == [['file_1.txt', 'file_2.txt'], 'added', '']
+
+
 status_data = [
     {
         'kind': 'upload',


### PR DESCRIPTION
This PR adds a number of improvements to the "monitor" module and associated functionality, including:

- Decomposing the `Monitor` class into `GridChecker` and `MagicFolderChecker` classes
- Tracking the authorship of individual changes made per magic-folder
- Tracking the type of individual changes made ("added", "updated", "deleted", "restored")
- Tracking per-sync transfer-related statistics (bytes transferred/total, speed of transfer, estimated time-remaining)
- Batching desktop notifications by author name and type
- Deduplicating buffered desktop notifications
- Scanning for untracked changes after "syncing" phase ends
- Fixing issues related to desktop notification buffering and delays
- Increasing module test-coverage to 100%

Note that although the improved Monitor module/class now provides additional useful information about grid status and magic-folder syncing operations, some of this information is not yet presented within the UI (such as change-authorship and time-remaining estimates); additional changes still need to be made to within the UI in order to display such information to the user in a useful manner (e.g., via the [forthcoming "history view" feature](https://github.com/gridsync/gridsync/issues/92)) -- in other words, the work in this PR can largely be considered a necessary precondition for other pending UI/UX improvements coming soon...