### PR TITLE
Desktop improvements

### DIFF
--- a/gridsync/desktop.py
+++ b/gridsync/desktop.py
@@ -72,7 +72,7 @@ def open_enclosing_folder(path):
         subprocess.Popen(['xdg-open', os.path.dirname(path)])
 
 
-def open_folder(path):
+def open_path(path):
     path = os.path.expanduser(path)
     if sys.platform == 'darwin':
         subprocess.Popen(['open', path])

--- a/gridsync/desktop.py
+++ b/gridsync/desktop.py
@@ -60,6 +60,18 @@ def notify(systray, title, message, duration=5000):
         systray.showMessage(title, message, msecs=duration)
 
 
+def open_enclosing_folder(path):
+    path = os.path.expanduser(path)
+    if sys.platform == 'darwin':
+        subprocess.Popen(['open', '--reveal', path])
+    elif sys.platform == 'win32':
+        subprocess.Popen('explorer /select,"{}"'.format(path))
+    else:
+        # TODO: Get file-manager via `xdg-mime query default inode/directory`
+        # and, if 'org.gnome.Nautilus.desktop', call `nautilus --select`?
+        subprocess.Popen(['xdg-open', os.path.dirname(path)])
+
+
 def open_folder(path):
     path = os.path.expanduser(path)
     if sys.platform == 'darwin':

--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QWidget)
 
 from gridsync import resource
-from gridsync.desktop import open_enclosing_folder, open_folder
+from gridsync.desktop import open_enclosing_folder, open_path
 from gridsync.gui.status import StatusPanel
 
 
@@ -163,7 +163,7 @@ class HistoryListWidget(QListWidget):
         widget = self.itemWidget(item)
         menu = QMenu(self)
         open_file_action = QAction("Open file")
-        open_file_action.triggered.connect(lambda: open_folder(widget.path))
+        open_file_action.triggered.connect(lambda: open_path(widget.path))
         menu.addAction(open_file_action)
         open_folder_action = QAction("Open enclosing folder")
         open_folder_action.triggered.connect(

--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QWidget)
 
 from gridsync import resource
-from gridsync.desktop import open_folder
+from gridsync.desktop import open_enclosing_folder, open_folder
 from gridsync.gui.status import StatusPanel
 
 
@@ -152,7 +152,7 @@ class HistoryListWidget(QListWidget):
         )
 
     def on_double_click(self, item):
-        open_folder(os.path.dirname(self.itemWidget(item).path))
+        open_enclosing_folder(self.itemWidget(item).path)
 
     def on_right_click(self, position):
         if not position:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
 from twisted.internet.defer import DeferredList
 
 from gridsync import resource, APP_NAME
-from gridsync.desktop import open_folder
+from gridsync.desktop import open_path
 from gridsync.gui.model import Model
 from gridsync.gui.share import ShareWidget
 from gridsync.util import humanized_list
@@ -166,7 +166,7 @@ class View(QTreeView):
         item = self.model().itemFromIndex(index)
         name = self.model().item(item.row(), 0).text()
         if name in self.gateway.magic_folders:
-            open_folder(self.gateway.magic_folders[name]['directory'])
+            open_path(self.gateway.magic_folders[name]['directory'])
         elif self.gateway.remote_magic_folder_exists(name):
             self.select_download_location([name])
 
@@ -281,7 +281,7 @@ class View(QTreeView):
         for folder in folders:
             folder_info = self.gateway.magic_folders.get(folder)
             if folder_info:
-                open_folder(folder_info['directory'])
+                open_path(folder_info['directory'])
 
     def deselect_local_folders(self):
         selected = self.selectedIndexes()

--- a/tests/gui/test_history.py
+++ b/tests/gui/test_history.py
@@ -83,13 +83,12 @@ def hlw(tmpdir_factory):
 
 def test_history_list_widget_on_double_click(hlw, monkeypatch):
     m = MagicMock()
-    monkeypatch.setattr('gridsync.gui.history.open_folder', m)
+    monkeypatch.setattr('gridsync.gui.history.open_enclosing_folder', m)
     monkeypatch.setattr(
         'gridsync.gui.history.HistoryListWidget.itemWidget', MagicMock()
     )
-    monkeypatch.setattr('os.path.dirname', lambda _: '/test/path')
     hlw.on_double_click(None)
