### PR TITLE
138.filesystem lock

### DIFF
--- a/gridsync/cli.py
+++ b/gridsync/cli.py
@@ -5,8 +5,6 @@ import argparse
 import logging
 import sys
 
-from twisted.internet.error import CannotListenError
-
 from gridsync import APP_NAME
 from gridsync import __doc__ as description
 from gridsync._version import __version__

--- a/gridsync/cli.py
+++ b/gridsync/cli.py
@@ -9,7 +9,7 @@ from gridsync import APP_NAME
 from gridsync import __doc__ as description
 from gridsync._version import __version__
 from gridsync.core import Core
-from gridsync.lock import FilesystemLockError
+from gridsync.errors import FilesystemLockError
 from gridsync import msg
 
 

--- a/gridsync/cli.py
+++ b/gridsync/cli.py
@@ -56,7 +56,7 @@ def main():
     try:
         core = Core(args)
         core.start()
-    except CannotListenError:
+    except OSError:
         msg.critical(
             "{} already running".format(APP_NAME),
             "{} is already running.".format(APP_NAME))

--- a/gridsync/cli.py
+++ b/gridsync/cli.py
@@ -9,6 +9,7 @@ from gridsync import APP_NAME
 from gridsync import __doc__ as description
 from gridsync._version import __version__
 from gridsync.core import Core
+from gridsync.lock import FilesystemLockError
 from gridsync import msg
 
 
@@ -54,7 +55,7 @@ def main():
     try:
         core = Core(args)
         core.start()
-    except OSError:
+    except FilesystemLockError:
         msg.critical(
             "{} already running".format(APP_NAME),
             "{} is already running.".format(APP_NAME))

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -15,7 +15,6 @@ qt5reactor.install()
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
-from twisted.internet.protocol import Protocol, Factory
 
 from gridsync import config_dir, resource, settings, APP_NAME
 from gridsync import msg
@@ -27,10 +26,6 @@ from gridsync.tor import get_tor
 
 
 app.setWindowIcon(QIcon(resource(settings['application']['tray_icon'])))
-
-
-class CoreFactory(Factory):  # pylint: disable=no-init
-    protocol = Protocol
 
 
 class Core():

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -79,15 +79,15 @@ class Core():
             yield self.select_executable()
 
     def start(self):
-        # Acquire a filesystem lock to prevent multiple instances from running
-        lock = FilesystemLock(
-            os.path.join(config_dir, "{}.lock".format(APP_NAME)))
-        lock.acquire()
-
         try:
             os.makedirs(config_dir)
         except OSError:
             pass
+
+        # Acquire a filesystem lock to prevent multiple instances from running
+        lock = FilesystemLock(
+            os.path.join(config_dir, "{}.lock".format(APP_NAME)))
+        lock.acquire()
 
         logging.info("Core starting with args: %s", self.args)
         logging.debug("$PATH is: %s", os.getenv('PATH'))

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -100,3 +100,4 @@ class Core():
         reactor.run()
         for nodedir in get_nodedirs(config_dir):
             Tahoe(nodedir, executable=self.executable).kill()
+        lock.release()

--- a/gridsync/errors.py
+++ b/gridsync/errors.py
@@ -5,6 +5,10 @@ class GridsyncError(Exception):
     pass
 
 
+class FilesystemLockError(GridsyncError):
+    pass
+
+
 class UpgradeRequiredError(GridsyncError):
     pass
 

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import fcntl
 import logging
 import os
 import sys
+
+try:
+    import fcntl
+except ImportError:  # win32
+    pass
 
 
 class Lock():

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -16,10 +16,10 @@ class Lock():
         self.fd = None
 
     def _acquire_win32(self):
-        #try:
-        #    os.remove(self.lockfile)
-        #except OSError:
-        #    pass
+        try:
+            os.remove(self.lockfile)
+        except OSError:
+            pass
         fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
         self.fd = fd
 

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -52,7 +52,7 @@ class Lock():
         else:
             self._release()
         logging.debug("Lock released.")
