### PR TITLE
173.consume tahoe lafs eliot logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ frozen-tahoe:
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout f7f9cf6abcc8ecb2e25cead4f6cb2de3fe2a82a6 && \
+	git checkout d73626b7da7133776c93c093f406f68c2b864446 && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -247,6 +247,11 @@ class GridChecker(QObject):
 
 
 class Monitor(QObject):
+    """
+
+    :ivar bool _started: Whether or not ``start`` has already been called.
+    """
+    _started = False
 
     connected = pyqtSignal()
     disconnected = pyqtSignal()
@@ -357,4 +362,6 @@ class Monitor(QObject):
         self.check_finished.emit()
 
     def start(self, interval=2):
-        self.timer.start(interval, now=True)
+        if not self._started:
+            self._started = True
+            self.timer.start(interval, now=True)

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+Support for reading the streaming Eliot logs available from a Tahoe-LAFS
+node.
+"""
+
+class StreamedLogs():
+    _started = False
+
+    def __init__(self, gateway):
+        self._gateway = gateway
+
+    def start(self):
+        if not self._started:
+            self._started = True

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -7,7 +7,6 @@ node.
 
 import logging
 from collections import deque
-from urllib.parse import urlsplit
 
 from hyperlink import parse
 
@@ -51,10 +50,8 @@ class StreamedLogs(MultiService):
             maxlen = 2000000
         self._buffer = deque(maxlen=maxlen)
 
-
     def add_message(self, message):
         self._buffer.append(message)
-
 
     def start(self, nodeurl, api_token):
         """

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -28,7 +28,8 @@ class TahoeLogReader(WebSocketClientProtocol):
                 "Received a binary-mode WebSocket message from Tahoe-LAFS "
                 "streaming log; dropping.",
             )
-        self.factory.streamedlogs.add_message(payload)
+        else:
+            self.factory.streamedlogs.add_message(payload)
 
 
 class StreamedLogs(MultiService):

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -65,12 +65,14 @@ class StreamedLogs(MultiService):
             self._client_service = self._create_client_service(nodeurl, api_token)
             self._client_service.setServiceParent(self)
             return super().startService()
+        return None
 
     def stop(self):
         if self.running:
             self._client_service.disownServiceParent()
             self._client_service = None
             return super().stopService()
+        return None
 
     def get_streamed_log_messages(self):
         """

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -5,6 +5,10 @@ Support for reading the streaming Eliot logs available from a Tahoe-LAFS
 node.
 """
 
