### PR TITLE
Update PyInstaller to 3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ frozen-tahoe:
 		Darwin) python ../../scripts/maybe_rebuild_libsodium.py ;; \
 	esac &&	\
 	pip install packaging && \
-	pip install pyinstaller==3.3.1 && \
+	pip install pyinstaller==3.4 && \
 	pip list && \
 	export PYTHONHASHSEED=1 && \
 	pyinstaller pyinstaller.spec && \
@@ -254,20 +254,10 @@ pyinstaller:
 	case `uname` in \
 		Darwin) \
 			python scripts/maybe_rebuild_libsodium.py && \
-			python scripts/maybe_downgrade_pyqt.py && \
-			git clone https://github.com/pyinstaller/pyinstaller.git build/pyinstaller && \
-			pushd build/pyinstaller && \
-			git checkout 355f0c76b2ee5af0cb2f7cb5512a060d2ed02b2b && \
-			pushd bootloader && \
-			python ./waf all && \
-			popd && \
-			pip install . && \
-			popd \
-		;; \
-		*) \
-			pip install pyinstaller==3.3.1 \
+			python scripts/maybe_downgrade_pyqt.py \
 		;; \
 	esac &&	\
+	pip install pyinstaller==3.4 && \
 	pip list && \
 	export PYTHONHASHSEED=1 && \
 	python -m PyInstaller -y misc/gridsync.spec

--- a/make.bat
+++ b/make.bat
@@ -75,7 +75,7 @@ call pushd .\build\tahoe-lafs
 call python setup.py update_version
 call pip install .
 call pip install packaging
-call pip install pyinstaller==3.3.1
+call pip install pyinstaller==3.4
 call pip list
 call set PYTHONHASHSEED=1
 call pyinstaller pyinstaller.spec
@@ -98,7 +98,7 @@ call .\build\venv-gridsync\Scripts\activate
 call pip install --upgrade setuptools pip
 call pip install -r .\requirements\requirements-hashes.txt
 call pip install . 
-call pip install pyinstaller==3.3.1
+call pip install pyinstaller==3.4
 call pip list
 call set PYTHONHASHSEED=1
 call pyinstaller -y --clean misc\gridsync.spec


### PR DESCRIPTION
With the upstream release of PyInstaller 3.4, bootloaders should no
longer need to be recompiled in order to have Gridsync run as an "agent"
process on macOS. See also #112.