### PR TITLE
147.refocus welcome

### DIFF
--- a/gridsync/gui/__init__.py
+++ b/gridsync/gui/__init__.py
@@ -38,7 +38,10 @@ class Gui():
 
     def show(self):
         self.systray.show()
-        self.show_main_window()
+        if self.main_window.gateways:
+            self.show_main_window()
+        else:
+            self.show_welcome_dialog()
 
     def hide(self):
         self.systray.hide()

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -61,8 +61,6 @@ class Menu(QMenu):
             export_action.triggered.connect(
                 self.gui.main_window.export_recovery_key)
             self.addAction(export_action)
-        else:
-            open_action.setEnabled(False)
 
         documentation_action = QAction(
             QIcon(''), "Browse Documentation...", self)

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -46,7 +46,7 @@ class Menu(QMenu):
         logging.debug("(Re-)populating systray menu...")
 
         open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
-        open_action.triggered.connect(self.gui.show_main_window)
+        open_action.triggered.connect(self.gui.show)
         self.addAction(open_action)
 
         gateways = self.gui.main_window.gateways

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -475,7 +475,7 @@ class WelcomeDialog(QStackedWidget):
             pass
 
     def finish_button_clicked(self):
-        self.gui.show()
+        self.gui.show_main_window()
         self.close()
         if self.prompt_to_export:
             self.prompt_for_export(self.gateway)


### PR DESCRIPTION
This PR updates the "Open Gridsync" systray menu action to always be enabled but to conditionally raise and show the "welcome" dialog in the event that a grid has not yet been joined, thereby allowing users to more easily access the application window from the systray before the initial setup process has completed.

Fixes #147 