### PR TITLE
Always enable Qt.AA_UseHighDpiPixmaps

### DIFF
--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -10,14 +10,15 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QCheckBox, QMessageBox
 
 if sys.platform in ('darwin', 'win32'):
-    # XXX These attributes appear to be broken on Linux in at least two ways:
-    #   - Under i3wm on Qubes-OS, setting them doubles the window-size but
-    #     keeps font-sizes the same, even on low-resolution (1080p) displays.
+    # XXX This attribute appears to be broken on Linux in at least two ways:
+    #   - On Qubes-OS, it doubles the window-size but keeps font-sizes the
+    #     same -- even on lower-resolution (1080p) displays.
     #   - Under GNOME on both Fedora 29 and Ubuntu 19.04 and with a display
-    #     scaling setting of "200%", setting them doubles the font-sizes but
-    #     keeps the window-sizes the same (i.e., at 100%)
+    #     scaling setting of "200%", it doubles the font-sizes but keeps the
+    #     window-sizes the same (i.e., at 100% when 200% is expected)
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
-    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+
+QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
 app = QApplication(sys.argv)
 


### PR DESCRIPTION
A minor follow-up/addendum to PR #199: after further testing, setting this attribute to `True` globally seems to produce no ill consequences on GNU/Linux on low-resolution displays (but keeping it set to `False` when the `QT_SCALE_FACTOR` env var is `2` or greater results in "blocky" pixmaps).

Note that this change does _not_ address the issue(s) described in #198: Qt's `AA_EnableHighDpiScaling` is broken on Qubes-OS and does nothing to upscale window-sizes in conjunction with GNOME's display scale setting (at least on a 1080p display).

