### PR TITLE
Whitelabel fixes

### DIFF
--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -14,6 +14,7 @@ from wormhole.errors import (
     ServerConnectionError, WelcomeError, WrongPasswordError)
 
 from gridsync import resource, APP_NAME
+from gridsync import settings as global_settings
 from gridsync.invite import InviteReceiver
 from gridsync.errors import UpgradeRequiredError
 from gridsync.gui.invite import InviteCodeWidget, show_failure
@@ -30,11 +31,12 @@ class WelcomeWidget(QWidget):
         self.parent = parent
 
         self.icon = QLabel()
-        self.icon.setPixmap(
-            QPixmap(resource('gridsync.png')).scaled(220, 220))
+        self.icon.setPixmap(QPixmap(resource(
+            global_settings['application']['tray_icon'])).scaled(220, 220))
         self.icon.setAlignment(Qt.AlignCenter)
 
-        self.slogan = QLabel("<i>Secure, distributed storage</i>")
+        self.slogan = QLabel("<i>{}</i>".format(
+            global_settings['application']['description']))
         font = QFont()
         if sys.platform == 'darwin':
             font.setPointSize(16)

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -32,7 +32,8 @@ class WelcomeWidget(QWidget):
 
         self.icon = QLabel()
         self.icon.setPixmap(QPixmap(resource(
-            global_settings['application']['tray_icon'])).scaled(220, 220))
+            global_settings['application']['tray_icon'])).scaled(
+                220, 220, Qt.KeepAspectRatio, Qt.SmoothTransformation))
         self.icon.setAlignment(Qt.AlignCenter)
 
         self.slogan = QLabel("<i>{}</i>".format(

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -1,5 +1,6 @@
 [application]
 name = Gridsync
+description = Secure, distributed storage
 tray_icon = gridsync.png
 tray_icon_sync = gridsync.gif
 


### PR DESCRIPTION
Just a couple of minor tweaks to better facilitate whitelabel builds: set the icon and slogan/description from `config.txt` and smoothen the resultant image when scaling to help prevent visual jaggedness.