### PR TITLE
Disable qmessagebox logging

### DIFF
--- a/gridsync/cli.py
+++ b/gridsync/cli.py
@@ -43,7 +43,7 @@ def main():
         msg.critical(
             "{} already running".format(APP_NAME),
             "{} is already running.".format(APP_NAME))
-        return 1
+        return "ERROR: {} is already running.".format(APP_NAME)
     return 0
 
 

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -91,6 +91,7 @@ class Core():
                 gateway = Tahoe(nodedir, executable=self.executable)
                 tcp = gateway.config_get('connections', 'tcp')
                 if tcp == 'tor' and not tor_available:
+                    logging.error("No running tor daemon found")
                     msg.error(
                         self.gui.main_window,
                         "Error Connecting To Tor Daemon",

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -60,6 +60,7 @@ class Core():
         self.executable = yield select_executable()
         logging.debug("Selected executable: %s", self.executable)
         if not self.executable:
+            logging.critical("Tahoe-LAFS not found")
             msg.critical(
                 "Tahoe-LAFS not found",
                 "Could not find a suitable 'tahoe' executable in your PATH. "
@@ -108,6 +109,7 @@ class Core():
         try:
             yield self.get_tahoe_version()
         except Exception as e:  # pylint: disable=broad-except
+            logging.critical("Error getting Tahoe-LAFS version")
             msg.critical(
                 "Error getting Tahoe-LAFS version",
                 "{}: {}".format(type(e).__name__, str(e))

--- a/gridsync/gui/debug.py
+++ b/gridsync/gui/debug.py
@@ -243,6 +243,7 @@ class DebugExporter(QDialog):
             with open(dest, 'w') as f:
                 f.write(self.plaintextedit.toPlainText())
         except Exception as e:  # pylint: disable=broad-except
+            logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
                 "Error exporting debug information",

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -320,6 +320,7 @@ class MainWindow(QMainWindow):
                 "Export successful",
                 "Recovery Key successfully exported to {}".format(path))
         else:
+            logging.error("Error exporting Recovery Key; file not found.")
             error(
                 self,
                 "Error exporting Recovery Key",

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import sys
 
@@ -313,6 +314,7 @@ class MainWindow(QMainWindow):
 
     def confirm_export(self, path):
         if os.path.isfile(path):
+            logging.info("Recovery Key successfully exported")
             info(
                 self,
                 "Export successful",

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -202,6 +202,7 @@ class View(QTreeView):
         try:
             yield self.gateway.restore_magic_folder(folder_name, dest)
         except Exception as e:  # pylint: disable=broad-except
+            logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
                 'Error downloading folder "{}"'.format(folder_name),
@@ -225,6 +226,7 @@ class View(QTreeView):
         d.addCallback(self.maybe_restart_gateway)
 
     def show_failure(self, failure):
+        logging.error("%s: %s", str(failure.type.__name__), str(failure.value))
         error(
             self,
             str(failure.type.__name__),
@@ -236,6 +238,7 @@ class View(QTreeView):
         try:
             yield self.gateway.unlink_magic_folder_from_rootcap(folder_name)
         except Exception as e:  # pylint: disable=broad-except
+            logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
                 'Error unlinking folder "{}"'.format(folder_name),
@@ -281,6 +284,7 @@ class View(QTreeView):
         try:
             yield self.gateway.remove_magic_folder(folder_name)
         except Exception as e:  # pylint: disable=broad-except
+            logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
                 'Error removing folder "{}"'.format(folder_name),
@@ -439,6 +443,7 @@ class View(QTreeView):
         try:
             yield self.gateway.create_magic_folder(path)
         except Exception as e:  # pylint: disable=broad-except
+            logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
                 'Error adding folder "{}"'.format(folder_name),

--- a/gridsync/msg.py
+++ b/gridsync/msg.py
@@ -35,5 +35,4 @@ def info(parent, title, text):
     msg.setIcon(QMessageBox.Information)
     msg.setWindowTitle(title)
     msg.setText(text)
-    logging.info(text)
     return msg.exec_()

--- a/gridsync/msg.py
+++ b/gridsync/msg.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
 import sys
 
 from PyQt5.QtWidgets import QMessageBox
@@ -26,7 +25,6 @@ def error(parent, title, text, detailed_text=None):
         msg.setWindowTitle(title)
         msg.setText(text)
     msg.setDetailedText(detailed_text)
-    logging.error("%s: %s", title, text)
     return msg.exec_()
 
 

--- a/gridsync/msg.py
+++ b/gridsync/msg.py
@@ -11,7 +11,6 @@ def critical(title, text):
     msg.setIcon(QMessageBox.Critical)
     msg.setWindowTitle(title)
     msg.setText(text)
-    logging.critical(text)
     return msg.exec_()
 
 


### PR DESCRIPTION
A follow-up to #179, this PR changes the `gridsync.msg` module to no longer automatically log every message that's shown to users, and adds distinct/explicit `logging.info`, `logging.critical`, `logging.error` calls in places where logging is actually desired. Distinguishing between these two types of messages -- i.e., `QMessageBox`-based messages and `logging`-based messages -- allows potentially sensitive information (such as folder names, paths, etc.) to be shown in the former, while omitting it from the latter. Normal, user-facing "error" messages that are shown as a result of a user trying to add a file instead of a folder or a folder which already exists, for example, will thus no longer result in the names of those files/folders also showing up in the logs.