+import logging
+from collections import deque
+from urllib.parse import urlsplit
+
 from autobahn.twisted.websocket import (
     WebSocketClientFactory,
     WebSocketClientProtocol,
@@ -24,8 +28,10 @@ class TahoeLogReader(WebSocketClientProtocol):
 class StreamedLogs():
     _started = False
 
-    def __init__(self, gateway):
+    def __init__(self, reactor, gateway, maxlen=10000):
+        self._reactor = reactor
         self._gateway = gateway
+        self._buffer = deque(maxlen=maxlen)
 
     def start(self):
         if not self._started:

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -5,6 +5,22 @@ Support for reading the streaming Eliot logs available from a Tahoe-LAFS
 node.
 """
 
+from autobahn.twisted.websocket import (
+    WebSocketClientFactory,
+    WebSocketClientProtocol,
+)
+
+
+class TahoeLogReader(WebSocketClientProtocol):
+    def onMessage(self, payload, isBinary):
+        if isBinary:
+            logging.warning(
+                "Received a binary-mode WebSocket message from Tahoe-LAFS "
+                "streaming log; dropping.",
+            )
+        self.factory.streamedlogs._buffer.append(payload)
+
+
 class StreamedLogs():
     _started = False
 
@@ -14,3 +30,24 @@ class StreamedLogs():
     def start(self):
         if not self._started:
             self._started = True
+    def _connect_log_reader(self):
+        nodeurl = self._gateway.nodeurl
+
+        from hyperlink import parse
+        url = parse(nodeurl)
+        wsurl = url.replace(scheme="ws").child("private", "logs", "v1")
+
+        factory = WebSocketClientFactory(
+            url=wsurl.to_uri().to_text(),
+            headers={
+                "Authorization": "{} {}".format('tahoe-lafs', "abcd"),
+            }
+        )
+        factory.protocol = TahoeLogReader
+        factory.streamedlogs = self
+        host, port = urlsplit(nodeurl).netloc.split(':')
+
+        # endpoint = HostnameEndpoint(self._reactor, host, int(port))
+        # ClientService(endpoint, factory).startService()
+
+        self._reactor.connectTCP(host, int(port), factory)

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -43,6 +43,7 @@ class StreamedLogs(MultiService):
     def __init__(self, reactor, maxlen=None):
         super().__init__()
         self._reactor = reactor
+        self._client_service = None
         if maxlen is None:
             # This deque limit is based on average message size of 260 bytes
             # and a desire to limit maximum memory consumption here to around

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -26,6 +26,15 @@ class TahoeLogReader(WebSocketClientProtocol):
 
 
 class StreamedLogs():
+    """
+    :ivar _reactor: A reactor that can connect using whatever transport the
+        Tahoe-LAFS node requires (TCP, etc).
+
+    :ivar Tahoe _gateway: The object representing the Tahoe-LAFS node from
+        which this object will receive streamed logs.
+
+    :ivar deque _buffer: Bounded storage for the streamed messages.
+    """
     _started = False
 
     def __init__(self, reactor, gateway, maxlen=10000):
@@ -36,6 +45,14 @@ class StreamedLogs():
     def start(self):
         if not self._started:
             self._started = True
+            self._connect_log_reader()
+
+    def get_streamed_log_messages(self):
+        """
+        :return list[str]: The messages currently in the message buffer.
+        """
+        return list(msg.decode("utf-8") for msg in self._buffer)
+
     def _connect_log_reader(self):
         nodeurl = self._gateway.nodeurl
 

--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -9,6 +9,9 @@ import logging
 from collections import deque
 from urllib.parse import urlsplit
 
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.application.internet import ClientService
+
 from autobahn.twisted.websocket import (
     WebSocketClientFactory,
     WebSocketClientProtocol,
@@ -70,7 +73,5 @@ class StreamedLogs():
         factory.streamedlogs = self
         host, port = urlsplit(nodeurl).netloc.split(':')
 
-        # endpoint = HostnameEndpoint(self._reactor, host, int(port))
-        # ClientService(endpoint, factory).startService()
-
-        self._reactor.connectTCP(host, int(port), factory)
+        endpoint = TCP4ClientEndpoint(self._reactor, host, int(port))
+        ClientService(endpoint, factory, clock=self._reactor).startService()

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -86,7 +86,9 @@ class Tahoe():
     STARTED = 2
     STOPPING = 3
 
-    def __init__(self, nodedir=None, executable=None):
+    def __init__(self, nodedir=None, executable=None, reactor=None):
+        if reactor is None:
+            from twisted.internet import reactor
         self.executable = executable
         self.multi_folder_support = True
         if nodedir:
@@ -109,7 +111,7 @@ class Tahoe():
         self.remote_magic_folders = defaultdict(dict)
         self.use_tor = False
         self.monitor = Monitor(self)
-        self.streamed_logs = StreamedLogs(self)
+        self.streamedlogs = StreamedLogs(reactor, self)
         self.state = Tahoe.STOPPED
 
     def config_set(self, section, option, value):
@@ -451,7 +453,7 @@ class Tahoe():
         log.debug('Starting "%s" tahoe client...', self.name)
         self.state = Tahoe.STARTING
         self.monitor.start()
-        self.streamed_logs.start()
+        self.streamedlogs.start()
         tcp = self.config_get('connections', 'tcp')
         if tcp and tcp.lower() == 'tor':
             self.use_tor = True

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -373,6 +373,7 @@ class Tahoe():
             log.error('No "twistd.pid" file found in %s', self.nodedir)
             return
         self.state = Tahoe.STOPPING
+        self.streamedlogs.stop()
         if self.lock.locked:
             log.warning(
                 "Delaying stop operation; "

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -14,7 +14,6 @@ from collections import defaultdict, OrderedDict
 from io import BytesIO
 
 import treq
-from twisted.internet import reactor
 from twisted.internet.defer import (
     Deferred, DeferredList, DeferredLock, inlineCallbacks)
 from twisted.internet.error import ConnectError, ProcessDone
@@ -303,6 +302,8 @@ class Tahoe():
 
     @inlineCallbacks
     def command(self, args, callback_trigger=None):
+        from twisted.internet import reactor
+
         exe = (self.executable if self.executable else which('tahoe')[0])
         args = [exe] + ['-d', self.nodedir] + args
         env = os.environ
@@ -497,6 +498,8 @@ class Tahoe():
 
     @inlineCallbacks
     def restart(self):
+        from twisted.internet import reactor
+
         log.debug("Restarting %s client...", self.name)
         if self.state in (Tahoe.STOPPING, Tahoe.STARTING):
             log.warning(
@@ -567,6 +570,8 @@ class Tahoe():
     def await_ready(self):
         # TODO: Replace with "readiness" API?
         # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2844
+        from twisted.internet import reactor
+
         ready = yield self.is_ready()
         if not ready:
             log.debug('Connecting to "%s"...', self.name)
@@ -725,6 +730,8 @@ class Tahoe():
     @inlineCallbacks
     def create_magic_folder(self, path, join_code=None, admin_dircap=None,
                             poll_interval=60):  # XXX See Issue #55
+        from twisted.internet import reactor
+
         path = os.path.realpath(os.path.expanduser(path))
         poll_interval = str(poll_interval)
         try:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -111,7 +111,7 @@ class Tahoe():
         self.remote_magic_folders = defaultdict(dict)
         self.use_tor = False
         self.monitor = Monitor(self)
-        self.streamedlogs = StreamedLogs(reactor, self)
+        self.streamedlogs = StreamedLogs(reactor)
         self.state = Tahoe.STOPPED
 
     def config_set(self, section, option, value):
@@ -463,7 +463,6 @@ class Tahoe():
         log.debug('Starting "%s" tahoe client...', self.name)
         self.state = Tahoe.STARTING
         self.monitor.start()
-        self.streamedlogs.start()
         tcp = self.config_get('connections', 'tcp')
         if tcp and tcp.lower() == 'tor':
             self.use_tor = True
@@ -483,6 +482,7 @@ class Tahoe():
             self.api_token = f.read().strip()
         self.shares_happy = int(self.config_get('client', 'shares.happy'))
         self.load_magic_folders()
+        self.streamedlogs.start(self.nodeurl, self.api_token)
         self.state = Tahoe.STARTED
         log.debug(
             'Finished starting "%s" tahoe client (pid: %s)', self.name, pid)

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -447,6 +447,15 @@ class Tahoe():
 
         log.debug("Finished upgrading legacy configuration")
 
+    def get_streamed_log_messages(self):
+        """
+        Return a ``deque`` containing all buffered log messages.
+
+        :return: A ``deque`` where each element is a UTF-8 & JSON encoded
+            ``bytes`` object giving a single log event with older events
+            appearing first.
+        """
+        return self.streamedlogs.get_streamed_log_messages()
 
     @inlineCallbacks
     def start(self):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -28,6 +28,7 @@ from gridsync import pkgdir
 from gridsync.config import Config
 from gridsync.errors import TahoeError, TahoeCommandError, TahoeWebError
 from gridsync.monitor import Monitor
+from gridsync.streamedlogs import StreamedLogs
 from gridsync.preferences import set_preference, get_preference
 
 
@@ -109,6 +110,7 @@ class Tahoe():
         self.remote_magic_folders = defaultdict(dict)
         self.use_tor = False
         self.monitor = Monitor(self)
+        self.streamed_logs = StreamedLogs(self)
         self.state = Tahoe.STOPPED
 
     def config_set(self, section, option, value):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -488,7 +488,7 @@ class Tahoe():
             with open(self.pidfile, 'w') as f:
                 f.write(pid)
         with open(os.path.join(self.nodedir, 'node.url')) as f:
-            self.nodeurl = f.read().strip()
+            self.set_nodeurl(f.read().strip())
         token_file = os.path.join(self.nodedir, 'private', 'api_auth_token')
         with open(token_file) as f:
             self.api_token = f.read().strip()
@@ -498,6 +498,14 @@ class Tahoe():
         self.state = Tahoe.STARTED
         log.debug(
             'Finished starting "%s" tahoe client (pid: %s)', self.name, pid)
+
+    def set_nodeurl(self, nodeurl):
+        """
+        Specify the location of the Tahoe-LAFS web API.
+
+        :param str nodeurl: A text string giving the URI root of the web API.
+        """
+        self.nodeurl = nodeurl
 
     @inlineCallbacks
     def restart(self):

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -109,7 +109,6 @@ class Tahoe():
         self.remote_magic_folders = defaultdict(dict)
         self.use_tor = False
         self.monitor = Monitor(self)
-        self._monitor_started = False
         self.state = Tahoe.STOPPED
 
     def config_set(self, section, option, value):
@@ -449,9 +448,8 @@ class Tahoe():
     def start(self):
         log.debug('Starting "%s" tahoe client...', self.name)
         self.state = Tahoe.STARTING
-        if not self._monitor_started:
-            self.monitor.start()
-            self._monitor_started = True
+        self.monitor.start()
+        self.streamed_logs.start()
         tcp = self.config_get('connections', 'tcp')
         if tcp and tcp.lower() == 'tor':
             self.use_tor = True

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -10,10 +10,14 @@ import shutil
 import signal
 import sys
 import tempfile
-from collections import defaultdict, OrderedDict
+from collections import defaultdict, deque, OrderedDict
 from io import BytesIO
+from urllib.parse import urlsplit
 
-
+from autobahn.twisted.websocket import (
+    WebSocketClientFactory,
+    WebSocketClientProtocol,
+)
 import treq
 from twisted.internet import reactor
 from twisted.internet.defer import (
@@ -80,6 +84,12 @@ class CommandProtocol(ProcessProtocol):
                     self.output.getvalue().decode('utf-8').strip()))
 
 
+class TahoeLogReader(WebSocketClientProtocol):
+    def onMessage(self, payload, _):
+        print(self.factory.tahoe.name, payload.decode('utf-8'))  # XXX
+        self.factory.tahoe.eliot_log.append(payload.decode('utf-8'))
+
+
 class Tahoe():
 
     STOPPED = 0
@@ -112,6 +122,7 @@ class Tahoe():
         self.monitor = Monitor(self)
         self.streamed_logs = StreamedLogs(self)
         self.state = Tahoe.STOPPED
+        self.eliot_log = deque(maxlen=10000)
 
     def config_set(self, section, option, value):
         self.config.set(section, option, value)
@@ -446,6 +457,18 @@ class Tahoe():
 
         log.debug("Finished upgrading legacy configuration")
 
+    def connect_log_reader(self):
+        factory = WebSocketClientFactory(
+            url=self.nodeurl.replace("http://", "ws://") + "private/logs/v1",
+            headers={
+                "Authorization": "{} {}".format('tahoe-lafs', self.api_token)
+            }
+        )
+        factory.protocol = TahoeLogReader
+        factory.tahoe = self
+        host, port = urlsplit(self.nodeurl).netloc.split(':')
+        reactor.connectTCP(host, int(port), factory)
+
     @inlineCallbacks
     def start(self):
         log.debug('Starting "%s" tahoe client...', self.name)
@@ -469,6 +492,7 @@ class Tahoe():
         token_file = os.path.join(self.nodedir, 'private', 'api_auth_token')
         with open(token_file) as f:
             self.api_token = f.read().strip()
+        self.connect_log_reader()
         self.shares_happy = int(self.config_get('client', 'shares.happy'))
         self.load_magic_folders()
         self.state = Tahoe.STARTED

--- a/make.bat
+++ b/make.bat
@@ -7,7 +7,7 @@
 ::
 ::  3) Python 3.6 <https://www.python.org>
 ::      -Select "Add Python 3.6 to PATH" option during install
-::      -On Windows Server 2012, if installation fails, try installing update "KB2919355". See https://bugs.python.org/issue29583 
+::      -On Windows Server 2012, if installation fails, try installing update "KB2919355". See https://bugs.python.org/issue29583
 ::
 ::  4) Microsoft Visual C++ Compiler for Python 2.7 <https://aka.ms/vcpython27>
 ::
@@ -99,7 +99,7 @@ call %PYTHON3% -m venv --clear .\build\venv-gridsync
 call .\build\venv-gridsync\Scripts\activate
 call python -m pip install --upgrade setuptools pip
 call python -m pip install -r .\requirements\requirements-hashes.txt
-call python -m pip install . 
+call python -m pip install .
 :: Adding --no-use-pep517 suggested by https://github.com/pypa/pip/issues/6163
 call python -m pip install --no-use-pep517 pyinstaller==3.4
 call python -m pip list

--- a/make.bat
+++ b/make.bat
@@ -72,7 +72,7 @@ call python -m pip install --upgrade setuptools pip
 call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout f7f9cf6abcc8ecb2e25cead4f6cb2de3fe2a82a6
+call git checkout d73626b7da7133776c93c093f406f68c2b864446
 call python setup.py update_version
 call python -m pip install .
 call python -m pip install packaging

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ if (sys.version_info.major, sys.version_info.minor) < (3, 5):
 requirements = [
     'autobahn',
     'humanize',
+    'hyperlink',
     'magic-wormhole',
     'PyNaCl >= 1.2.0',  # 1.2.0 adds Argon2id KDF
     'PyQt5',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ if (sys.version_info.major, sys.version_info.minor) < (3, 5):
 
 
 requirements = [
+    'autobahn',
     'humanize',
     'magic-wormhole',
     'PyNaCl >= 1.2.0',  # 1.2.0 adds Argon2id KDF

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import os.path
+from base64 import b64encode
+from functools import partial
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+import pytest
+
+from gridsync.tahoe import Tahoe
+
+
+@pytest.fixture()
+def reactor():
+    return Mock()
+
+
+def _tahoe(tmpdir_factory, reactor):
+    client = Tahoe(str(tmpdir_factory.mktemp('tahoe')), executable='tahoe_exe', reactor=reactor)
+    with open(os.path.join(client.nodedir, 'tahoe.cfg'), 'w') as f:
+        f.write('[node]\nnickname = default')
+    with open(os.path.join(client.nodedir, 'icon.url'), 'w') as f:
+        f.write('test_url')
+    private_dir = os.path.join(client.nodedir, 'private')
+    os.mkdir(private_dir)
+    with open(os.path.join(private_dir, 'aliases'), 'w') as f:
+        f.write('test_alias: test_cap')
+    with open(os.path.join(private_dir, 'magic_folders.yaml'), 'w') as f:
+        f.write("magic-folders:\n  test_folder: {directory: test_dir}")
+    client.set_nodeurl('http://example.invalid:12345/')
+    with open(os.path.join(client.nodedir, 'node.url'), 'w') as f:
+        f.write('http://example.invalid:12345/')
+    with open(os.path.join(private_dir, 'api_auth_token'), 'w') as f:
+        f.write(b64encode(b'a' * 32).decode('ascii'))
+    return client
+
+
+@pytest.fixture()
+def tahoe_factory(tmpdir_factory):
+    return partial(_tahoe, tmpdir_factory)
+
+
+@pytest.fixture()
+def tahoe(tmpdir_factory, reactor):
+    return _tahoe(tmpdir_factory, reactor)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -482,3 +482,15 @@ def test_monitor_start():
     monitor.timer = MagicMock()
     monitor.start()
     assert monitor.timer.mock_calls == [call.start(2, now=True)]
+
+
+def test_monitor_multiple_start():
+    """
+    Calling ``Monitor.start`` multiple times has no effects beyond those of
+    calling it once.
+    """
+    monitor = Monitor(MagicMock())
+    monitor.timer = MagicMock()
+    monitor.start()
+    monitor.start()
+    assert monitor.timer.mock_calls == [call.start(2, now=True)]

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -17,6 +17,7 @@ from autobahn.twisted.websocket import (
 from twisted.internet.defer import Deferred
 from twisted.internet.task import deferLater
 from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.error import CannotListenError
 
 from gridsync.tahoe import Tahoe
 from gridsync.streamedlogs import StreamedLogs

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -191,11 +191,3 @@ def test_authentication(reactor, tahoe):
     )
     h = yield headers
     assert h.get("authorization", None) == "tahoe-lafs {}".format(api_token), h
-
-
-def test_restart():
-    """
-    When the Tahoe-LAFS process is restarted, a new connection is made and a
-    request is sent including the new Tahoe-LAFS API token in the
-    *Authorization* header.
-    """

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -1,0 +1,112 @@
+from random import randrange
+from urllib.parse import urlsplit
+from json import dumps
+
+import pytest
+from pytest_twisted import inlineCallbacks
+
+from test_tahoe import reactor, tahoe
+
+from autobahn.twisted.websocket import (
+    WebSocketClientFactory,
+    WebSocketServerFactory,
+    WebSocketServerProtocol,
+
+)
+
+from twisted.internet.task import deferLater
+from twisted.internet.endpoints import HostnameEndpoint
+
+from gridsync.tahoe import Tahoe
+from gridsync.streamedlogs import StreamedLogs
+
+def test_do_nothing_before_start(reactor, tahoe):
+    """
+    ``StreamedLogs`` doesn't connect to anything before it is started.
+    """
+    assert reactor.connectTCP.call_count == 0
+
+
+def test_connect_eliot_logs(reactor, tahoe):
+    """
+    When ``StreamedLogs`` starts it tries to connect to the streaming log
+    WebSocket endpoint run by the Tahoe-LAFS node.
+    """
+    tahoe.streamedlogs.start()
+
+    host, port, factory = reactor.connectTCP.call_args[0]
+    expected_url = urlsplit(tahoe.nodeurl)
+
+    assert "{}:{}".format(host, port) == expected_url.netloc
+    assert isinstance(factory, WebSocketClientFactory)
+
+
+def fake_log_server(protocol):
+    from twisted.internet import reactor
+    while True:
+        port_number = randrange(10000, 60000)
+        # Why do you make me know the port number in advance, Autobahn?
+        factory = WebSocketServerFactory(u"ws://127.0.0.1:{}".format(port_number))
+        factory.protocol = protocol
+
+        try:
+            server_port = reactor.listenTCP(port_number, factory)
+        except CannotListenError as e:
+            if e.socketError.errno == EADDRINUSE:
+                continue
+            raise
+        else:
+            break
+
+    return server_port
+
+
+class FakeLogServerProtocol(WebSocketServerProtocol):
+    FAKE_MESSAGE = dumps({"fake": "message"})
+
+    def onOpen(self):
+        self.sendMessage(
+            self.FAKE_MESSAGE.encode("utf-8"),
+            isBinary=False,
+        )
+
+
+def twlog():
+    from sys import stdout
+    from twisted.logger import globalLogBeginner
+    from twisted.logger import textFileLogObserver
+    globalLogBeginner.beginLoggingTo([textFileLogObserver(stdout)])
+
+
+@inlineCallbacks
+def test_collect_eliot_logs(reactor, tahoe):
+    """
+    ``StreamedLogs`` saves the JSON log messages so that they can be retrieved
+    using ``Tahoe.get_streamed_log_messages``.
+    """
+    twlog()
+
+    server_port = fake_log_server(FakeLogServerProtocol)
+    server_addr = server_port.getHost()
+
+    # Make sure the streamed logs websocket client can compute the correct ws
+    # url.  If it doesn't match the server, the handshake fails.
+    tahoe.set_nodeurl("http://{}:{}".format(server_addr.host, server_addr.port))
+
+    tahoe.streamedlogs.start()
+    _, _, client_factory = reactor.connectTCP.call_args[0]
+
+    from twisted.internet import reactor as real_reactor
+    endpoint = HostnameEndpoint(real_reactor, server_addr.host, server_addr.port)
+    client_protocol = yield endpoint.connect(client_factory)
+
+    # Arbitrarily give it about a second to deliver the message.  All the I/O
+    # is loopback and the data is small.  One second should be plenty of time.
+    for i in range(20):
+        messages = tahoe.get_streamed_log_messages()
+        if FakeLogServerProtocol.FAKE_MESSAGE in messages:
+            break
+        yield deferLater(real_reactor, 0.1, lambda: None)
+
+    messages = tahoe.get_streamed_log_messages()
+    assert FakeLogServerProtocol.FAKE_MESSAGE in messages

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -33,10 +33,11 @@ def test_connect_to_nodeurl(reactor, tahoe):
     When ``StreamedLogs`` starts it tries to connect to the streaming log
     WebSocket endpoint run by the Tahoe-LAFS node.
     """
-    tahoe.streamedlogs.start()
+    nodeurl = "http://example.invalid:12345"
+    tahoe.streamedlogs.start(nodeurl, "api-token")
 
     host, port, factory = reactor.connectTCP.call_args[0]
-    expected_url = urlsplit(tahoe.nodeurl)
+    expected_url = urlsplit(nodeurl)
 
     assert "{}:{}".format(host, port) == expected_url.netloc
 
@@ -84,9 +85,8 @@ def connect_to_log_endpoint(reactor, tahoe, real_reactor, protocolClass):
 
     # Make sure the streamed logs websocket client can compute the correct ws
     # url.  If it doesn't match the server, the handshake fails.
-    tahoe.set_nodeurl("http://{}:{}".format(server_addr.host, server_addr.port))
-
-    tahoe.streamedlogs.start()
+    tahoe.nodeurl = "http://{}:{}".format(server_addr.host, server_addr.port)
+    tahoe.streamedlogs.start(tahoe.nodeurl, tahoe.api_token)
     _, _, client_factory = reactor.connectTCP.call_args[0]
 
     endpoint = TCP4ClientEndpoint(real_reactor, server_addr.host, server_addr.port)
@@ -121,7 +121,7 @@ def test_bounded_streamed_log_buffer(reactor, tahoe):
     log message buffer.
     """
     maxlen = 3
-    streamedlogs = StreamedLogs(reactor, tahoe, maxlen=maxlen)
+    streamedlogs = StreamedLogs(reactor, maxlen=maxlen)
     for i in range(maxlen + 1):
         streamedlogs.add_message(u"{}".format(i).encode("ascii"))
 

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -16,7 +16,7 @@ from autobahn.twisted.websocket import (
 
 from twisted.internet.defer import Deferred
 from twisted.internet.task import deferLater
-from twisted.internet.endpoints import HostnameEndpoint
+from twisted.internet.endpoints import TCP4ClientEndpoint
 
 from gridsync.tahoe import Tahoe
 from gridsync.streamedlogs import StreamedLogs
@@ -89,7 +89,7 @@ def connect_to_log_endpoint(reactor, tahoe, real_reactor, protocolClass):
     tahoe.streamedlogs.start()
     _, _, client_factory = reactor.connectTCP.call_args[0]
 
-    endpoint = HostnameEndpoint(real_reactor, server_addr.host, server_addr.port)
+    endpoint = TCP4ClientEndpoint(real_reactor, server_addr.host, server_addr.port)
     return endpoint.connect(client_factory)
 
 

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -90,7 +90,12 @@ def connect_to_log_endpoint(reactor, tahoe, real_reactor, protocolClass):
     tahoe.streamedlogs.start(tahoe.nodeurl, tahoe.api_token)
     _, _, client_factory = reactor.connectTCP.call_args[0]
 
-    endpoint = TCP4ClientEndpoint(real_reactor, server_addr.host, server_addr.port)
+    endpoint = TCP4ClientEndpoint(
+        real_reactor,
+        # Windows doesn't like to connect to 0.0.0.0.
+        "127.0.0.1" if server_addr.host == "0.0.0.0" else server_addr.host,
+        server_addr.port,
+        )
     return endpoint.connect(client_factory)
 
 

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -114,6 +114,26 @@ def test_collect_eliot_logs(reactor, tahoe):
     messages = tahoe.get_streamed_log_messages()
     assert FakeLogServerProtocol.FAKE_MESSAGE in messages
 
+
+def test_bounded_streamed_log_buffer(reactor, tahoe):
+    """
+    Only a limited number of the most recent messages remain in the streamed
+    log message buffer.
+    """
+    maxlen = 3
+    streamedlogs = StreamedLogs(reactor, tahoe, maxlen=maxlen)
+    for i in range(maxlen + 1):
+        streamedlogs.add_message(u"{}".format(i).encode("ascii"))
+
+    actual = streamedlogs.get_streamed_log_messages()
+    expected = list(
+        u"{}".format(i)
+        for i
+        in range(1, maxlen + 1)
+    )
+    assert actual == expected
+
+
 def advance_mock_clock(reactor):
     for call in reactor.callLater.call_args_list:
         args, kwargs = call

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -188,6 +188,29 @@ def test_stop(reactor, tahoe):
 
 
 @inlineCallbacks
+def test_path(reactor, tahoe):
+    """
+    The request is made to the correct path on the server to reach the
+    WebSocket endpoint.
+    """
+    from twisted.internet import reactor as real_reactor
+
+    path = Deferred()
+    class PathCheckingProtocol(WebSocketServerProtocol):
+        def onConnect(self, request):
+            path.callback(request.path)
+
+    client_protocol = yield connect_to_log_endpoint(
+        reactor,
+        tahoe,
+        real_reactor,
+        PathCheckingProtocol,
+    )
+    p = yield path
+    assert p == "/private/logs/v1"
+
+
+@inlineCallbacks
 def test_authentication(reactor, tahoe):
     """
     The request to the WebSocket endpoint includes the necessary

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -191,3 +191,11 @@ def test_authentication(reactor, tahoe):
     )
     h = yield headers
     assert h.get("authorization", None) == "tahoe-lafs {}".format(api_token), h
