### PR TITLE
149.tahoe restart fix

### DIFF
--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -360,6 +360,7 @@ class Tahoe():
 
     @inlineCallbacks
     def stop(self):
+        log.debug('Stopping "%s" tahoe client...', self.name)
         if not os.path.isfile(self.pidfile):
             log.error('No "twistd.pid" file found in %s', self.nodedir)
             return
@@ -374,6 +375,7 @@ class Tahoe():
             os.remove(self.pidfile)
         except EnvironmentError:
             pass
+        log.debug('Finished stopping "%s" tahoe client', self.name)
 
     @inlineCallbacks
     def upgrade_legacy_config(self):
@@ -430,6 +432,7 @@ class Tahoe():
 
     @inlineCallbacks
     def start(self):
+        log.debug('Starting "%s" tahoe client...', self.name)
         if not self._monitor_started:
             self.monitor.start()
             self._monitor_started = True
@@ -452,6 +455,8 @@ class Tahoe():
             self.api_token = f.read().strip()
         self.shares_happy = int(self.config_get('client', 'shares.happy'))
         self.load_magic_folders()
+        log.debug(
+            'Finished starting "%s" tahoe client (pid: %s)', self.name, pid)
 
     @inlineCallbacks
     def restart(self):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -472,6 +472,12 @@ class Tahoe():
     @inlineCallbacks
     def restart(self):
         log.debug("Restarting %s client...", self.name)
+        if self.state in (Tahoe.STOPPING, Tahoe.STARTING):
+            log.warning(
+                'Aborting restart operation; '
+                'the "%s" client is already (re)starting',
+                self.name)
+            return
         # Temporarily disable desktop notifications for (dis)connect events
         pref = get_preference('notifications', 'connection')
         set_preference('notifications', 'connection', 'false')

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -356,6 +356,29 @@ def test_tahoe_stop_linux_monkeypatch(tahoe, monkeypatch):
     assert output == ['stop']
 
 
+@pytest.mark.parametrize(
+    'tahoe_state,call_count',
+    [
+        (Tahoe.STOPPED, 1),  # restart completed
+        (Tahoe.STARTING, 0),  # restart aborted
+        (Tahoe.STARTED, 1),  # restart completed
+        (Tahoe.STOPPING, 0),  # restart aborted
+    ]
+)
+@inlineCallbacks
+def test_tahoe_restart(tahoe_state, call_count, tahoe, monkeypatch):
+    mocked_start = MagicMock()
+    monkeypatch.setattr('gridsync.tahoe.Tahoe.stop', MagicMock())
+    monkeypatch.setattr('gridsync.tahoe.Tahoe.start', mocked_start)
+    monkeypatch.setattr('gridsync.tahoe.Tahoe.await_ready', MagicMock())
+    monkeypatch.setattr('gridsync.tahoe.deferLater', MagicMock())
+    monkeypatch.setattr('gridsync.preferences.set_preference', MagicMock())
+    monkeypatch.setattr('gridsync.preferences.get_preference', MagicMock())
+    tahoe.state = tahoe_state
+    yield tahoe.restart()
+    assert mocked_start.call_count == call_count
+
+
 @inlineCallbacks
 def test_get_grid_status(tahoe, monkeypatch):
     json_content = b'''{

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -372,8 +372,8 @@ def test_tahoe_restart(tahoe_state, call_count, tahoe, monkeypatch):
     monkeypatch.setattr('gridsync.tahoe.Tahoe.start', mocked_start)
     monkeypatch.setattr('gridsync.tahoe.Tahoe.await_ready', MagicMock())
     monkeypatch.setattr('gridsync.tahoe.deferLater', MagicMock())
-    monkeypatch.setattr('gridsync.preferences.set_preference', MagicMock())
-    monkeypatch.setattr('gridsync.preferences.get_preference', MagicMock())
+    monkeypatch.setattr('gridsync.tahoe.set_preference', MagicMock())
+    monkeypatch.setattr('gridsync.tahoe.get_preference', MagicMock())
     tahoe.state = tahoe_state
     yield tahoe.restart()
     assert mocked_start.call_count == call_count


### PR DESCRIPTION
This PR fixes #149 by keeping track of the run-state of the tahoe client and aborting subsequent `restart` operations if the client is already in a "stopping" or "starting" state (thereby preventing needless restarts when adding folders in quick succession).