### PR TITLE
Folder removal improvements

### DIFF
--- a/gridsync/config.py
+++ b/gridsync/config.py
@@ -7,37 +7,40 @@ from configparser import RawConfigParser, NoOptionError, NoSectionError
 class Config():
     def __init__(self, filename):
         self.filename = filename
-        self.config = RawConfigParser(allow_no_value=True)
 
     def set(self, section, option, value):
-        self.config.read(self.filename)
-        if not self.config.has_section(section):
-            self.config.add_section(section)
-        self.config.set(section, option, value)
+        config = RawConfigParser(allow_no_value=True)
+        config.read(self.filename)
+        if not config.has_section(section):
+            config.add_section(section)
+        config.set(section, option, value)
         with open(self.filename, 'w') as f:
-            self.config.write(f)
+            config.write(f)
 
     def get(self, section, option):
-        self.config.read(self.filename)
+        config = RawConfigParser(allow_no_value=True)
+        config.read(self.filename)
         try:
-            return self.config.get(section, option)
+            return config.get(section, option)
         except (NoOptionError, NoSectionError):
             return None
 
     def save(self, settings_dict):
-        self.config.read(self.filename)
+        config = RawConfigParser(allow_no_value=True)
+        config.read(self.filename)
         for section, d in settings_dict.items():
-            if not self.config.has_section(section):
-                self.config.add_section(section)
+            if not config.has_section(section):
+                config.add_section(section)
             for option, value in d.items():
-                self.config.set(section, option, value)
+                config.set(section, option, value)
         with open(self.filename, 'w') as f:
-            self.config.write(f)
+            config.write(f)
 
     def load(self):
-        self.config.read(self.filename)
+        config = RawConfigParser(allow_no_value=True)
+        config.read(self.filename)
         settings_dict = defaultdict(dict)
-        for section in self.config.sections():
-            for option, value in self.config.items(section):
+        for section in config.sections():
+            for option, value in config.items(section):
                 settings_dict[section][option] = value
         return dict(settings_dict)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -178,20 +178,22 @@ class View(QTreeView):
         self.invite_sender_dialogs.append(isd)  # TODO: Remove on close
         isd.show()
 
+    @inlineCallbacks
     def maybe_rescan_rootcap(self, _):
         if self._rescan_required:
             self._rescan_required = False
             logging.debug("A rescan was scheduled; rescanning...")
-            d = self.gateway.monitor.scan_rootcap()
-            d.addCallback(self.show_drop_label)
+            yield self.gateway.monitor.scan_rootcap()
+            self.show_drop_label()
         else:
             logging.debug("No rescans were scheduled; not rescanning")
 
+    @inlineCallbacks
     def maybe_restart_gateway(self, _):
         if self._restart_required:
             self._restart_required = False
             logging.debug("A restart was scheduled; restarting...")
-            self.gateway.restart()
+            yield self.gateway.restart()
         else:
             logging.debug("No restarts were scheduled; not restarting")
 
@@ -330,8 +332,6 @@ class View(QTreeView):
                 for folder in folders:
                     tasks.append(self.remove_folder(folder, unlink=False))
             d = DeferredList(tasks)
-            d.addCallback(lambda _: self.model().monitor.scan_rootcap())
-            d.addCallback(self.show_drop_label)
             d.addCallback(self.maybe_restart_gateway)
 
     def open_folders(self, folders):

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -318,16 +318,19 @@ class View(QTreeView):
         msgbox.setDefaultButton(QMessageBox.Yes)
         if msgbox.exec_() == QMessageBox.Yes:
             tasks = []
-            for folder in folders:
-                #d = self.gateway.remove_magic_folder(folder)
-                d = self.remove_folder(folder)
+            if checkbox.checkState() == Qt.Unchecked:
+                for folder in folders:
+                    tasks.append(self.remove_folder(folder, unlink=True))
+            else:
+                for folder in folders:
+                    tasks.append(self.remove_folder(folder, unlink=False))
                 #d.addErrback(self.show_failure)