-        #try:
-        #    os.remove(self.lockfile)
-        #except OSError:
-        #    pass
+        try:
+            os.remove(self.lockfile)
+        except OSError:
+            pass

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -56,6 +56,3 @@ class Lock():
             os.remove(self.lockfile)
         except OSError:
             pass
-
-    def __del__(self):
-        self.release()

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -16,10 +16,10 @@ class Lock():
         self.fd = None
 
     def _acquire_win32(self):
-        try:
-            os.remove(self.lockfile)
-        except OSError:
-            pass
+        #try:
+        #    os.remove(self.lockfile)
+        #except OSError:
+        #    pass
         fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
         self.fd = fd
 
@@ -52,7 +52,7 @@ class Lock():
         else:
             self._release()
         logging.debug("Lock released.")
-        try:
-            os.remove(self.lockfile)
-        except OSError:
-            pass
+        #try:
+        #    os.remove(self.lockfile)
+        #except OSError:
+        #    pass

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -29,7 +29,7 @@ class FilesystemLock():
             try:
                 fd = os.open(self.filepath, os.O_CREAT | os.O_EXCL | os.O_RDWR)
             except OSError as error:
-                if error.errno == 13:  # Permission denied
+                if error.errno == 17:  # File exists
                     raise FilesystemLockError(
                         "Could not acquire lock on {}: {}".format(
                             self.filepath, str(error)))

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import fcntl
+import logging
+import os
+import sys
+
+
+class Lock():
+    def __init__(self, lockfile):
+        self.lockfile = lockfile
+        self.fd = None
+
+    def _acquire_win32(self):
+        try:
+            os.remove(self.lockfile)
+        except OSError:
+            pass
+        fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        self.fd = fd
+
+    def _acquire(self):
+        fd = open(self.lockfile, 'w')
+        fd.flush()
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.fd = fd
+
+    def acquire(self):
+        logging.debug("Acquiring lock: %s ...", self.lockfile)
+        if sys.platform == 'win32':
+            self._acquire_win32()
+        else:
+            self._acquire()
+        logging.debug("Acquired lock: %s", self.fd)
+
+    def _release_win32(self):
+        if self.fd:
+            self.fd.close()
+
+    def _release(self):
+        if self.fd:
+            fcntl.lockf(self.fd, fcntl.LOCK_UN)
+
+    def release(self):
+        logging.debug("Releasing lock: %s ...", self.lockfile)
+        if sys.platform == 'win32':
+            self._release_win32()
+        else:
+            self._release()
+        logging.debug("Lock released.")
+        try:
+            os.remove(self.lockfile)
+        except OSError:
+            pass
+
+    def __del__(self):
+        self.release()

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -43,7 +43,7 @@ class Lock():
 
     def _release(self):
         if self.fd:
-            fcntl.lockf(self.fd, fcntl.LOCK_UN)
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
 
     def release(self):
         logging.debug("Releasing lock: %s ...", self.lockfile)

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -9,9 +9,7 @@ try:
 except ImportError:  # win32
     pass
 
-
-class FilesystemLockError(OSError):
-    pass
+from gridsync.errors import FilesystemLockError
 
 
 class FilesystemLock():

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -11,35 +11,35 @@ except ImportError:  # win32
 
 
 class Lock():
-    def __init__(self, lockfile):
-        self.lockfile = lockfile
+    def __init__(self, filepath):
+        self.filepath = filepath
         self.fd = None
 
     def acquire(self):
-        logging.debug("Acquiring lock: %s ...", self.lockfile)
+        logging.debug("Acquiring lock: %s ...", self.filepath)
         if sys.platform == 'win32':
             try:
-                os.remove(self.lockfile)
+                os.remove(self.filepath)
             except OSError:
                 pass
-            fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            fd = os.open(self.filepath, os.O_CREAT | os.O_EXCL | os.O_RDWR)
         else:
-            fd = open(self.lockfile, 'w')
+            fd = open(self.filepath, 'w')
             fd.flush()
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         self.fd = fd
         logging.debug("Acquired lock: %s", self.fd)
 
     def release(self):
