### PR TITLE
Custom start message

### DIFF
--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -83,7 +83,7 @@ class Core():
         warning_settings = settings.get('warning')
         if not warning_settings:
             return
-        if get_preference('warning', 'ignore') == 'true':
+        if get_preference('warning', 'suppress') == 'true':
             return
         msgbox = QMessageBox()
         msgbox.setIcon(QMessageBox.Warning)
@@ -95,7 +95,7 @@ class Core():
             msgbox.setText(warning_settings.get('text'))
         checkbox = QCheckBox("Do not show this message again")
         checkbox.stateChanged.connect(lambda state: set_preference(
-            'warning', 'ignore', ('true' if state else 'false')))
+            'warning', 'suppress', ('true' if state else 'false')))
         msgbox.setCheckBox(checkbox)
         msgbox.exec_()
 

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -81,7 +81,7 @@ class Core():
     @staticmethod
     def show_message():
         message_settings = settings.get('message')
-        if not warning_settings:
+        if not message_settings:
             return
         if get_preference('message', 'suppress') == 'true':
             return

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -86,8 +86,9 @@ class Core():
         if get_preference('message', 'suppress') == 'true':
             return
         msgbox = QMessageBox()
-        icon_type = message_settings.get('type').lower()
+        icon_type = message_settings.get('type')
         if icon_type:
+            icon_type = icon_type.lower()
             if icon_type == 'information':
                 msgbox.setIcon(QMessageBox.Information)
             elif icon_type == 'warning':

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -86,7 +86,14 @@ class Core():
         if get_preference('message', 'suppress') == 'true':
             return
         msgbox = QMessageBox()
-        msgbox.setIcon(QMessageBox.Warning)
+        icon_type = message_settings.get('type').lower()
+        if icon_type:
+            if icon_type == 'information':
+                msgbox.setIcon(QMessageBox.Information)
+            elif icon_type == 'warning':
+                msgbox.setIcon(QMessageBox.Warning)
+            elif icon_type == 'critical':
+                msgbox.setIcon(QMessageBox.Critical)
         if sys.platform == 'darwin':
             msgbox.setText(message_settings.get('title'))
             msgbox.setInformativeText(message_settings.get('text'))

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -96,7 +96,7 @@ class Core():
         checkbox.stateChanged.connect(lambda state: set_preference(
             'warning', 'ignore', ('true' if state else 'false')))
         msgbox.setCheckBox(checkbox)
-        return msgbox.exec_()
+        msgbox.exec_()
 
     def start(self):
         try:

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -78,7 +78,8 @@ class Core():
             self.gui.show_welcome_dialog()
             yield self.select_executable()
 
-    def show_warning(self):
+    @staticmethod
+    def show_warning():
         warning_settings = settings.get('warning')
         if not warning_settings:
             return

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -79,23 +79,23 @@ class Core():
             yield self.select_executable()
 
     @staticmethod
-    def show_warning():
-        warning_settings = settings.get('warning')
+    def show_message():
+        message_settings = settings.get('message')
         if not warning_settings:
             return
-        if get_preference('warning', 'suppress') == 'true':
+        if get_preference('message', 'suppress') == 'true':
             return
         msgbox = QMessageBox()
         msgbox.setIcon(QMessageBox.Warning)
         if sys.platform == 'darwin':
-            msgbox.setText(warning_settings.get('title'))
-            msgbox.setInformativeText(warning_settings.get('text'))
+            msgbox.setText(message_settings.get('title'))
+            msgbox.setInformativeText(message_settings.get('text'))
         else:
-            msgbox.setWindowTitle(warning_settings.get('title'))
-            msgbox.setText(warning_settings.get('text'))
+            msgbox.setWindowTitle(message_settings.get('title'))
+            msgbox.setText(message_settings.get('text'))
         checkbox = QCheckBox("Do not show this message again")
         checkbox.stateChanged.connect(lambda state: set_preference(
-            'warning', 'suppress', ('true' if state else 'false')))
+            'message', 'suppress', ('true' if state else 'false')))
         msgbox.setCheckBox(checkbox)
         msgbox.exec_()
 
@@ -118,7 +118,7 @@ class Core():
         self.gui.show_systray()
 
         reactor.callLater(0, self.start_gateways)
-        reactor.callLater(0, self.show_warning)
+        reactor.callLater(0, self.show_message)
         reactor.run()
         for nodedir in get_nodedirs(config_dir):
             Tahoe(nodedir, executable=self.executable).kill()


### PR DESCRIPTION
This PR adds support for (optionally) displaying a popup message to the user when first launching the application. Specifically, with this change, Gridsync will check for a `[message]` section in `config.txt` when starting up and, if it is found, display a `QMessageBox` to the user with the `title`, `text`, and (icon) `type` specified by that section (where `type` is one of "information", "warning", or "critical") -- for example:

```
[message]
type = information
title = Cat Fact 8413 
text = Cats have been domesticated for around 4,000 years
```

Silly example aside, the purpose of this change is to allow whitelabel/rebranded distributions of Gridsync to display custom messages/reminders to their users (for example, about where to obtain an invite code or about who to contact for further help/support). Because this feature can constitute an annoyance, however, users can choose to suppress subsequent messages by checking/ticking the "Do not show this message again" checkbox inside the initial message box.