+
+
+def test_restart():
+    """
+    When the Tahoe-LAFS process is restarted, a new connection is made and a
+    request is sent including the new Tahoe-LAFS API token in the
+    *Authorization* header.
+    """

--- a/tests/test_streamedlogs.py
+++ b/tests/test_streamedlogs.py
@@ -3,10 +3,7 @@ from urllib.parse import urlsplit
 from json import dumps
 from errno import EADDRINUSE
 
-import pytest
 from pytest_twisted import inlineCallbacks
-
-from test_tahoe import reactor, tahoe
 
 from autobahn.twisted.websocket import (
     WebSocketServerFactory,

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -746,11 +746,11 @@ def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
     )
     tahoe = tahoe_factory(MemoryReactorClock())
     tahoe.monitor = Mock()
-    write_pidfile(tahoe.nodedir)
     tahoe.config_set('client', 'shares.needed', '3')
     tahoe.config_set('client', 'shares.happy', '7')
     tahoe.config_set('client', 'shares.total', '10')
     yield tahoe.start()
+    write_pidfile(tahoe.nodedir)
     yield tahoe.stop()
     assert not tahoe.streamedlogs.running
 

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -63,7 +63,7 @@ def tahoe(tmpdir_factory):
         f.write('test_alias: test_cap')
     with open(os.path.join(private_dir, 'magic_folders.yaml'), 'w') as f:
         f.write("magic-folders:\n  test_folder: {directory: test_dir}")
