### PR TITLE
169.tor proxy bypass

### DIFF
--- a/gridsync/wormhole_.py
+++ b/gridsync/wormhole_.py
@@ -53,6 +53,9 @@ class Wormhole(QObject):
     @inlineCallbacks
     def close(self):
         logging.debug("Closing wormhole...")
+        if not self._wormhole:
+            logging.warning("No wormhole was created; returning")
+            return
         try:
             yield self._wormhole.close()
         except WormholeError:

--- a/gridsync/wormhole_.py
+++ b/gridsync/wormhole_.py
@@ -33,7 +33,7 @@ class Wormhole(QObject):
     def __init__(self, use_tor=False):
         super(Wormhole, self).__init__()
         self.use_tor = use_tor
-        self._wormhole = wormhole.create(APPID, RELAY, reactor)
+        self._wormhole = None
 
     @inlineCallbacks
     def connect(self):
@@ -43,6 +43,8 @@ class Wormhole(QObject):
             if not tor:
                 raise TorError("Could not connect to a running Tor daemon")
             self._wormhole = wormhole.create(APPID, RELAY, reactor, tor=tor)
+        else:
+            self._wormhole = wormhole.create(APPID, RELAY, reactor)
         logging.debug("Connecting to %s (tor=%s)...", RELAY, tor)
         welcome = yield self._wormhole.get_welcome()
         logging.debug("Connected to wormhole server; got welcome: %s", welcome)

--- a/tests/test_wormhole.py
+++ b/tests/test_wormhole.py
@@ -85,9 +85,15 @@ def test_wormhole_receive_via_xfer_util(qtbot, monkeypatch):
 
 
 @inlineCallbacks
