### PR TITLE
Fix "shared" folder emblems

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -52,7 +52,6 @@ class Model(QStandardItemModel):
         self.monitor.mtime_updated.connect(self.set_mtime)
         self.monitor.size_updated.connect(self.set_size)
         self.monitor.members_updated.connect(self.on_members_updated)
-        #self.monitor.member_added.connect(self.add_member)
         self.monitor.sync_started.connect(self.on_sync_started)
         self.monitor.sync_finished.connect(self.on_sync_finished)
         self.monitor.files_updated.connect(self.on_updated_files)
@@ -141,12 +140,6 @@ class Model(QStandardItemModel):
         self.view.setIndexWidget(action.index(), action_bar)
         self.view.hide_drop_label()
         self.set_status(basename, status_data)
-
-    @pyqtSlot(str, str)
-    def add_member(self, folder, _):
-        self.members_dict[folder] = self.members_dict.get(folder, 0) + 1
-        if self.members_dict.get(folder, 0) == 2:
-            self.set_status_shared(folder)
 
     def populate(self):
         for magic_folder in list(self.gateway.load_magic_folders().values()):

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -51,7 +51,8 @@ class Model(QStandardItemModel):
         self.monitor.status_updated.connect(self.set_status)
         self.monitor.mtime_updated.connect(self.set_mtime)
         self.monitor.size_updated.connect(self.set_size)
-        self.monitor.member_added.connect(self.add_member)
+        self.monitor.members_updated.connect(self.on_members_updated)
+        #self.monitor.member_added.connect(self.add_member)
         self.monitor.sync_started.connect(self.on_sync_started)
         self.monitor.sync_finished.connect(self.on_sync_finished)
         self.monitor.files_updated.connect(self.on_updated_files)
@@ -191,10 +192,15 @@ class Model(QStandardItemModel):
 
     def update_overlay(self, folder_name):
         members = self.members_dict.get(folder_name)
-        if members and members > 1:
+        if members and len(members) > 1:
             self.set_status_shared(folder_name)
         else:
             self.set_status_private(folder_name)
+
+    @pyqtSlot(str, list)
+    def on_members_updated(self, folder, members):
+        self.members_dict[folder] = members
+        self.update_overlay(folder)
 
     @pyqtSlot(str, int)
     def set_status(self, name, status):

--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -254,7 +254,7 @@ class InviteSenderDialog(QDialog):
                     for folder in self.folder_names:
                         # Immediately tell the Model that there are at least 2
                         # members for this folder, i.e., that it is now shared
-                        view.model().members_updated(folder, [None, None])
+                        view.model().on_members_updated(folder, [None, None])
 
     def handle_failure(self, failure):
         if failure.type == wormhole.errors.LonelyError:

--- a/gridsync/gui/share.py
+++ b/gridsync/gui/share.py
@@ -252,13 +252,9 @@ class InviteSenderDialog(QDialog):
             for view in self.gui.main_window.central_widget.views:
                 if view.gateway.name == self.gateway.name:
                     for folder in self.folder_names:
-                        # Add two members for now, in case the original folder
-                        # was empty (in which case the original "syncing"
-                        # operation would not have occured and thus "admin"'s
-                        # membership would not have been detected).
-                        # FIXME Force call a Monitor.do_remote_scan() instead?
-                        view.model().add_member(folder, None)
-                        view.model().add_member(folder, None)
+                        # Immediately tell the Model that there are at least 2
+                        # members for this folder, i.e., that it is now shared
+                        view.model().members_updated(folder, [None, None])
 
     def handle_failure(self, failure):
         if failure.type == wormhole.errors.LonelyError:

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -22,6 +22,7 @@ class MagicFolderChecker(QObject):
     mtime_updated = pyqtSignal(int)
     size_updated = pyqtSignal(object)
 
+    members_updated = pyqtSignal(list)
     member_added = pyqtSignal(str)
     member_removed = pyqtSignal(str)
 
@@ -171,10 +172,14 @@ class MagicFolderChecker(QObject):
         members, size, t, history = yield self.gateway.get_magic_folder_state(
             self.name, members)
         if members:
