### PR TITLE
Use updated .spec file for Tahoe; exclude Tcl/Tk

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -71,7 +71,7 @@ call .\build\venv-tahoe\Scripts\activate
 call python -m pip install --upgrade setuptools pip
 call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call git --git-dir=build\tahoe-lafs\.git --work-tree=build\tahoe-lafs checkout tahoe-lafs-1.13.0
-::call copy .\misc\tahoe.spec .\build\tahoe-lafs
+call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
 call python setup.py update_version
 call python -m pip install .


### PR DESCRIPTION
This PR excludes the Tcl/Tk libraries from the included Tahoe-LAFS binary bundle (which are needlessly included by PyInstaller) on Windows, reducing the total filesize of the application on-disk by about 10 MB. Note that Tcl/Tk is already excluded for macOS and Linux binary distributions; this PR merely updates the Windows build script to use the same/correct PyInstaller ".spec" file (which, apparently, I forgot to do earlier).