### PR TITLE
Remove folder from 'operations' list upon removal

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -140,6 +140,7 @@ class Model(QStandardItemModel):
         self.set_status(basename, status_data)
 
     def remove_folder(self, folder_name):
+        self.on_sync_finished(folder_name)
         items = self.findItems(folder_name)
         if items:
             self.removeRow(items[0].row())


### PR DESCRIPTION
The systray icon will animate so long as a gateway+folder tuple is found in the `gui.core.operations` list. This one-line PR updates `Model.remove_folder` to also call `Model.on_syncing_finshed`, thereby ensuring that removed folders are always also removed from the `operations` list -- and thereby stopping the systray icon from endlessly spinning/animating in the event that the folder gets removed before the syncing operation naturally completes.

Fixes #197