### PR TITLE
Disable sync progress indicators

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -239,7 +239,10 @@ class Model(QStandardItemModel):
         if not items:
             return
         item = self.item(items[0].row(), 1)
-        item.setText("Syncing ({}%)".format(int(transferred / total * 100)))
+        item.setText("Syncing ({}%)".format(
+            # XXX The magic-folder status queue will sometimes display transfer
+            # progresses as exceeding 100%. Cap it at 100% in the UI for now.
+            min(100, int(transferred / total * 100))))
 
     def fade_row(self, folder_name, overlay_file=None):
         folder_item = self.findItems(folder_name)[0]

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -57,8 +57,10 @@ class Model(QStandardItemModel):
         self.monitor.files_updated.connect(self.on_updated_files)
         self.monitor.check_finished.connect(self.update_natural_times)
         self.monitor.remote_folder_added.connect(self.add_remote_folder)
-        self.monitor.transfer_progress_updated.connect(
-            self.set_transfer_progress)
+
+        # XXX Temporarily(?) disabled due to magic-folder queue/status bugs
+        #self.monitor.transfer_progress_updated.connect(
+        #    self.set_transfer_progress)
 
     def on_space_updated(self, size):
         self.available_space = size

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -86,6 +86,10 @@ class MagicFolderChecker(QObject):
             bytes_remaining = bytes_total - bytes_transferred
             seconds_remaining = bytes_remaining / speed
             self.transfer_seconds_remaining_updated.emit(seconds_remaining)
+            logging.debug(
+                "%s: %s / %s (%s%%); %s seconds remaining",
+                self.name, bytes_transferred, bytes_total,
+                int(bytes_transferred / bytes_total * 100), seconds_remaining)
 
     def parse_status(self, status):
         state = 0


### PR DESCRIPTION
Due to persisting bugs in tahoe's magic-folder status queue (which often displays inaccurate information or otherwise fails to reflect the number or state of queued upload/download operations), this PR (temporarily?) disables sync progress indicators from being displayed in the UI. Users needing to get a (very) rough sense of sync progress can still do so by watching the "size" status column (which increases as new files finish uploading), the newly-added "History" tab (which populates as files are added, updated, or removed), or the debug log (which now periodically prints the total progress and time remaining values as calculated from the magic-folder queue).

Proper status indicators will be re-implemented if/when the corresponding magic-folder bugs are fixed upstream (and/or when I figure out a sufficiently reliable workaround..). See #132 