### PR TITLE
Remove redundant "finish"/"done" button clicks

### DIFF
--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -444,6 +444,7 @@ class InviteReceiverDialog(QDialog):
             self.message_label.setText(
                 'Successfully joined {0}!\n{0} are now available for '
                 'download'.format(target))
+        self.close()  # TODO: Cleanup
 
     def on_grid_already_joined(self, grid_name):
         QMessageBox.information(

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -313,6 +313,7 @@ class WelcomeDialog(QStackedWidget):
         self.page_2.checkmark.setPixmap(
             QPixmap(resource('green_checkmark.png')).scaled(32, 32))
         self.finish_button.show()
+        self.finish_button_clicked()  # TODO: Cleanup
 
     def on_already_joined(self, grid_name):
         QMessageBox.information(


### PR DESCRIPTION
As suggested by #98, there is little need to have the user click
"finish" or "done" buttons after setup operations have completed.
Instead, click/close such buttons/dialogs automatically when done.

Closes #98