### PR TITLE
178.systray menu fallback

### DIFF
--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -211,9 +211,9 @@ class HistoryListWidget(QListWidget):
 
 
 class HistoryView(QWidget):
-    def __init__(self, gateway, deduplicate=True, max_items=30):
+    def __init__(self, gateway, gui, deduplicate=True, max_items=30):
         super(HistoryView, self).__init__()
         layout = QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(HistoryListWidget(gateway, deduplicate, max_items))
-        layout.addWidget(StatusPanel(gateway))
+        layout.addWidget(StatusPanel(gateway, gui))

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -66,13 +66,13 @@ class CentralWidget(QStackedWidget):
             left, _, right, _ = layout.getContentsMargins()
             layout.setContentsMargins(left, 0, right, 0)
         layout.addWidget(view)
-        layout.addWidget(StatusPanel(gateway))
+        layout.addWidget(StatusPanel(gateway, self.gui))
         self.addWidget(widget)
         self.views.append(view)
         self.folders_views[gateway] = widget
 
     def add_history_view(self, gateway):
-        view = HistoryView(gateway)
+        view = HistoryView(gateway, self.gui)
         self.addWidget(view)
         self.history_views[gateway] = view
 

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -252,7 +252,6 @@ class MainWindow(QMainWindow):
                 self.central_widget.add_history_view(gateway)
                 self.combo_box.add_gateway(gateway)
                 self.gateways.append(gateway)
-        self.gui.systray.menu.populate()
 
     def current_view(self):
         try:

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import webbrowser
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QAction, QMenu, QMessageBox
+
+from gridsync import resource, settings, APP_NAME
+from gridsync._version import __version__
+
+
+def open_documentation():
+    webbrowser.open(settings['help']['docs_url'])
+
+
+def open_issue():
+    webbrowser.open(settings['help']['issues_url'])
+
+
+class Menu(QMenu):
+    def __init__(self, parent):
+        super(Menu, self).__init__()
+        self.parent = parent
+        self.gui = self.parent.parent
+
+        self.about_msg = QMessageBox()
+        self.about_msg.setWindowTitle("{} - About".format(APP_NAME))
+        app_icon = QIcon(resource(settings['application']['tray_icon']))
+        self.about_msg.setIconPixmap(app_icon.pixmap(64, 64))
+        self.about_msg.setText("{} {}".format(APP_NAME, __version__))
+        self.about_msg.setWindowModality(Qt.WindowModal)
+
+        self.populate()
+
+    def populate(self):
+        self.clear()
+        logging.debug("(Re-)populating systray menu...")
+
+        open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
+        open_action.triggered.connect(self.gui.show)
+        self.addAction(open_action)
+
+        self.addSeparator()
+
+        preferences_action = QAction(QIcon(''), "Preferences...", self)
+        preferences_action.triggered.connect(self.gui.show_preferences_window)
+        self.addAction(preferences_action)
+
+        help_menu = QMenu(self)
+        help_menu.setTitle("Help")
+        help_settings = settings.get('help')
+        if help_settings:
+            if help_settings.get('docs_url'):
+                docs_action = QAction(
+                    QIcon(''), "Browse Documentation...", self)
+                docs_action.triggered.connect(open_documentation)
+                help_menu.addAction(docs_action)
+            if help_settings.get('issues_url'):
+                issue_action = QAction(QIcon(''), "Report Issue...", self)
+                issue_action.triggered.connect(open_issue)
+                help_menu.addAction(issue_action)
+        export_action = QAction(QIcon(''), "Export Debug Information...", self)
+        export_action.triggered.connect(self.gui.show_debug_exporter)
+        help_menu.addAction(export_action)
+        help_menu.addSeparator()
+        about_action = QAction(QIcon(''), "About {}...".format(APP_NAME), self)
+        about_action.triggered.connect(self.about_msg.exec_)
+        help_menu.addAction(about_action)
+        self.addMenu(help_menu)
+
+        self.addSeparator()
+
+        quit_action = QAction(
+            QIcon(''), "&Quit {}".format(APP_NAME), self)
+        quit_action.triggered.connect(self.gui.main_window.confirm_quit)
+        self.addAction(quit_action)

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -11,7 +11,7 @@ from gridsync._version import __version__
 
 
 class Menu(QMenu):
-    def __init__(self, gui):
+    def __init__(self, gui, show_open_action=True):
         super(Menu, self).__init__()
         self.gui = gui
 