-def test_wormhole_receive_via_xfer_util_raise_unknown_offer(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_via_xfer_util_raise_unknown_offer(
+        qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"offer": {"NOT_message": "{\\"nickname\\": \\"Test Grid\\"}"}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with pytest.raises(Exception):
         yield wormhole.receive('123-test-test')
 

--- a/tests/test_wormhole.py
+++ b/tests/test_wormhole.py
@@ -18,8 +18,12 @@ def wormhole():
 
 
 @inlineCallbacks
-def test_wormhole_connect_emit_got_welcome_signal(qtbot, wormhole):
-    wormhole._wormhole.get_welcome.return_value = {'current_cli_version': '0'}
+def test_wormhole_connect_emit_got_welcome_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {'current_cli_version': '0'}
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.got_welcome) as blocker:
         yield wormhole.connect()
     assert blocker.args == [{'current_cli_version': '0'}]
@@ -68,9 +72,14 @@ def test_wormhole_close_emit_closed_signal_with_wormhole_error_pass(qtbot):
 
 
 @inlineCallbacks
-def test_wormhole_receive_via_xfer_util(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_via_xfer_util(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"offer": {"message": "{\\"nickname\\": \\"Test Grid\\"}"}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     output = yield wormhole.receive('123-test-test')
     assert output == {"nickname": "Test Grid"}
 
@@ -84,82 +93,137 @@ def test_wormhole_receive_via_xfer_util_raise_unknown_offer(qtbot, wormhole):
 
 
 @inlineCallbacks
-def test_wormhole_receive_emit_got_introduction_signal(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_emit_got_introduction_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"server-v1": {}}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.got_introduction):
         yield wormhole.receive('123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_receive_raise_upgrade_required_no_abilities(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = b'{"blah": "blah"}'
+def test_wormhole_receive_raise_upgrade_required_no_abilities(
+        qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
+        b'{"blah": "blah"}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with pytest.raises(UpgradeRequiredError):
         yield wormhole.receive('123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_receive_raise_upgrade_required_bad_version(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_raise_upgrade_required_bad_version(
+        qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"server-v9999": {}}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with pytest.raises(UpgradeRequiredError):
         yield wormhole.receive('123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_receive_succeed_return_msg_dict(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_succeed_return_msg_dict(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"server-v1": {}}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     output = yield wormhole.receive('123-test-test')
     assert output == {'abilities': {'server-v1': {}}}
 
 
 @inlineCallbacks
-def test_wormhole_receive_succeed_emit_got_message_signal(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_receive_succeed_emit_got_message_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"offer": {"message": "{\\"nickname\\": \\"Test Grid\\"}"}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.got_message) as blocker:
         yield wormhole.receive('123-test-test')
     assert blocker.args == [{'nickname': 'Test Grid'}]
 
 
 @inlineCallbacks
-def test_wormhole_send_emit_got_introduction_signal(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_send_emit_got_introduction_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"client-v1": {}}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.got_introduction):
         yield wormhole.send('Testing', '123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_send_raise_upgrade_required_no_abilities(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = b'{"blah": "blah"}'
+def test_wormhole_send_raise_upgrade_required_no_abilities(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
+        b'{"blah": "blah"}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with pytest.raises(UpgradeRequiredError):
         yield wormhole.send('Testing', '123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_send_raise_upgrade_required_bad_version(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_send_raise_upgrade_required_bad_version(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"server-v9999": {}}}'
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with pytest.raises(UpgradeRequiredError):
         yield wormhole.send('Testing', '123-test-test')
 
 
 @inlineCallbacks
-def test_wormhole_send_allocate_code_emit_got_code_signal(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_send_allocate_code_emit_got_code_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"client-v1": {}}}'
-    wormhole._wormhole.get_code.return_value = "9999-test-code"
+    fake_wormhole.get_code.return_value = "9999-test-code"
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.got_code) as blocker:
         yield wormhole.send('Testing')
     assert blocker.args == ['9999-test-code']
 
 
 @inlineCallbacks
-def test_wormhole_send_succeed_emit_send_completed_signal(qtbot, wormhole):
-    wormhole._wormhole.get_message.return_value = \
+def test_wormhole_send_succeed_emit_send_completed_signal(qtbot, monkeypatch):
+    fake_wormhole = MagicMock()
+    fake_wormhole.get_welcome.return_value = {}
+    fake_wormhole.get_message.return_value = \
         b'{"abilities": {"client-v1": {}}}'
+    fake_wormhole.get_code.return_value = "9999-test-code"
+    monkeypatch.setattr(
+        'gridsync.wormhole_.wormhole.create', lambda x, y, z: fake_wormhole)
+    wormhole = Wormhole()
     with qtbot.wait_signal(wormhole.send_completed):
         yield wormhole.send('Testing')
 

--- a/tests/test_wormhole.py
+++ b/tests/test_wormhole.py
@@ -77,6 +77,13 @@ def test_wormhole_close_emit_closed_signal_with_wormhole_error_pass(qtbot):
 
 
 @inlineCallbacks
+def test_wormhole_close_return_early_no_wormhole_no_emit_closed(qtbot):
+    wormhole = Wormhole()
+    with qtbot.assert_not_emitted(wormhole.closed):
+        yield wormhole.close()
+
+
+@inlineCallbacks
 def test_wormhole_receive_via_xfer_util(qtbot, monkeypatch):
     fake_wormhole = MagicMock()
     fake_wormhole.get_welcome.return_value = {}

--- a/tests/test_wormhole.py
+++ b/tests/test_wormhole.py
@@ -17,6 +17,11 @@ def wormhole():
     return w
 
 
+def test_wormhole_init__wormhole_object_is_none():
+    wormhole = Wormhole()
+    assert wormhole._wormhole is None
+
+
 @inlineCallbacks
 def test_wormhole_connect_emit_got_welcome_signal(qtbot, monkeypatch):
     fake_wormhole = MagicMock()


### PR DESCRIPTION
This PR updates the behavior of the `gridsync.wormhole_.Wormhole` QObject/wrapper to delay creating the underlying `wormhole` object (from the magic-wormhole library) until `Wormhole.connect()` is called. This fixes the situation in which Gridsync/magic-wormhole would needlessly open an idle connection to the relay/rendezvous server during initialization (despite not actually _using_ that connection -- thankfully -- in the event that the user enables Tor).

Fixes #169 

Big thanks to @abmoka for noticing this!