-        logging.debug("Releasing lock: %s ...", self.lockfile)
+        logging.debug("Releasing lock: %s ...", self.filepath)
         if not self.fd:
             logging.warning("No file descriptor found")
         elif sys.platform == 'win32':
             os.close(self.fd)
         else:
             fcntl.flock(self.fd, fcntl.LOCK_UN)
-        logging.debug("Lock released: %s", self.lockfile)
+        logging.debug("Lock released: %s", self.filepath)
         try:
-            os.remove(self.lockfile)
+            os.remove(self.filepath)
         except OSError:
             pass

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -39,7 +39,7 @@ class Lock():
 
     def _release_win32(self):
         if self.fd:
-            self.fd.close()
+            os.close(self.fd)
 
     def _release(self):
         if self.fd:

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -10,7 +10,7 @@ except ImportError:  # win32
     pass
 
 
-class Lock():
+class FilesystemLock():
     def __init__(self, filepath):
         self.filepath = filepath
         self.fd = None

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -15,43 +15,30 @@ class Lock():
         self.lockfile = lockfile
         self.fd = None
 
-    def _acquire_win32(self):
-        try:
-            os.remove(self.lockfile)
-        except OSError:
-            pass
-        fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
-        self.fd = fd
-
-    def _acquire(self):
-        fd = open(self.lockfile, 'w')
-        fd.flush()
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        self.fd = fd
-
     def acquire(self):
         logging.debug("Acquiring lock: %s ...", self.lockfile)
         if sys.platform == 'win32':
-            self._acquire_win32()
+            try:
+                os.remove(self.lockfile)
+            except OSError:
+                pass
+            fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
         else:
-            self._acquire()
+            fd = open(self.lockfile, 'w')
+            fd.flush()
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.fd = fd
         logging.debug("Acquired lock: %s", self.fd)
-
-    def _release_win32(self):
-        if self.fd:
-            os.close(self.fd)
-
-    def _release(self):
-        if self.fd:
-            fcntl.flock(self.fd, fcntl.LOCK_UN)
 
     def release(self):
         logging.debug("Releasing lock: %s ...", self.lockfile)
-        if sys.platform == 'win32':
-            self._release_win32()
+        if not self.fd:
+            logging.warning("No file descriptor found")
+        elif sys.platform == 'win32':
+            os.close(self.fd)
         else:
-            self._release()
-        logging.debug("Lock released.")
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+        logging.debug("Lock released: %s", self.lockfile)
         try:
             os.remove(self.lockfile)
         except OSError:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+
+from gridsync.lock import Lock
+
+
+def test_lock_acquire(tmpdir):
+    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock._acquire()
+    assert lock.fd
+
+
+def test_lock_acquire_lockfile_created(tmpdir):
+    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock._acquire()
+    assert os.path.isfile(lock.lockfile)
+
+
+def test_lock_acquire_raise_oserror(tmpdir):
+    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock._acquire()
+    with pytest.raises(OSError):
+        lock._acquire()
+
+
+def test_lock_release_lockfile_removed(tmpdir):
+    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock._acquire()
+    lock._release()
+    assert not os.path.isfile(lock.lockfile)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,7 +4,8 @@ import os
 
 import pytest
 
