### PR TITLE
Show/open the window when clicking a notification

### DIFF
--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -21,6 +21,8 @@ class SystemTrayIcon(QSystemTrayIcon):
         self.setContextMenu(self.menu)
         self.activated.connect(self.on_click)
 
+        self.messageClicked.connect(self.gui.show_main_window)
+
         self.animation = QMovie()
         self.animation.setFileName(
             resource(settings['application']['tray_icon_sync']))


### PR DESCRIPTION
This should work on Windows but won't (yet?) on macOS. See:

https://doc.qt.io/qt-5/qsystemtrayicon.html#messageClicked

(Partially) closes #207 