-    assert m.mock_calls == [call('/test/path')]
+    assert m.mock_calls
 
 
 def test_history_list_widget_on_right_click(hlw, monkeypatch):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -7,7 +7,7 @@ import pytest
 
 from gridsync.desktop import (
     _dbus_notify, notify, get_clipboard_modes, get_clipboard_text,
-    set_clipboard_text, open_enclosing_folder, open_folder,
+    set_clipboard_text, open_enclosing_folder, open_path,
     autostart_enable, autostart_is_enabled, autostart_disable)
 
 
@@ -106,19 +106,19 @@ def test_open_enclosing_folder(platform, args, monkeypatch):
         ('linux', ['xdg-open', '/test/path/file.txt'])
     ]
 )
-def test_open_folder(platform, args, monkeypatch):
+def test_open_path(platform, args, monkeypatch):
     m = MagicMock()
     monkeypatch.setattr('subprocess.Popen', m)
     monkeypatch.setattr('sys.platform', platform)
-    open_folder('/test/path/file.txt')
+    open_path('/test/path/file.txt')
     assert m.mock_calls == [call(args)]
 
 
-def test_open_folder_win32(monkeypatch):
+def test_open_path_win32(monkeypatch):
     m = MagicMock()
     monkeypatch.setattr('os.startfile', m, raising=False)
     monkeypatch.setattr('sys.platform', 'win32')
-    open_folder('/test/path/file.txt')
+    open_path('/test/path/file.txt')
     assert m.mock_calls == [call('/test/path/file.txt')]
 
 

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import os
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, call
 
 import pytest
 
 from gridsync.desktop import (
     _dbus_notify, notify, get_clipboard_modes, get_clipboard_text,
-    set_clipboard_text, autostart_enable, autostart_is_enabled,
-    autostart_disable)
+    set_clipboard_text, open_enclosing_folder, open_folder,
+    autostart_enable, autostart_is_enabled, autostart_disable)
 
 
 def test__dbus_notify_bus_not_connected(monkeypatch):
@@ -83,9 +83,43 @@ def test_notify_call_systray_show_message(monkeypatch):
     assert show_message_args == ['test_title', 'test_message', 9001]
 
 
-@pytest.fixture()
-def tmpfile(tmpdir):
-    return str(tmpdir.join('tmpfile.lnk'))  # .lnk extension required on win32
+@pytest.mark.parametrize(
+    'platform,args',
+    [
+        ('darwin', ['open', '--reveal', '/test/path/file.txt']),
+        ('linux', ['xdg-open', '/test/path']),
+        ('win32', 'explorer /select,"/test/path/file.txt"')
+    ]
+)
+def test_open_enclosing_folder(platform, args, monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr('subprocess.Popen', m)
+    monkeypatch.setattr('sys.platform', platform)
+    open_enclosing_folder('/test/path/file.txt')
+    assert m.mock_calls == [call(args)]
+
+
+@pytest.mark.parametrize(
+    'platform,args',
+    [
+        ('darwin', ['open', '/test/path/file.txt']),
+        ('linux', ['xdg-open', '/test/path/file.txt'])
+    ]
+)
+def test_open_folder(platform, args, monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr('subprocess.Popen', m)
+    monkeypatch.setattr('sys.platform', platform)
+    open_folder('/test/path/file.txt')
+    assert m.mock_calls == [call(args)]
+
+
+def test_open_folder_win32(monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr('os.startfile', m, raising=False)
+    monkeypatch.setattr('sys.platform', 'win32')
+    open_folder('/test/path/file.txt')
+    assert m.mock_calls == [call('/test/path/file.txt')]
 
 
 def test_get_clipboard_modes():
@@ -97,6 +131,11 @@ def test_get_clipboard_modes():
 def test_clipboard_text():
     set_clipboard_text('test')
     assert get_clipboard_text() == 'test'
+
+
+@pytest.fixture()
+def tmpfile(tmpdir):
+    return str(tmpdir.join('tmpfile.lnk'))  # .lnk extension required on win32
 
 
 def test_autostart_is_enabled_true(tmpfile, monkeypatch):


### PR DESCRIPTION
This PR adds an "open_enclosing_folder" function (selecting/revealing the given `path` in macOS' _Finder_ or Windows' _Explorer_), renames the existing "open_folder" function to "open_path", and adds proper tests for both functions.