### PR TITLE
Disable MainWindow toolbar context menu

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -92,6 +92,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(APP_NAME)
         self.setMinimumSize(QSize(600, 400))
         self.setUnifiedTitleAndToolBarOnMac(True)
+        self.setContextMenuPolicy(Qt.NoContextMenu)
 
         self.shortcut_new = QShortcut(QKeySequence.New, self)
         self.shortcut_new.activated.connect(self.show_welcome_dialog)


### PR DESCRIPTION
This removes the default context menu on toolbars that allows them
to be shown/hidden, thereby ensuring that the the toolbar remains
visible at all times.

Closes #215