### PR TITLE
Add support for macOS Mojave's "dark mode"

### DIFF
--- a/gridsync/gui/color.py
+++ b/gridsync/gui/color.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from PyQt5.QtGui import QColor
+
+
+class BlendedColor(QColor):
+    def __init__(self, color_a, color_b, pct_a=0.5):
+        super(QColor, self).__init__()
+        pct_b = 1.0 - pct_a
+        self.setRgb(
+            pct_a * color_a.red() + pct_b * color_b.red(),
+            pct_a * color_a.green() + pct_b * color_b.green(),
+            pct_a * color_a.blue() + pct_b * color_b.blue(),
+            pct_a * color_a.alpha() + pct_b * color_b.alpha()
+        )

--- a/gridsync/gui/color.py
+++ b/gridsync/gui/color.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QColor
 
 class BlendedColor(QColor):
     def __init__(self, color_a, color_b, pct_a=0.5):
-        super(QColor, self).__init__()
+        super().__init__()
         pct_b = 1.0 - pct_a
         self.setRgb(
             pct_a * color_a.red() + pct_b * color_b.red(),

--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -55,7 +55,10 @@ class HistoryItemWidget(QWidget):
 
         self.details_label = QLabel()
         self.details_label.setFont(Font(10))
-        self.details_label.setStyleSheet('color: grey')
+        palette = self.palette()
+        dimmer_grey = BlendedColor(
+            palette.text().color(), palette.base().color(), 0.6).name()
+        self.details_label.setStyleSheet('color: {}'.format(dimmer_grey))
 
         self.button = QPushButton()
         self.button.setIcon(QIcon(resource('dots-horizontal-triple.png')))

--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import (
 
 from gridsync import resource
 from gridsync.desktop import open_enclosing_folder, open_path
+from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
 from gridsync.gui.status import StatusPanel
 
@@ -118,8 +119,10 @@ class HistoryListWidget(QListWidget):
         self.deduplicate = deduplicate
         self.max_items = max_items
 
-        self.base_color = self.palette().base().color()
-        self.highlighted_color = QColor("#E6F1F7")  # TODO: Get from theme?
+        palette = self.palette()
+        self.base_color = palette.base().color()
+        self.highlighted_color = BlendedColor(
+            self.base_color, palette.highlight().color(), 0.88)  # Was #E6F1F7
         self.highlighted = None
 
         self.action_icon = QIcon(resource('dots-horizontal-triple.png'))

--- a/gridsync/gui/history.py
+++ b/gridsync/gui/history.py
@@ -6,7 +6,7 @@ import time
 
 from humanize import naturalsize, naturaltime
 from PyQt5.QtCore import QFileInfo, QTimer, Qt
-from PyQt5.QtGui import QColor, QCursor, QIcon, QPixmap
+from PyQt5.QtGui import QCursor, QIcon, QPixmap
 from PyQt5.QtWidgets import (
     QAction, QAbstractItemView, QFileIconProvider, QGridLayout, QLabel,
     QListWidgetItem, QListWidget, QMenu, QPushButton, QSizePolicy, QSpacerItem,

--- a/gridsync/gui/invite.py
+++ b/gridsync/gui/invite.py
@@ -17,6 +17,7 @@ from wormhole.errors import (
 from gridsync import resource, APP_NAME
 from gridsync.desktop import get_clipboard_modes, get_clipboard_text
 from gridsync.errors import UpgradeRequiredError
+from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
 from gridsync.invite import wordlist, is_valid_code
 from gridsync.tor import get_tor
@@ -131,7 +132,11 @@ class InviteCodeWidget(QWidget):
 
         self.label = QLabel("Enter invite code:")
         self.label.setFont(Font(14))
-        self.label.setStyleSheet("color: grey")
+        p = self.palette()
+        dimmer_grey = BlendedColor(
+            p.windowText().color(), p.window().color()).name()
+        self.label.setStyleSheet("color: {}".format(dimmer_grey))
+
         self.label.setAlignment(Qt.AlignCenter)
 
         self.code_info_text = (

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import (
 from twisted.internet import reactor
 
 from gridsync import resource, APP_NAME, config_dir, settings
+from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
 from gridsync.gui.history import HistoryView
 from gridsync.gui.pixmap import CompositePixmap
@@ -215,14 +216,17 @@ class MainWindow(QMainWindow):
         recovery_button.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
 
         self.toolbar = self.addToolBar('')
+        p = self.palette()
+        dimmer_grey = BlendedColor(
+            p.windowText().color(), p.window().color(), 0.7).name()
         if sys.platform != 'darwin':
             self.toolbar.setStyleSheet("""
-                QToolBar { border: 0px }
-                QToolButton { color: rgb(50, 50, 50) }
-            """)
+                QToolBar {{ border: 0px }}
+                QToolButton {{ color: {} }}
+            """.format(dimmer_grey))
         else:
             self.toolbar.setStyleSheet(
-                "QToolButton { color: rgb(50, 50, 50) }")
+                "QToolButton {{ color: {} }}".format(dimmer_grey))
         self.toolbar.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         self.toolbar.setIconSize(QSize(24, 24))
         self.toolbar.setMovable(False)

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -17,6 +17,7 @@ from gridsync.preferences import get_preference
 from gridsync.util import humanized_list
 
 
+
 class Model(QStandardItemModel):
     def __init__(self, view):
         super(Model, self).__init__(0, 5)
@@ -286,7 +287,6 @@ class Model(QStandardItemModel):
             item.setForeground(QColor('gray'))
 
     def unfade_row(self, folder_name):
-        default_foreground = QStandardItem().foreground()
         folder_item = self.findItems(folder_name)[0]
         row = folder_item.row()
         for i in range(4):
@@ -294,7 +294,7 @@ class Model(QStandardItemModel):
             font = item.font()
             font.setItalic(False)
             item.setFont(font)
-            item.setForeground(default_foreground)
+            item.setForeground(self.view.palette().text())
 
     @pyqtSlot(str)
     def on_sync_started(self, folder_name):

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -130,7 +130,10 @@ class Model(QStandardItemModel):
         if sys.platform == 'darwin':
             # See: https://bugreports.qt.io/browse/QTBUG-12717
             action_bar.setStyleSheet(
-                'background-color: white; border: 0px white')
+                'background-color: {0}; border: 0px {0}'.format(
+                    self.view.palette().base().color().name()
+                )
+            )
         action_bar_action = QAction(self.icon_action, "Action...", self)
         action_bar_action.setStatusTip("Action...")
         action_bar_action.triggered.connect(self.view.on_right_click)

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -17,7 +17,6 @@ from gridsync.preferences import get_preference
 from gridsync.util import humanized_list
 
 
-
 class Model(QStandardItemModel):
     def __init__(self, view):
         super(Model, self).__init__(0, 5)

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QWidget)
 
 from gridsync import resource
+from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
 from gridsync.gui.menu import Menu
 from gridsync.gui.pixmap import Pixmap
@@ -39,12 +40,15 @@ class StatusPanel(QWidget):
         )
 
         self.status_label = QLabel()
-        self.status_label.setStyleSheet("color: dimgrey")
+        p = self.palette()
+        dimmer_grey = BlendedColor(
+            p.windowText().color(), p.window().color(), 0.6).name()
+        self.status_label.setStyleSheet("color: {}".format(dimmer_grey))
         self.status_label.setFont(Font(10))
 
         self.on_sync_state_updated(0)
 
-        self.setStyleSheet('QToolButton { color: dimgrey; border: none; }')
+        self.setStyleSheet('QToolButton { border: none }')
         #self.setStyleSheet("""
         #    QToolButton { color: dimgrey; border: none; }
         #    QToolButton:hover {

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -17,8 +17,9 @@ from gridsync import resource, APP_NAME
 from gridsync import settings as global_settings
 from gridsync.invite import InviteReceiver
 from gridsync.errors import UpgradeRequiredError
-from gridsync.gui.invite import InviteCodeWidget, show_failure
+from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
+from gridsync.gui.invite import InviteCodeWidget, show_failure
 from gridsync.gui.pixmap import Pixmap
 from gridsync.gui.widgets import TahoeConfigForm
 from gridsync.recovery import RecoveryKeyImporter
@@ -48,7 +49,10 @@ class WelcomeWidget(QWidget):
         self.slogan = QLabel("<i>{}</i>".format(
             application_settings.get('description', '')))
         self.slogan.setFont(Font(12))
-        self.slogan.setStyleSheet("color: grey")
+        p = self.palette()
+        dimmer_grey = BlendedColor(
+            p.windowText().color(), p.window().color()).name()
+        self.slogan.setStyleSheet("color: {}".format(dimmer_grey))
         self.slogan.setAlignment(Qt.AlignCenter)
         if logo_icon:
             self.slogan.hide()
@@ -150,7 +154,10 @@ class ProgressBarWidget(QWidget):
         self.progressbar.setValue(0)
 
         self.message = QLabel()
-        self.message.setStyleSheet("color: grey")
+        p = self.palette()
+        dimmer_grey = BlendedColor(
+            p.windowText().color(), p.window().color()).name()
+        self.message.setStyleSheet("color: {}".format(dimmer_grey))
         self.message.setAlignment(Qt.AlignCenter)
 
         self.finish_button = QPushButton("Finish")

--- a/misc/gridsync.spec
+++ b/misc/gridsync.spec
@@ -91,6 +91,7 @@ app = BUNDLE(
         'LSBackgroundOnly': True,
         'LSUIElement': True,
         'NSHighResolutionCapable': True,
+        'NSRequiresAquaSystemAppearance': False,
     }
 )
 


### PR DESCRIPTION
This PR adds basic support for macOS 10.14/Mojave's "dark mode", by explicitly disabling the `NSRequiresAquaSystemAppearance` app bundle setting (via "Info.plist") and fixing the most egregious color/stylesheet-related issues that prevented dark mode from being considered "supported" earlier.

There are additional optimizations that could be made here still (for example, by providing both "light" and "dark" variants of various image files/resources and loading the appropriate variant to further improve contrast as needed) but, for now, Mojave's dark mode should at least be usable.

Closes #213 