-    client.nodeurl = 'http://127.0.0.1:65536/'
+    client.set_nodeurl('http://example.invalid:12345/')
     return client
 
 

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -721,6 +721,14 @@ def test_tahoe_start_use_tor_false(monkeypatch, tmpdir_factory):
 
 
 @inlineCallbacks
+def test_tahoe_stops_streamedlogs(monkeypatch, tahoe):
+    monkeypatch.setattr('gridsync.tahoe.Tahoe.command', lambda x, y, z: 9999)
+    yield client.start()
+    yield client.stop()
+    assert not client.streamedlogs.running
+
+
+@inlineCallbacks
 def test_tahoe_start_use_tor_true(monkeypatch, tmpdir_factory):
     client = Tahoe(str(tmpdir_factory.mktemp('tahoe-start')))
     privatedir = os.path.join(client.nodedir, 'private')

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -6,9 +6,6 @@ try:
 except ImportError:
     from mock import Mock, MagicMock
 
-from functools import partial
-from base64 import b64encode
-
 import pytest
 from pytest_twisted import inlineCallbacks
 import yaml
@@ -53,41 +50,6 @@ def fake_post_code_500(*args, **kwargs):
     response = MagicMock()
     response.code = 500
     return response
-
-
-@pytest.fixture()
-def reactor():
-    return Mock()
-
-
-def _tahoe(tmpdir_factory, reactor):
-    client = Tahoe(str(tmpdir_factory.mktemp('tahoe')), executable='tahoe_exe', reactor=reactor)
-    with open(os.path.join(client.nodedir, 'tahoe.cfg'), 'w') as f:
-        f.write('[node]\nnickname = default')
-    with open(os.path.join(client.nodedir, 'icon.url'), 'w') as f:
-        f.write('test_url')
-    private_dir = os.path.join(client.nodedir, 'private')
-    os.mkdir(private_dir)
-    with open(os.path.join(private_dir, 'aliases'), 'w') as f:
-        f.write('test_alias: test_cap')
-    with open(os.path.join(private_dir, 'magic_folders.yaml'), 'w') as f:
-        f.write("magic-folders:\n  test_folder: {directory: test_dir}")
-    client.set_nodeurl('http://example.invalid:12345/')
-    with open(os.path.join(client.nodedir, 'node.url'), 'w') as f:
-        f.write('http://example.invalid:12345/')
-    with open(os.path.join(private_dir, 'api_auth_token'), 'w') as f:
-        f.write(b64encode(b'a' * 32).decode('ascii'))
-    return client
-
-
-@pytest.fixture()
-def tahoe_factory(tmpdir_factory):
-    return partial(_tahoe, tmpdir_factory)
-
-
-@pytest.fixture()
-def tahoe(tmpdir_factory, reactor):
-    return _tahoe(tmpdir_factory, reactor)
 
 
 def test_is_valid_furl():

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -745,6 +745,7 @@ def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
         lambda self, args, callback_trigger=None: 9999,
     )
     tahoe = tahoe_factory(MemoryReactorClock())