-                tasks.append(d)
-                if checkbox.checkState() == Qt.Unchecked:
-                    d2 = self.gateway.unlink_magic_folder_from_rootcap(folder)
-                    d2.addErrback(self.show_failure)
-                    tasks.append(d2)
-                self.model().remove_folder(folder)
+                #tasks.append(d)
+                #if checkbox.checkState() == Qt.Unchecked:
+                #    d2 = self.gateway.unlink_magic_folder_from_rootcap(folder)
+                #    d2.addErrback(self.show_failure)
+                #    tasks.append(d2)
+                #self.model().remove_folder(folder)
             d = DeferredList(tasks)
             d.addCallback(lambda _: self.model().monitor.scan_rootcap())
             d.addCallback(self.show_drop_label)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -332,6 +332,7 @@ class View(QTreeView):
                 for folder in folders:
                     tasks.append(self.remove_folder(folder, unlink=False))
             d = DeferredList(tasks)
+            d.addCallback(self.maybe_rescan_rootcap)
             d.addCallback(self.maybe_restart_gateway)
 
     def open_folders(self, folders):

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -334,6 +334,7 @@ class View(QTreeView):
             d = DeferredList(tasks)
             d.addCallback(lambda _: self.model().monitor.scan_rootcap())
             d.addCallback(self.show_drop_label)
+            d.addCallback(self.maybe_restart_gateway)
 
     def open_folders(self, folders):
         for folder in folders:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -270,7 +270,7 @@ class View(QTreeView):
             d.addCallback(self.show_drop_label)
 
     @inlineCallbacks
-    def remove_folder(self, folder_name):
+    def remove_folder(self, folder_name, unlink=False):
         try:
             yield self.gateway.remove_magic_folder(folder_name)
         except Exception as e:  # pylint: disable=broad-except
@@ -287,6 +287,8 @@ class View(QTreeView):
         self._restart_required = True
         logging.debug(
             'Successfully removed folder "%s"; scheduled restart', folder_name)
+        if unlink:
+            yield self.unlink_folder(folder_name)
 
     def confirm_remove(self, folders):
         msgbox = QMessageBox(self)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -260,11 +260,7 @@ class View(QTreeView):
         if msgbox.exec_() == QMessageBox.Yes:
             tasks = []
             for folder in folders:
-                #d = self.gateway.unlink_magic_folder_from_rootcap(folder)
-                d = self.unlink_folder(folder)
-                #d.addErrback(self.show_failure)
-                tasks.append(d)
-                #self.model().remove_folder(folder)
+                tasks.append(self.unlink_folder(folder))
             d = DeferredList(tasks)
             d.addCallback(lambda _: self.model().monitor.scan_rootcap())
             d.addCallback(self.show_drop_label)
@@ -324,13 +320,6 @@ class View(QTreeView):
             else:
                 for folder in folders:
                     tasks.append(self.remove_folder(folder, unlink=False))
-                #d.addErrback(self.show_failure)
-                #tasks.append(d)
-                #if checkbox.checkState() == Qt.Unchecked:
-                #    d2 = self.gateway.unlink_magic_folder_from_rootcap(folder)
-                #    d2.addErrback(self.show_failure)
-                #    tasks.append(d2)
-                #self.model().remove_folder(folder)
             d = DeferredList(tasks)
             d.addCallback(lambda _: self.model().monitor.scan_rootcap())
             d.addCallback(self.show_drop_label)


### PR DESCRIPTION
Similar to the fixes relating to folder-creation and linking from #160, this PR provides a few minor improvements relating to folder-removal and unlinking, specifically:

* Show (slightly) more "humanized" error messages for failures/exceptions that occur while removing or unlinking a folder
* Schedule a `tahoe restart` after successfully leaving one or more magic-folders (in order to compensate for Tahoe-LAFS' ["Zombie Dragon" issue](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2996))
* Schedule a rootcap rescan _after_ unlinking one or more folders (instead of possibly during)
* Fix a weird issue in which `RawConfigParser` was erroneously caching old values from `tahoe.cfg` even after `tahoe magic-folder leave` had modified it causing folders to appear to be stuck in a "Loading..." state after restarting