### PR TITLE
Always use bundled tahoe executable if frozen

### DIFF
--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -893,8 +893,12 @@ class Tahoe():
 
 @inlineCallbacks
 def select_executable():
-    if sys.platform == 'darwin' and getattr(sys, 'frozen', False):
-        # Because magic-folder on macOS has not yet landed upstream
+    if getattr(sys, 'frozen', False):
+        # Always select the bundled tahoe executable if using a binary build.
+        # To prevent issues caused by potentially broken or outdated tahoe
+        # installations on the user's PATH.
+        if sys.platform == 'win32':
+            return os.path.join(pkgdir, 'Tahoe-LAFS', 'tahoe.exe')
         return os.path.join(pkgdir, 'Tahoe-LAFS', 'tahoe')
     executables = which('tahoe')
     if not executables:


### PR DESCRIPTION
This PR updates the "tahoe" module's `select_executable()` logic to _always_ use the bundled Tahoe-LAFS executable in the event that the user is running a frozen/binary build, thereby preventing problems stemming from another, potentially broken or outdated Tahoe-LAFS installation on the user's PATH interfering with the operation of the application. As a bonus, the application startup time should be shortened by a second or two (as a result of no longer having to probe the other `tahoe` instances on the PATH).

Users still wishing to use their own tahoe installs with Gridsync can still do so by running the application from source or in a python virtual environment and/or by replacing the PyInstaller bundle in the `Tahoe-LAFS` directory with one their own.