@@ -22,11 +22,11 @@ class Menu(QMenu):
         self.about_msg.setText("{} {}".format(APP_NAME, __version__))
         self.about_msg.setWindowModality(Qt.WindowModal)
 
-        open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
-        open_action.triggered.connect(self.gui.show)
-        self.addAction(open_action)
-
-        self.addSeparator()
+        if show_open_action:
+            open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
+            open_action.triggered.connect(self.gui.show)
+            self.addAction(open_action)
+            self.addSeparator()
 
         preferences_action = QAction(QIcon(''), "Preferences...", self)
         preferences_action.triggered.connect(self.gui.show_preferences_window)

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
 import webbrowser
 
 from PyQt5.QtCore import Qt
@@ -31,12 +30,6 @@ class Menu(QMenu):
         self.about_msg.setIconPixmap(app_icon.pixmap(64, 64))
         self.about_msg.setText("{} {}".format(APP_NAME, __version__))
         self.about_msg.setWindowModality(Qt.WindowModal)
-
-        self.populate()
-
-    def populate(self):
-        self.clear()
-        logging.debug("(Re-)populating systray menu...")
 
         open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
         open_action.triggered.connect(self.gui.show)

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -10,14 +10,6 @@ from gridsync import resource, settings, APP_NAME
 from gridsync._version import __version__
 
 
-def open_documentation():
-    webbrowser.open(settings['help']['docs_url'])
-
-
-def open_issue():
-    webbrowser.open(settings['help']['issues_url'])
-
-
 class Menu(QMenu):
     def __init__(self, parent):
         super(Menu, self).__init__()
@@ -48,11 +40,13 @@ class Menu(QMenu):
             if help_settings.get('docs_url'):
                 docs_action = QAction(
                     QIcon(''), "Browse Documentation...", self)
-                docs_action.triggered.connect(open_documentation)
+                docs_action.triggered.connect(
+                    lambda: webbrowser.open(settings['help']['docs_url']))
                 help_menu.addAction(docs_action)
             if help_settings.get('issues_url'):
                 issue_action = QAction(QIcon(''), "Report Issue...", self)
-                issue_action.triggered.connect(open_issue)
+                issue_action.triggered.connect(
+                    lambda: webbrowser.open(settings['help']['issues_url']))
                 help_menu.addAction(issue_action)
         export_action = QAction(QIcon(''), "Export Debug Information...", self)
         export_action.triggered.connect(self.gui.show_debug_exporter)

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -11,10 +11,9 @@ from gridsync._version import __version__
 
 
 class Menu(QMenu):
-    def __init__(self, parent):
+    def __init__(self, gui):
         super(Menu, self).__init__()
-        self.parent = parent
-        self.gui = self.parent.parent
+        self.gui = gui
 
         self.about_msg = QMessageBox()
         self.about_msg.setWindowTitle("{} - About".format(APP_NAME))

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QWidget)
 
 from gridsync import resource
+from gridsync.gui.menu import Menu
 
 
 class StatusPanel(QWidget):
@@ -65,6 +66,14 @@ class StatusPanel(QWidget):
         self.globe_action = QAction(QIcon(resource('globe.png')), '')
         self.globe_button.setDefaultAction(self.globe_action)
 
+        preferences_button = QToolButton(self)
+        preferences_button.setIcon(QIcon(resource('preferences.png')))
+        preferences_button.setIconSize(QSize(20, 20))
+        preferences_button.setMenu(Menu(self.gui))
+        preferences_button.setPopupMode(2)
+        preferences_button.setStyleSheet(
+            'QToolButton::menu-indicator { image: none }')
+
         layout = QGridLayout(self)
         left, _, right, bottom = layout.getContentsMargins()
         layout.setContentsMargins(left, 0, right, bottom - 2)
@@ -74,6 +83,7 @@ class StatusPanel(QWidget):
         layout.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, 0), 1, 3)
         layout.addWidget(self.tor_button, 1, 4)
         layout.addWidget(self.globe_button, 1, 5)
