### PR TITLE
Strip HTML tags from newscap notification messages

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -21,6 +21,7 @@ from gridsync.gui.view import View
 from gridsync.gui.welcome import WelcomeDialog
 from gridsync.msg import error, info
 from gridsync.recovery import RecoveryKeyExporter
+from gridsync.util import strip_html_tags
 
 
 class ComboBox(QComboBox):
@@ -279,7 +280,7 @@ class MainWindow(QMainWindow):
 
     def on_message_received(self, gateway, message):
         title = "New message from {}".format(gateway.name)
-        self.gui.show_message(title, message)
+        self.gui.show_message(title, strip_html_tags(message))
         if self.isVisible():
             self.show_news_message(gateway, title, message)
         else:

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -280,7 +280,10 @@ class MainWindow(QMainWindow):
 
     def on_message_received(self, gateway, message):
         title = "New message from {}".format(gateway.name)
-        self.gui.show_message(title, strip_html_tags(message))
+        self.gui.show_message(
+            title,
+            strip_html_tags(message.replace('<p>', '\n\n'))
+        )
         if self.isVisible():
             self.show_news_message(gateway, title, message)
         else:

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -60,7 +60,7 @@ def humanized_list(list_, kind='files'):
                                             len(list_) - 2, kind)
 
 
-class _TagStripper(HTMLParser):
+class _TagStripper(HTMLParser):  # pylint: disable=abstract-method
     def __init__(self):
         super().__init__()
         self.data = []

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from binascii import hexlify, unhexlify
+from html.parser import HTMLParser
 
 
 B58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
@@ -57,3 +58,21 @@ def humanized_list(list_, kind='files'):
         return "{}, {}, and {}".format(*list_)
     return "{}, {}, and {} other {}".format(list_[0], list_[1],
                                             len(list_) - 2, kind)
+
+
+class _TagStripper(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.data = []
+
+    def handle_data(self, data):
+        self.data.append(data)
+
+    def get_data(self):
+        return ''.join(self.data)
+
+
+def strip_html_tags(s):
+    ts = _TagStripper()
+    ts.feed(s)
+    return ts.get_data()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,8 @@ from binascii import hexlify, unhexlify
 
 import pytest
 
-from gridsync.util import b58encode, b58decode, humanized_list
+from gridsync.util import (
+    b58encode, b58decode, humanized_list, strip_html_tags)
 
 
 # From https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
@@ -48,3 +49,11 @@ def test_b58decode_value_error():
 ])
 def test_humanized_list(items, kind, humanized):
     assert humanized_list(items, kind) == humanized
+
+
+@pytest.mark.parametrize("s,expected", [
+    ['1<p>2<br>3', '123'],
+    ['<a href="https://example.org">link</a>', 'link']
+])
+def test_strip_html_tags(s, expected):
+    assert strip_html_tags(s) == expected


### PR DESCRIPTION
A minor follow-up/improvement to #192: Qt5's `QMessageBox` will correctly render HTML tags included in newscap messages but native desktop notification popup windows will not. In order to make the text in desktop notification popup windows render similarly to the text shown in QMessageBoxes, this PR replaces HTML `<p>` tags with newlines and strips other tags from newscap messages (using the python standard library's `html.parser.HTMLParser`), thereby preventing un-rendered HTML from showing up in desktop notifications.