-            for member in members:
-                if member not in self.members:
-                    self.member_added.emit(member[0])
-                    self.members.append(member)
+            members = sorted(members)
+            if members != self.members:
+                self.members = members
+                self.members_updated.emit(members)
+            #for member in members:
+            #    if member not in self.members:
+            #        self.member_added.emit(member[0])
+            #        self.members.append(member)
             self.size_updated.emit(size)
             self.mtime_updated.emit(t)
             self.compare_states(history, self.history)
@@ -257,6 +262,7 @@ class Monitor(QObject):
     mtime_updated = pyqtSignal(str, int)
     size_updated = pyqtSignal(str, object)
 
+    members_updated = pyqtSignal(str, list)
     member_added = pyqtSignal(str, str)
     member_removed = pyqtSignal(str, str)
 
@@ -298,6 +304,8 @@ class Monitor(QObject):
         mfc.mtime_updated.connect(lambda x: self.mtime_updated.emit(name, x))
         mfc.size_updated.connect(lambda x: self.size_updated.emit(name, x))
 
+        mfc.members_updated.connect(
+            lambda x: self.members_updated.emit(name, x))
         mfc.member_added.connect(lambda x: self.member_added.emit(name, x))
         mfc.member_removed.connect(lambda x: self.member_removed.emit(name, x))
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -23,8 +23,6 @@ class MagicFolderChecker(QObject):
     size_updated = pyqtSignal(object)
 
     members_updated = pyqtSignal(list)
-    member_added = pyqtSignal(str)
-    member_removed = pyqtSignal(str)
 
     file_updated = pyqtSignal(object)
     files_updated = pyqtSignal(list, str, str)
@@ -176,10 +174,6 @@ class MagicFolderChecker(QObject):
             if members != self.members:
                 self.members = members
                 self.members_updated.emit(members)
-            #for member in members:
-            #    if member not in self.members:
-            #        self.member_added.emit(member[0])
-            #        self.members.append(member)
             self.size_updated.emit(size)
             self.mtime_updated.emit(t)
             self.compare_states(history, self.history)
@@ -263,8 +257,6 @@ class Monitor(QObject):
     size_updated = pyqtSignal(str, object)
 
     members_updated = pyqtSignal(str, list)
-    member_added = pyqtSignal(str, str)
-    member_removed = pyqtSignal(str, str)
 
     file_updated = pyqtSignal(str, object)
     files_updated = pyqtSignal(str, list, str, str)
@@ -306,8 +298,6 @@ class Monitor(QObject):
 
         mfc.members_updated.connect(
             lambda x: self.members_updated.emit(name, x))
-        mfc.member_added.connect(lambda x: self.member_added.emit(name, x))
-        mfc.member_removed.connect(lambda x: self.member_removed.emit(name, x))
 
         mfc.file_updated.connect(lambda x: self.file_updated.emit(name, x))
         mfc.files_updated.connect(

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -338,11 +338,11 @@ fake_gateway.get_magic_folder_state = MagicMock(
 
 
 @pytest.inlineCallbacks
-def test_do_remote_scan_emit_member_added(mfc, qtbot):
+def test_do_remote_scan_emit_members_updated(mfc, qtbot):
     mfc.gateway = fake_gateway
-    with qtbot.wait_signal(mfc.member_added) as blocker:
+    with qtbot.wait_signal(mfc.members_updated) as blocker:
         yield mfc.do_remote_scan()
-    assert blocker.args == ['Alice']
+    assert blocker.args == [[('Alice', 'URI:DIR2:aaaa:bbbb')]]
 
 
 @pytest.inlineCallbacks


### PR DESCRIPTION
This PR updates how the "shared" status of a given folder is determined. More specifically, it changes the MagicFolderChecker class/QObject to emit a `members_updated` signal (replacing `member_added`, `member_removed`) which passes a list of currently known members to the folder status `Model` class. The `Model`, in turn, updates the UI to display the "shared" emblem/overlay if the list contains more than one member and removes it (thus setting the status to "private") if it contains only one. Previously, the `Model` tracked membership numbers by way of an integer mapped to each folder name, however this was mistakenly being incremented too often (specifically, when re-scanning a remote folder after it had been removed/deactivated) and was never decremented (thus the status would be displayed as "shared" even if all other members get manually removed from the magic-folder DMD). Passing the full list of currently known members thus helps to ensure that membership information is accurately reflected in the UI and will make it easier, in the future, to perform other membership-related operations from the `Model` class (like fetching/viewing member "profiles" or removing members from a folder).