+    tahoe.monitor = Mock()
     write_pidfile(tahoe.nodedir)
     tahoe.config_set('client', 'shares.needed', '3')
     tahoe.config_set('client', 'shares.happy', '7')

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -77,9 +77,6 @@ def _tahoe(tmpdir_factory, reactor):
         f.write('http://example.invalid:12345/')
     with open(os.path.join(private_dir, 'api_auth_token'), 'w') as f:
         f.write(b64encode(b'a' * 32).decode('ascii'))
-    client.config_set('client', 'shares.needed', '3')
-    client.config_set('client', 'shares.happy', '7')
-    client.config_set('client', 'shares.total', '10')
     return client
 
 
@@ -749,6 +746,9 @@ def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
     )
     tahoe = tahoe_factory(MemoryReactorClock())
     write_pidfile(tahoe.nodedir)
+    tahoe.config_set('client', 'shares.needed', '3')
+    tahoe.config_set('client', 'shares.happy', '7')
+    tahoe.config_set('client', 'shares.total', '10')
     yield tahoe.start()
     yield tahoe.stop()
     assert not tahoe.streamedlogs.running

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -739,6 +739,24 @@ def test_tahoe_start_use_tor_false(monkeypatch, tmpdir_factory):
 
 
 @inlineCallbacks