+        layout.addWidget(preferences_button, 1, 6)
 
         self.gateway.monitor.total_sync_state_updated.connect(
             self.on_sync_state_updated

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -4,8 +4,8 @@ from humanize import naturalsize
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QIcon, QMovie, QPixmap
 from PyQt5.QtWidgets import (
-    QAction, QGridLayout, QLabel, QSizePolicy, QSpacerItem, QToolButton,
-    QWidget)
+    QAction, QGridLayout, QLabel, QSizePolicy, QSpacerItem, QSystemTrayIcon,
+    QToolButton, QWidget)
 
 from gridsync import resource
 from gridsync.gui.menu import Menu
@@ -73,6 +73,9 @@ class StatusPanel(QWidget):
         preferences_button.setPopupMode(2)
         preferences_button.setStyleSheet(
             'QToolButton::menu-indicator { image: none }')
+
+        if QSystemTrayIcon.isSystemTrayAvailable():
+            preferences_button.hide()
 
         layout = QGridLayout(self)
         left, _, right, bottom = layout.getContentsMargins()

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -11,9 +11,10 @@ from gridsync import resource
 
 
 class StatusPanel(QWidget):
-    def __init__(self, gateway):
+    def __init__(self, gateway, gui):
         super(StatusPanel, self).__init__()
         self.gateway = gateway
+        self.gui = gui
 
         self.num_connected = 0
         self.num_known = 0

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -69,7 +69,7 @@ class StatusPanel(QWidget):
         preferences_button = QToolButton(self)
         preferences_button.setIcon(QIcon(resource('preferences.png')))
         preferences_button.setIconSize(QSize(20, 20))
-        preferences_button.setMenu(Menu(self.gui))
+        preferences_button.setMenu(Menu(self.gui, show_open_action=False))
         preferences_button.setPopupMode(2)
         preferences_button.setStyleSheet(
             'QToolButton::menu-indicator { image: none }')

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -10,14 +10,14 @@ from gridsync.gui.menu import Menu
 
 
 class SystemTrayIcon(QSystemTrayIcon):
-    def __init__(self, parent):
+    def __init__(self, gui):
         super(SystemTrayIcon, self).__init__()
-        self.parent = parent
+        self.gui = gui
 
         self.icon = QIcon(resource(settings['application']['tray_icon']))
         self.setIcon(self.icon)
 
-        self.menu = Menu(self)
+        self.menu = Menu(self.gui)
         self.setContextMenu(self.menu)
         self.activated.connect(self.on_click)
 
@@ -28,7 +28,7 @@ class SystemTrayIcon(QSystemTrayIcon):
         self.animation.setCacheMode(True)
 
     def update(self):
-        if self.parent.core.operations:
+        if self.gui.core.operations:
             self.animation.setPaused(False)
             self.setIcon(QIcon(self.animation.currentPixmap()))
         else:
@@ -37,4 +37,4 @@ class SystemTrayIcon(QSystemTrayIcon):
 
     def on_click(self, value):
         if value == QSystemTrayIcon.Trigger and sys.platform != 'darwin':
-            self.parent.show_main_window()
+            self.gui.show_main_window()

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -1,82 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import logging
 import sys
-import webbrowser
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon, QMovie
-from PyQt5.QtWidgets import QAction, QMenu, QMessageBox, QSystemTrayIcon
+from PyQt5.QtWidgets import QSystemTrayIcon
 
