### PR TITLE
Hide/remove systray icon before exiting on Windows

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -364,6 +364,8 @@ class MainWindow(QMainWindow):
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         msg.setDefaultButton(QMessageBox.No)
         if msg.exec_() == QMessageBox.Yes:
+            if sys.platform == 'win32':
+                self.gui.systray.hide()
             reactor.stop()
 
     def keyPressEvent(self, event):

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -500,4 +500,6 @@ class WelcomeDialog(QStackedWidget):
             msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
             msgbox.setDefaultButton(QMessageBox.No)
             if msgbox.exec_() == QMessageBox.Yes:
+                if sys.platform == 'win32':
+                    self.gui.systray.hide()
                 QCoreApplication.instance().quit()

--- a/gridsync/lock.py
+++ b/gridsync/lock.py
@@ -31,8 +31,7 @@ class FilesystemLock():
                     raise FilesystemLockError(
                         "Could not acquire lock on {}: {}".format(
                             self.filepath, str(error)))
-                else:
-                    raise
+                raise
         else:
             fd = open(self.filepath, 'w')
             fd.flush()

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -297,8 +297,7 @@ class Tahoe():
         proc.poll()
         if proc.returncode:
             raise TahoeCommandError(str(output.getvalue()).strip())
-        else:
-            return str(output.getvalue()).strip()
+        return str(output.getvalue()).strip()
 
     @inlineCallbacks
     def command(self, args, callback_trigger=None):


### PR DESCRIPTION
This prevents the icon from persisting in the system tray after the
processs has terminated. Fixes #156.