### PR TITLE
Use Twisted's reactor.spawnProcess() on win32

### DIFF
--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -253,16 +253,6 @@ def test_load_magic_folders(tahoe):
 
 
 @inlineCallbacks
-def test_tahoe_command_win32_monkeypatch(tahoe, monkeypatch):
-    monkeypatch.setattr('sys.platform', 'win32')
-    monkeypatch.setattr('sys.frozen', True, raising=False)
-    monkeypatch.setattr('gridsync.tahoe.Tahoe._win32_popen',
-                        lambda a, b, c, d: 'test output')
-    output = yield tahoe.command(['test_command'])
-    assert output == 'test output'
-
-
-@inlineCallbacks
 def test_tahoe_get_features_multi_magic_folder_support(tahoe, monkeypatch):
     monkeypatch.setattr('gridsync.tahoe.Tahoe.command', lambda x, y: 'test')
     output = yield tahoe.get_features()


### PR DESCRIPTION
The threaded `subprocess.Popen` workaround/hack that this PR removes is no longer necessary, as Twisted now -- and by default -- suppresses console windows for win32 subprocesses. See: https://github.com/twisted/twisted/pull/697