-from gridsync import resource, settings, APP_NAME
-from gridsync._version import __version__
-
-
-def open_documentation():
-    webbrowser.open(settings['help']['docs_url'])
-
-
-def open_issue():
-    webbrowser.open(settings['help']['issues_url'])
-
-
-class Menu(QMenu):
-    def __init__(self, parent):
-        super(Menu, self).__init__()
-        self.parent = parent
-        self.gui = self.parent.parent
-
-        self.about_msg = QMessageBox()
-        self.about_msg.setWindowTitle("{} - About".format(APP_NAME))
-        app_icon = QIcon(resource(settings['application']['tray_icon']))
-        self.about_msg.setIconPixmap(app_icon.pixmap(64, 64))
-        self.about_msg.setText("{} {}".format(APP_NAME, __version__))
-        self.about_msg.setWindowModality(Qt.WindowModal)
-
-        self.populate()
-
-    def populate(self):
-        self.clear()
-        logging.debug("(Re-)populating systray menu...")
-
-        open_action = QAction(QIcon(''), "Open {}".format(APP_NAME), self)
-        open_action.triggered.connect(self.gui.show)
-        self.addAction(open_action)
-
-        self.addSeparator()
-
-        preferences_action = QAction(QIcon(''), "Preferences...", self)
-        preferences_action.triggered.connect(self.gui.show_preferences_window)
-        self.addAction(preferences_action)
-
-        help_menu = QMenu(self)
-        help_menu.setTitle("Help")
-        help_settings = settings.get('help')
-        if help_settings:
-            if help_settings.get('docs_url'):
-                docs_action = QAction(
-                    QIcon(''), "Browse Documentation...", self)
-                docs_action.triggered.connect(open_documentation)
-                help_menu.addAction(docs_action)
-            if help_settings.get('issues_url'):
-                issue_action = QAction(QIcon(''), "Report Issue...", self)
-                issue_action.triggered.connect(open_issue)
-                help_menu.addAction(issue_action)
-        export_action = QAction(QIcon(''), "Export Debug Information...", self)
-        export_action.triggered.connect(self.gui.show_debug_exporter)
-        help_menu.addAction(export_action)
-        help_menu.addSeparator()
-        about_action = QAction(QIcon(''), "About {}...".format(APP_NAME), self)
-        about_action.triggered.connect(self.about_msg.exec_)
-        help_menu.addAction(about_action)
-        self.addMenu(help_menu)
-
-        self.addSeparator()
-
-        quit_action = QAction(
-            QIcon(''), "&Quit {}".format(APP_NAME), self)
-        quit_action.triggered.connect(self.gui.main_window.confirm_quit)
-        self.addAction(quit_action)
+from gridsync import resource, settings
+from gridsync.gui.menu import Menu
 
 
 class SystemTrayIcon(QSystemTrayIcon):

--- a/tests/gui/test_history.py
+++ b/tests/gui/test_history.py
@@ -208,5 +208,5 @@ def test_history_list_widget_update_visible_widgets_on_show_event(
 
 
 def test_history_view_init():
-    hv = HistoryView(MagicMock())
+    hv = HistoryView(MagicMock(), MagicMock())
     assert hv

--- a/tests/gui/test_status.py
+++ b/tests/gui/test_status.py
@@ -10,7 +10,7 @@ from gridsync.gui.status import StatusPanel
 def test_status_panel_hide_tor_button():
     gateway = MagicMock()
     gateway.use_tor = False
-    sp = StatusPanel(gateway)
+    sp = StatusPanel(gateway, MagicMock())
     assert sp.tor_button.isHidden() is True
 
 
@@ -20,7 +20,7 @@ def test_status_panel_hide_tor_button():
     [2, "Up to date"]
 ])
 def test_on_sync_state_updated(state, text):
-    sp = StatusPanel(MagicMock())
+    sp = StatusPanel(MagicMock(), MagicMock())
     sp.on_sync_state_updated(state)
     assert sp.status_label.text() == text
 
@@ -30,7 +30,7 @@ def test_on_sync_state_updated(state, text):
     [1, 2, None, "Connected to 1 of 2 storage nodes"],
 ])
 def test__update_grid_info(num_connected, num_known, available_space, tooltip):
-    sp = StatusPanel(MagicMock())
+    sp = StatusPanel(MagicMock(), MagicMock())
     sp.num_connected = num_connected
     sp.num_known = num_known
     sp.available_space = available_space
@@ -39,12 +39,12 @@ def test__update_grid_info(num_connected, num_known, available_space, tooltip):
 
 
 def test_on_space_updated_humanize():
-    sp = StatusPanel(MagicMock())
+    sp = StatusPanel(MagicMock(), MagicMock())
     sp.on_space_updated(1024)
     assert sp.available_space == "1.0 kB"
 
 
 def test_on_nodes_updated():
-    sp = StatusPanel(MagicMock())
+    sp = StatusPanel(MagicMock(), MagicMock())
     sp.on_nodes_updated(4, 5)
     assert (sp.num_connected, sp.num_known) == (4, 5)


### PR DESCRIPTION
This PR fixes #178 by decoupling the system tray menu from the system tray icon itself: in the event that the application is being run under a desktop environment that does _not_ support a system tray (such as the latest vanilla version of GNOME), a gear/cog button will appear in the bottom-right corner of the status panel which, when clicked, will display the menu that was previously inaccessible.

For users of desktop environments that _do_ support a system tray (including macOS, Windows, Ubuntu and, seemingly, every other commonly-used Linux distro/environment), this changes nothing: the menu will continue to be accessible from the system tray, as expected.