### PR TITLE
Tahoe/eliot update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,19 +204,18 @@ build-deps: deps
 frozen-tahoe:
 	mkdir -p dist
 	mkdir -p build/tahoe-lafs
-	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
+	git clone -b 3005.upstream-inline_callbacks https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	cp misc/tahoe.spec build/tahoe-lafs/pyinstaller.spec
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout a14d9f61163d9a0edf2c9bec328be8d9119e3303 && \
+	git checkout 5bdb37b78685a3e901405256bdfe7fd32cd0913d && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \
 		Darwin) python ../../scripts/maybe_rebuild_libsodium.py ;; \
 	esac &&	\
 	python -m pip install packaging && \
-	python -m pip install git+git://github.com/crwood/eliot.git@frozen-build-support && \
 	python -m pip install --no-use-pep517 pyinstaller==3.4 && \
 	python -m pip list && \
 	export PYTHONHASHSEED=1 && \

--- a/Makefile
+++ b/Makefile
@@ -204,12 +204,12 @@ build-deps: deps
 frozen-tahoe:
 	mkdir -p dist
 	mkdir -p build/tahoe-lafs
-	git clone -b 3005.upstream-inline_callbacks https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
+	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	cp misc/tahoe.spec build/tahoe-lafs/pyinstaller.spec
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout 5bdb37b78685a3e901405256bdfe7fd32cd0913d && \
+	git checkout f7f9cf6abcc8ecb2e25cead4f6cb2de3fe2a82a6 && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \

--- a/make.bat
+++ b/make.bat
@@ -69,14 +69,13 @@ call .\build\venv-tahoe\Scripts\activate
 ::call C:\Python27\python.exe -m zipfile -e .\build\tahoe-lafs.zip .\build
 ::call move .\build\tahoe-lafs-1.11.0 .\build\tahoe-lafs
 call python -m pip install --upgrade setuptools pip
-call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
+call git clone -b 3005.upstream-inline_callbacks https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout a14d9f61163d9a0edf2c9bec328be8d9119e3303
+call git checkout 5bdb37b78685a3e901405256bdfe7fd32cd0913d
 call python setup.py update_version
 call python -m pip install .
 call python -m pip install packaging
-call python -m pip install git+git://github.com/crwood/eliot.git@frozen-build-support
 :: Adding --no-use-pep517 suggested by https://github.com/pypa/pip/issues/6163
 call python -m pip install --no-use-pep517 pyinstaller==3.4
 call python -m pip list

--- a/make.bat
+++ b/make.bat
@@ -69,10 +69,10 @@ call .\build\venv-tahoe\Scripts\activate
 ::call C:\Python27\python.exe -m zipfile -e .\build\tahoe-lafs.zip .\build
 ::call move .\build\tahoe-lafs-1.11.0 .\build\tahoe-lafs
 call python -m pip install --upgrade setuptools pip
-call git clone -b 3005.upstream-inline_callbacks https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
+call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout 5bdb37b78685a3e901405256bdfe7fd32cd0913d
+call git checkout f7f9cf6abcc8ecb2e25cead4f6cb2de3fe2a82a6
 call python setup.py update_version
 call python -m pip install .
 call python -m pip install packaging


### PR DESCRIPTION
Upstream changes in eliot now correctly allow for running frozen tahoe executables generated by PyInstaller. This PR updates `Makefile`/`make.bat` to use that upstream work (rather than relying on my fork of eliot to achieve the same).