### PR TITLE
macOS tweaks

### DIFF
--- a/gridsync/gui/invite.py
+++ b/gridsync/gui/invite.py
@@ -244,23 +244,26 @@ def show_failure(failure, parent=None):
     msg.setDetailedText(str(failure))
     if failure.type == ServerConnectionError:
         msg.setWindowTitle("Server Connection Error")
-        msg.setText(
-            "An error occured while connecting to the invite server. This "
-            "could mean that it is currently offline or that there is some "
-            "other problem with your connection. Please try again later.")
+        msg.setText("An error occured while connecting to the invite server.")
+        msg.setInformativeText(
+            "This could mean that it is currently offline or that there is "
+            "some other problem with your connection. Please try again later.")
     elif failure.type == WelcomeError:
         msg.setWindowTitle("Invite refused")
         msg.setText(
-            "The server negotiating your invitation is online but is "
-            "currently refusing to process any invitations. This may indicate "
-            "that your version of {} is out-of-date, in which case you should "
-            "upgrade to the latest version and try again.".format(APP_NAME))
+            "The server negotiating your invitation is refusing to process "
+            "any invitations.")
+        msg.setInformativeText(
+            "This may indicate that your version of {} is out-of-date, in "
+            "which case you should upgrade to the latest version and try "
+            "again.".format(APP_NAME))
         msg.setIcon(QMessageBox.Critical)
         msg.setStandardButtons(QMessageBox.Ok)
         msg.setEscapeButton(QMessageBox.Ok)
     elif failure.type == WrongPasswordError:
         msg.setWindowTitle("Invite confirmation failed")