+def test_tahoe_starts_streamedlogs(monkeypatch, tahoe_factory):
+    monkeypatch.setattr(
+        'gridsync.tahoe.Tahoe.command',
+        lambda self, args, callback_trigger=None: 9999,
+    )
+    reactor = MemoryReactorClock()
+    tahoe = tahoe_factory(reactor)
+    tahoe.monitor = Mock()
+    tahoe.config_set('client', 'shares.needed', '3')
+    tahoe.config_set('client', 'shares.happy', '7')
+    tahoe.config_set('client', 'shares.total', '10')
+    yield tahoe.start()
+    assert tahoe.streamedlogs.running
+    (host, port, _, _, _) = reactor.tcpClients.pop(0)
+    assert (host, port) == ("example.invalid", 12345)
+
+
+@inlineCallbacks
 def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
     monkeypatch.setattr(
         'gridsync.tahoe.Tahoe.command',

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -6,6 +6,9 @@ try:
 except ImportError:
     from mock import Mock, MagicMock
 
+from functools import partial
+from base64 import b64encode
+
 import pytest
 from pytest_twisted import inlineCallbacks
 import yaml
@@ -70,6 +73,13 @@ def _tahoe(tmpdir_factory, reactor):
     with open(os.path.join(private_dir, 'magic_folders.yaml'), 'w') as f:
         f.write("magic-folders:\n  test_folder: {directory: test_dir}")
     client.set_nodeurl('http://example.invalid:12345/')
+    with open(os.path.join(client.nodedir, 'node.url'), 'w') as f:
+        f.write('http://example.invalid:12345/')
+    with open(os.path.join(private_dir, 'api_auth_token'), 'w') as f:
+        f.write(b64encode(b'a' * 32).decode('ascii'))
+    client.config_set('client', 'shares.needed', '3')
+    client.config_set('client', 'shares.happy', '7')
+    client.config_set('client', 'shares.total', '10')
     return client
 
 

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -2,9 +2,9 @@
 
 import os
 try:
-    from unittest.mock import MagicMock
+    from unittest.mock import Mock, MagicMock
 except ImportError:
-    from mock import MagicMock
+    from mock import Mock, MagicMock
 
 import pytest
 from pytest_twisted import inlineCallbacks
@@ -50,9 +50,14 @@ def fake_post_code_500(*args, **kwargs):
     return response
 
 
-@pytest.fixture(scope='module')
-def tahoe(tmpdir_factory):
-    client = Tahoe(str(tmpdir_factory.mktemp('tahoe')), executable='tahoe_exe')
+@pytest.fixture()
+def reactor():
+    return Mock()
+
+
+@pytest.fixture()
+def tahoe(tmpdir_factory, reactor):
+    client = Tahoe(str(tmpdir_factory.mktemp('tahoe')), executable='tahoe_exe', reactor=reactor)
     with open(os.path.join(client.nodedir, 'tahoe.cfg'), 'w') as f:
         f.write('[node]\nnickname = default')
     with open(os.path.join(client.nodedir, 'icon.url'), 'w') as f:

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -708,8 +708,10 @@ def test_tahoe_start_use_tor_false(monkeypatch, tmpdir_factory):
     client = Tahoe(str(tmpdir_factory.mktemp('tahoe-start')))
     privatedir = os.path.join(client.nodedir, 'private')
     os.makedirs(privatedir)
+    nodeurl = 'http://127.0.0.1:54321'
+    client.set_nodeurl(nodeurl)
     with open(os.path.join(client.nodedir, 'node.url'), 'w') as f:
-        f.write('http://127.0.0.1:65536')
+        f.write(nodeurl)
     with open(os.path.join(privatedir, 'api_auth_token'), 'w') as f:
         f.write('1234567890')
     client.config_set('client', 'shares.happy', '99999')
@@ -723,8 +725,10 @@ def test_tahoe_start_use_tor_true(monkeypatch, tmpdir_factory):
     client = Tahoe(str(tmpdir_factory.mktemp('tahoe-start')))
     privatedir = os.path.join(client.nodedir, 'private')
     os.makedirs(privatedir)
+    nodeurl = 'http://127.0.0.1:54321'
+    client.set_nodeurl(nodeurl)
     with open(os.path.join(client.nodedir, 'node.url'), 'w') as f:
-        f.write('http://127.0.0.1:65536')
+        f.write(nodeurl)
     with open(os.path.join(privatedir, 'api_auth_token'), 'w') as f:
         f.write('1234567890')
     client.config_set('client', 'shares.happy', '99999')


### PR DESCRIPTION
Fixes #173

Well, it sort-of fixes it.  It only gathers the logs into the GridSync process.  It doesn't expose them to anyone in any way.  I imagine there should be a follow-up to #173 that describes some specific user experience involving this data.
