### PR TITLE
Add support for specifying a "logo" via config.txt

### DIFF
--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -30,14 +30,22 @@ class WelcomeWidget(QWidget):
         super(WelcomeWidget, self).__init__()
         self.parent = parent
 
+        application_settings = global_settings['application']
+        logo_icon = application_settings.get('logo_icon')
+        if logo_icon:
+            icon_file = logo_icon
+            icon_size = 288
+        else:
+            icon_file = application_settings.get('tray_icon')
+            icon_size = 220
+
         self.icon = QLabel()
-        self.icon.setPixmap(QPixmap(resource(
-            global_settings['application']['tray_icon'])).scaled(
-                220, 220, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+        self.icon.setPixmap(QPixmap(resource(icon_file)).scaled(
+            icon_size, icon_size, Qt.KeepAspectRatio, Qt.SmoothTransformation))
         self.icon.setAlignment(Qt.AlignCenter)
 
         self.slogan = QLabel("<i>{}</i>".format(
-            global_settings['application']['description']))
+            application_settings.get('description', '')))
         font = QFont()
         if sys.platform == 'darwin':
             font.setPointSize(16)
@@ -46,6 +54,8 @@ class WelcomeWidget(QWidget):
         self.slogan.setFont(font)
         self.slogan.setStyleSheet("color: grey")
         self.slogan.setAlignment(Qt.AlignCenter)
+        if logo_icon:
+            self.slogan.hide()
 
         self.invite_code_widget = InviteCodeWidget(self)
         self.lineedit = self.invite_code_widget.lineedit


### PR DESCRIPTION
This adds support for specifying a 'logo_icon' application setting via
'config.txt'. If 'logo_icon' is set to a resource file, that file will
be loaded/displayed on the initial "Welcome" screen in place of the
'tray_icon'. In addition, if a 'logo_icon' is set, hide the application
description/slogan (since "logos", by definition, contain a "mark" and a
"type" -- i.e., an image and text combination -- and so we probably
don't want/need the description/slogan text)