-        msg.setText(
+        msg.setWindowTitle("Invite confirmation failed")
+        msg.setInformativeText(
             "Either your recipient mistyped the invite code or a potential "
             "attacker tried to guess the code and failed.\n\nTo try again, "
             "you will need a new invite code.")
@@ -268,18 +271,19 @@ def show_failure(failure, parent=None):
         return
     elif failure.type == UpgradeRequiredError:
         msg.setWindowTitle("Upgrade required")
-        msg.setText(
-            "Your version of {} is out-of-date. Please upgrade to the latest "
-            "version and try again with a new invite code.".format(APP_NAME))
+        msg.setText("Your version of {} is out-of-date.".format(APP_NAME))
+        msg.setInformativeText(
+            "Please upgrade to the latest version and try again with a new "
+            "invite code.")
         msg.setIcon(QMessageBox.Critical)
         msg.setStandardButtons(QMessageBox.Ok)
         msg.setEscapeButton(QMessageBox.Ok)
     elif failure.type == CancelledError:
         msg.setWindowTitle("Invite timed out")
-        msg.setText(
-            "The invitation process has timed out. Your invite code may have "
-            "have expired. Please request a new invite code from the other "
-            "party and try again.")
+        msg.setText("The invitation process has timed out.")
+        msg.setInformativeText(
+            "Your invite code may have expired. Please request a new invite "
+            "code from the other party and try again.")
     else:
         msg.setWindowTitle(str(failure.type.__name__))
         msg.setText(str(failure.value))

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -63,9 +63,11 @@ class CentralWidget(QStackedWidget):
         view = View(self.gui, gateway)
         widget = QWidget()
         layout = QGridLayout(widget)
-        if sys.platform != 'darwin':
-            margin_left, _, margin_right, _ = layout.getContentsMargins()
-            layout.setContentsMargins(margin_left, 0, margin_right, 0)
+        left, top, right, bottom = layout.getContentsMargins()
+        if sys.platform == 'darwin':
+            layout.setContentsMargins(left, top, right, 0)
+        else:
+            layout.setContentsMargins(left, 0, right, 0)
         layout.addWidget(view)
         layout.addWidget(StatusPanel(gateway))
         self.addWidget(widget)

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -350,13 +350,23 @@ class MainWindow(QMainWindow):
             self.active_pair_widgets.append(pair_widget)
 
     def confirm_quit(self):
-        reply = QMessageBox.question(
-            self, "Exit {}?".format(APP_NAME),
-            "Are you sure you wish to quit? If you quit, {} will stop "
-            "synchronizing your folders until you run it again.".format(
-                APP_NAME),
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+        msg = QMessageBox(self)
+        msg.setIcon(QMessageBox.Question)
+        if sys.platform == 'darwin':
+            msg.setText("Are you sure you wish to quit?")
+            msg.setInformativeText(
+                "If you quit, {} will stop synchronizing your folders until "
+                "you run it again.".format(APP_NAME))
+            msg.setWindowModality(Qt.WindowModal)
+        else:
+            msg.setWindowTitle("Exit {}?".format(APP_NAME))
+            msg.setText(
+                "Are you sure you wish to quit? If you quit, {} will stop "
+                "synchronizing your folders until you run it again.".format(
+                    APP_NAME))
+        msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msg.setDefaultButton(QMessageBox.No)
+        if msg.exec_() == QMessageBox.Yes:
             reactor.stop()
 
     def keyPressEvent(self, event):

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -63,7 +63,7 @@ class CentralWidget(QStackedWidget):
         view = View(self.gui, gateway)
         widget = QWidget()
         layout = QGridLayout(widget)
-        left, top, right, bottom = layout.getContentsMargins()
+        left, top, right, _ = layout.getContentsMargins()
         if sys.platform == 'darwin':
             layout.setContentsMargins(left, top, right, 0)
         else:

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -63,10 +63,11 @@ class CentralWidget(QStackedWidget):
         view = View(self.gui, gateway)
         widget = QWidget()
         layout = QGridLayout(widget)
-        left, top, right, _ = layout.getContentsMargins()
         if sys.platform == 'darwin':
-            layout.setContentsMargins(left, top, right, 0)
+            # XXX: For some reason, getContentsMargins returns 20 px on macOS..
+            layout.setContentsMargins(11, 11, 11, 0)
         else:
+            left, _, right, _ = layout.getContentsMargins()
             layout.setContentsMargins(left, 0, right, 0)
         layout.addWidget(view)
         layout.addWidget(StatusPanel(gateway))

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -357,7 +357,6 @@ class MainWindow(QMainWindow):
             msg.setInformativeText(
                 "If you quit, {} will stop synchronizing your folders until "
                 "you run it again.".format(APP_NAME))
-            msg.setWindowModality(Qt.WindowModal)
         else:
             msg.setWindowTitle("Exit {}?".format(APP_NAME))
             msg.setText(

--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -320,14 +320,18 @@ class ShareWidget(QDialog):
 
     def closeEvent(self, event):
         if self.code_label.text() and self.progress_bar.value() < 2:
-            reply = QMessageBox.question(
-                self, "Cancel invitation?",
-                'Are you sure you wish to cancel the invitation to "{}"?\n\n'
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Question)
+            msg.setWindowTitle("Cancel invitation?")
+            msg.setText(
+                'Are you sure you wish to cancel the invitation to "{}"?'
+                .format(self.gateway.name))
+            msg.setInformativeText(
                 'The invite code "{}" will no longer be valid.'.format(
-                    self.gateway.name, self.code_label.text()),
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No)
-            if reply == QMessageBox.Yes:
+                    self.code_label.text()))
+            msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            msg.setDefaultButton(QMessageBox.No)
+            if msg.exec_() == QMessageBox.Yes:
                 self.wormhole.close()
                 if self.folder_names:
                     for folder, member_id in self.pending_invites:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -206,22 +206,25 @@ class View(QTreeView):
         msg.exec_()
 
     def confirm_unlink(self, folders):
+        msgbox = QMessageBox(self)
+        msgbox.setIcon(QMessageBox.Question)
         humanized_folders = humanized_list(folders, "folders")
-        title = "Permanently remove {}?".format(humanized_folders)
+        msgbox.setWindowTitle(
+            "Permanently remove {}?".format(humanized_folders))
         if len(folders) == 1:
-            text = ("Are you sure you wish to <b>permanently</b> remove the "
-                    "'{}' folder? If you do, it will be unlinked from your "
-                    "rootcap and cannot be restored with your Recovery Key."
-                    .format(folders[0]))
+            msgbox.setText(
+                'Are you sure you wish to <b>permanently</b> remove the "{}" '
+                'folder?'.format(folders[0]))
         else:
-            text = ("Are you sure you wish to <b>permanently</b> remove {}? "
-                    "If you do, they will be unlinked from your rootcap and "
-                    "cannot be restored with your Recovery Key.".format(
-                        humanized_folders))
-        reply = QMessageBox.question(
-            self, title, text, QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No)
-        if reply == QMessageBox.Yes:
+            msgbox.setText(
+                "Are you sure you wish to <b>permanently</b> remove {}?"
+                .format(humanized_folders))
+        msgbox.setInformativeText(
+            "Permanently removed folders cannot be restored with your "
+            "Recovery Key.")
+        msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msgbox.setDefaultButton(QMessageBox.No)
+        if msgbox.exec_() == QMessageBox.Yes:
             tasks = []
             for folder in folders:
                 d = self.gateway.unlink_magic_folder_from_rootcap(folder)
@@ -233,36 +236,32 @@ class View(QTreeView):
             d.addCallback(self.show_drop_label)
 
     def confirm_remove(self, folders):
-        humanized_folders = humanized_list(folders, "folders")
-        title = "Remove {}?".format(humanized_folders)
-        if len(folders) == 1:
-            text = ("Are you sure you wish to remove the '{}' folder? If "
-                    "you do, it will remain on your computer, however, {} "
-                    "will no longer synchronize its contents with {}.".format(
-                        folders[0], APP_NAME, self.gateway.name))
-            cb_text = ("Allow this folder to be restored later with my "
-                       "Recovery Key")
-        else:
-            text = ("Are you sure you wish to remove {}? If you do, they "
-                    "will remain on your computer, however, {} will no "
-                    "longer synchronize their contents with {}.".format(
-                        humanized_folders, APP_NAME, self.gateway.name))
-            cb_text = ("Allow these folders to be restored later with my "
-                       "Recovery Key")
-        checkbox = QCheckBox(cb_text)
-        checkbox.setCheckState(Qt.Checked)
         msgbox = QMessageBox(self)
         msgbox.setIcon(QMessageBox.Question)
-        msgbox.setWindowTitle(title)
-        msgbox.setText(text)
+        humanized_folders = humanized_list(folders, "folders")
+        msgbox.setWindowTitle("Remove {}?".format(humanized_folders))
+        if len(folders) == 1:
+            msgbox.setText(
+                'Are you sure you wish to remove the "{}" folder?'.format(
+                    folders[0]))
+            checkbox = QCheckBox(
+                "Allow this folder to be restored later with my Recovery Key")
+        else:
+            msgbox.setText(
+                "Are you sure you wish to remove {}?".format(humanized_folders)
+            )
+            checkbox = QCheckBox(
+                "Allow these folders to be restored later with my Recovery Key"
+            )
+        msgbox.setInformativeText(
+            "Removed folders will remain on your computer but {} will no "
+            "longer synchronize their contents with {}.".format(
+                APP_NAME, self.gateway.name))
+        checkbox.setCheckState(Qt.Checked)
         msgbox.setCheckBox(checkbox)
         msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         msgbox.setDefaultButton(QMessageBox.Yes)
-        reply = msgbox.exec_()
-        #reply = QMessageBox.question(
-        #    self, title, text, QMessageBox.Yes | QMessageBox.No,
-        #    QMessageBox.No)
-        if reply == QMessageBox.Yes:
+        if msgbox.exec_() == QMessageBox.Yes:
             tasks = []
             for folder in folders:
                 d = self.gateway.remove_magic_folder(folder)

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -371,13 +371,15 @@ class WelcomeDialog(QStackedWidget):
         if self.page_2.is_complete():
             self.finish_button_clicked()
             return
-        reply = QMessageBox.question(
-            self, "Cancel setup?",
-            "Are you sure you wish to cancel the {} setup process? "
-            "If you do, you may need to obtain a new invite code.".format(
-                APP_NAME),
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+        msgbox = QMessageBox(self)
+        msgbox.setIcon(QMessageBox.Question)
+        msgbox.setWindowTitle("Cancel setup?")
+        msgbox.setText("Are you sure you wish to cancel the setup process?")
+        msgbox.setInformativeText(
+            "If you cancel, you may need to obtain a new invite code.")
+        msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msgbox.setDefaultButton(QMessageBox.No)
+        if msgbox.exec_() == QMessageBox.Yes:
             self.reset()
 
     def on_accepted(self):
@@ -413,14 +415,15 @@ class WelcomeDialog(QStackedWidget):
         msg.setText(
             "Before uploading any folders to {}, it is recommended that you "
             "export a Recovery Key and store it in a safe location (such as "
-            "an encrypted USB drive or password manager).<p><p>"
+            "an encrypted USB drive or password manager).".format(gateway.name)
+        )
+        msg.setInformativeText(
             "{} does not have access to your folders, and cannot restore "
             "access to them. But with a Recovery Key, you can restore access "
             "to uploaded folders in case something goes wrong (e.g., hardware "
             "failure, accidental data-loss).<p><p><a href={}>More information."
             "..</a>".format(
-                gateway.name, gateway.name,
-                global_settings['help']['recovery_url']
+                gateway.name, global_settings['help']['recovery_url']
             )
         )
         #msg.setText(
@@ -463,9 +466,13 @@ class WelcomeDialog(QStackedWidget):
             event.accept()
         else:
             event.ignore()
-            reply = QMessageBox.question(
-                self, "Exit setup?", "{} has not yet been configured. "
-                "Are you sure you wish to exit?".format(APP_NAME),
-                QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-            if reply == QMessageBox.Yes:
+            msgbox = QMessageBox(self)
+            msgbox.setIcon(QMessageBox.Question)
+            msgbox.setWindowTitle("Exit setup?")
+            msgbox.setText("Are you sure you wish to exit?")
+            msgbox.setInformativeText(
+                "{} has not yet been configured.".format(APP_NAME))
+            msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            msgbox.setDefaultButton(QMessageBox.No)
+            if msgbox.exec_() == QMessageBox.Yes:
                 QCoreApplication.instance().quit()

--- a/gridsync/tor.py
+++ b/gridsync/tor.py
@@ -46,16 +46,18 @@ def get_tor(reactor):  # TODO: Add launch option?
 def get_tor_with_prompt(reactor, parent=None):
     tor = yield get_tor(reactor)
     while not tor:
-        reply = QMessageBox.critical(
-            parent,
-            "Tor Required",
+        msgbox = QMessageBox(parent)
+        msgbox.setIcon(QMessageBox.Critical)
+        msgbox.setWindowTitle("Tor Required")
+        msgbox.setText(
             "This connection can only be made over the Tor network, however, "
-            "no running Tor daemon was found.<p>Please ensure that Tor is "
-            "running and try again.<p>For help installing Tor, visit "
-            "<a href=https://torproject.org>https://torproject.org</a>",
-            QMessageBox.Abort | QMessageBox.Retry
-        )
-        if reply == QMessageBox.Retry:
+            "no running Tor daemon was found.")
+        msgbox.setInformativeText(
+            "Please ensure that Tor is running and try again.<p>For help "
+            "installing Tor, visit "
+            "<a href=https://torproject.org>https://torproject.org</a>")
+        msgbox.setStandardButtons(QMessageBox.Abort | QMessageBox.Retry)
+        if msgbox.exec_() == QMessageBox.Retry:
             tor = yield get_tor(reactor)
         else:
             break

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -41,7 +41,7 @@ def test_get_tor_with_prompt_retry(monkeypatch):
     monkeypatch.setattr(
         'gridsync.tor.get_tor', MagicMock(side_effect=[None, 'FakeTxtorcon']))
     monkeypatch.setattr(
-        'PyQt5.QtWidgets.QMessageBox.critical',
+        'PyQt5.QtWidgets.QMessageBox.exec_',
         MagicMock(return_value=QMessageBox.Retry))
     tor = yield get_tor_with_prompt(None)
     assert tor == 'FakeTxtorcon'
@@ -52,7 +52,7 @@ def test_get_tor_with_prompt_abort(monkeypatch):
     monkeypatch.setattr(
         'gridsync.tor.get_tor', MagicMock(return_value=None))
     monkeypatch.setattr(
-        'PyQt5.QtWidgets.QMessageBox.critical',
+        'PyQt5.QtWidgets.QMessageBox.exec_',
         MagicMock(return_value=QMessageBox.Abort))
     tor = yield get_tor_with_prompt(None)
     assert tor is None


### PR DESCRIPTION
This PR adjusts the MainWindow folders-view contents margins to an explicit/standard 11 px and updates numerous QMessageBox instances to set/use the `informativeText` property (resulting in appearances which should more closely match [Apple's Human Interface Guidelines for macOS Alerts](https://developer.apple.com/design/human-interface-guidelines/macos/windows-and-views/alerts/)).