-from gridsync.lock import FilesystemLock, FilesystemLockError
+from gridsync.lock import FilesystemLock
+from gridsync.errors import FilesystemLockError
 
 
 def test_lock_acquire(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -26,8 +26,9 @@ def test_lock_acquire_raise_oserror(tmpdir):
         lock.acquire()
 
 
-def test_lock_release_lockfile_removed(tmpdir):
+def test_lock_release(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     lock.release()
-    assert not os.path.isfile(lock.lockfile)
+    lock.acquire()
+    lock.release()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -19,11 +19,19 @@ def test_lock_acquire_lockfile_created(tmpdir):
     assert os.path.isfile(lock.lockfile)
 
 
-def test_lock_acquire_raise_oserror(tmpdir):
+def test_lock_acquire_raise_oserror_on_second_call(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     with pytest.raises(OSError):
         lock.acquire()
+
+
+def test_lock_acquire_raise_oserror_from_second_instance(tmpdir):
+    lock_1 = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock_1.acquire()
+    lock_2 = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    with pytest.raises(OSError):
+        lock_2.acquire()
 
 
 def test_lock_release(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from gridsync.lock import FilesystemLock
+from gridsync.lock import FilesystemLock, FilesystemLockError
 
 
 def test_lock_acquire(tmpdir):
@@ -19,18 +19,18 @@ def test_lock_acquire_filepath_created(tmpdir):
     assert os.path.isfile(lock.filepath)
 
 
-def test_lock_acquire_raise_oserror_on_second_call(tmpdir):
+def test_lock_acquire_raise_filesystemlockerror_on_second_call(tmpdir):
     lock = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
-    with pytest.raises(OSError):
+    with pytest.raises(FilesystemLockError):
         lock.acquire()
 
 
-def test_lock_acquire_raise_oserror_from_second_instance(tmpdir):
+def test_lock_acquire_raise_filesystemlockerror_from_second_instance(tmpdir):
     lock_1 = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock_1.acquire()
     lock_2 = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
-    with pytest.raises(OSError):
+    with pytest.raises(FilesystemLockError):
         lock_2.acquire()
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,38 +4,38 @@ import os
 
 import pytest
 
-from gridsync.lock import Lock
+from gridsync.lock import FilesystemLock
 
 
 def test_lock_acquire(tmpdir):
-    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     assert lock.fd
 
 
 def test_lock_acquire_filepath_created(tmpdir):
-    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     assert os.path.isfile(lock.filepath)
 
 
 def test_lock_acquire_raise_oserror_on_second_call(tmpdir):
-    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     with pytest.raises(OSError):
         lock.acquire()
 
 
 def test_lock_acquire_raise_oserror_from_second_instance(tmpdir):
-    lock_1 = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock_1 = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock_1.acquire()
-    lock_2 = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock_2 = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     with pytest.raises(OSError):
         lock_2.acquire()
 
 
 def test_lock_release(tmpdir):
-    lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
+    lock = FilesystemLock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
     lock.release()
     lock.acquire()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -13,10 +13,10 @@ def test_lock_acquire(tmpdir):
     assert lock.fd
 
 
-def test_lock_acquire_lockfile_created(tmpdir):
+def test_lock_acquire_filepath_created(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
     lock.acquire()
-    assert os.path.isfile(lock.lockfile)
+    assert os.path.isfile(lock.filepath)
 
 
 def test_lock_acquire_raise_oserror_on_second_call(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -9,25 +9,25 @@ from gridsync.lock import Lock
 
 def test_lock_acquire(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
-    lock._acquire()
+    lock.acquire()
     assert lock.fd
 
 
 def test_lock_acquire_lockfile_created(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
-    lock._acquire()
+    lock.acquire()
     assert os.path.isfile(lock.lockfile)
 
 
 def test_lock_acquire_raise_oserror(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
-    lock._acquire()
+    lock.acquire()
     with pytest.raises(OSError):
-        lock._acquire()
+        lock.acquire()
 
 
 def test_lock_release_lockfile_removed(tmpdir):
     lock = Lock(os.path.join(str(tmpdir), 'test.lock'))
-    lock._acquire()
-    lock._release()
+    lock.acquire()
+    lock.release()
     assert not os.path.isfile(lock.lockfile)


### PR DESCRIPTION
A fix/workaround for the issue described in #138: rather than listening on port 52045 to provide a quick-and-dirty interprocess mutex that works across platforms, this PR instead leverages the python standard library's [`fcntl.flock()`](https://docs.python.org/3/library/fcntl.html#fcntl.flock) to provide a filesystem-based exclusive locking mechanism on UNIX-like systems (falling back to keeping an open file descriptor on Windows to provide similar -- but not wholly equivalent -- functionality), thereby preventing the situation in which Gridsync would sometimes erroneously throw a user-facing "Gridsync is already running" error message on certain macOS Mojave configurations (caused, it seems, from security/sandbox policies that might prevent listening/binding on ports).