### PR TITLE
Fix MainWindow 'populate' method

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -274,7 +274,7 @@ class MainWindow(QMainWindow):
             self.show_welcome_dialog()
         if not self.combo_box.currentData():
             return
-        elif self.history_button.isChecked():
+        if self.history_button.isChecked():
             self.show_history_view()
         else:
             self.show_folders_view()


### PR DESCRIPTION
This change updates the MainWindow.populate method to behave in a more
"additive" manner: calling it will no longer clear/re-create the
associated QComboBox items and folders/history views widgets, thereby
fixing the bug which required users to re-start the application in the
event of joining a new grid via the Welcome dialog due to disconnected
Qt Signals/Slots. In addition, adding a new grid will now select it
immediately in the combobox, making it more obvious that the new grid
has been joined and facilitating adding new folders afterward.