### PR TITLE
Add support for notification "badges"

### DIFF
--- a/gridsync/gui/__init__.py
+++ b/gridsync/gui/__init__.py
@@ -16,7 +16,7 @@ class Gui():
         self.preferences_window = PreferencesWindow()
         self.systray = SystemTrayIcon(self)
         self.debug_exporter = DebugExporter(core)
-        self.unread_messages = ['test1', 'test2']  # XXX
+        self.unread_messages = []
 
     def show_message(self, title, message, duration=5000):
         notify(self.systray, title, message, duration)

--- a/gridsync/gui/__init__.py
+++ b/gridsync/gui/__init__.py
@@ -16,6 +16,7 @@ class Gui():
         self.preferences_window = PreferencesWindow()
         self.systray = SystemTrayIcon(self)
         self.debug_exporter = DebugExporter(core)
+        self.unread_messages = ['test1', 'test2']  # XXX
 
     def show_message(self, title, message, duration=5000):
         notify(self.systray, title, message, duration)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -48,6 +48,9 @@ class BadgedPixmap(QPixmap):
         base_size = base_pixmap.size()
         base_max = min(base_size.height(), base_size.width())
         if not base_max:
+            # Because gridsync.gui.systray.animation.currentPixmap() returns
+            # a blank pixmap when unpausing the animation for the first time.
+            # Returning early to prevents QPainter from spewing warnings.
             self.swap(base_pixmap)
             return
 

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -68,7 +68,7 @@ class BadgedPixmap(QPixmap):
             font.setPixelSize(badge_max - pen_width)
             painter.setFont(font)
             painter.setPen(Qt.white)
-            painter.drawText(rect, Qt.AlignCenter, text)
+            painter.drawText(rect, Qt.AlignCenter, str(text))
 
         painter.end()
         self.swap(base_pixmap)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor, QPainter, QPixmap
+from PyQt5.QtCore import QRect, Qt
+from PyQt5.QtGui import QBrush, QColor, QPainter, QPen, QPixmap
 
 from gridsync import resource
 
@@ -32,4 +31,44 @@ class CompositePixmap(QPixmap):
             painter = QPainter(base_pixmap)
             painter.drawPixmap(width, height, overlay_pixmap)
             painter.end()
+        self.swap(base_pixmap)
+
+
+class BadgedPixmap(QPixmap):
+
+    TopLeft = (0, 0)
+    TopRight = (1, 0)
+    BottomLeft = (0, 1)
+    BottomRight = (1, 1)
+
+    def __init__(self, pixmap, text, size=0.5, corner=BottomRight):
+        super().__init__()
+
+        base_pixmap = QPixmap(pixmap)
+        base_size = base_pixmap.size()
+        base_max = min(base_size.height(), base_size.width())
+
+        badge_max = base_max * size
+        pen_width = badge_max * 0.05
+        rect = QRect(
+            base_max * max(corner[0] - size, 0) + pen_width,
+            base_max * max(corner[1] - size, 0) + pen_width,
+            badge_max - pen_width,
+            badge_max - pen_width
+        )
+
+        painter = QPainter(base_pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setPen(QPen(Qt.red, pen_width))
+        painter.setBrush(QBrush(Qt.red))
+        painter.drawEllipse(rect)
+
+        if text:
+            font = painter.font()
+            font.setPixelSize(badge_max - pen_width)
+            painter.setFont(font)
+            painter.setPen(Qt.white)
+            painter.drawText(rect, Qt.AlignCenter, text)
+
+        painter.end()
         self.swap(base_pixmap)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -47,6 +47,9 @@ class BadgedPixmap(QPixmap):
         base_pixmap = QPixmap(pixmap)
         base_size = base_pixmap.size()
         base_max = min(base_size.height(), base_size.width())
+        if not base_max:
+            self.swap(base_pixmap)
+            return
 
         badge_max = base_max * size
         pen_width = badge_max * 0.05

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -37,13 +37,15 @@ class SystemTrayIcon(QSystemTrayIcon):
             self.animation.setPaused(False)
             pixmap = self.animation.currentPixmap()
             if self.gui.unread_messages:
-                pixmap = BadgedPixmap(pixmap, len(self.gui.unread_messages))
+                pixmap = BadgedPixmap(
+                    pixmap, len(self.gui.unread_messages), 0.6
+                )
             self.setIcon(QIcon(pixmap))
         else:
             self.animation.setPaused(True)
             if self.gui.unread_messages:
                 self.setIcon(QIcon(BadgedPixmap(
-                    self.app_pixmap, len(self.gui.unread_messages)
+                    self.app_pixmap, len(self.gui.unread_messages), 0.6
                 )))
             else:
                 self.setIcon(self.app_icon)


### PR DESCRIPTION
In fulfillment of #226, this PR adds a `BadgedPixmap` class that overlays a red/circular "badge" onto an arbitrary pixmap that may contain text, at a relative size, and in a corner of the developer's choice. This is intended to be used to highlight the presence of pending or important information within the application, for example, like so (on macOS):

![badge-mac](https://user-images.githubusercontent.com/882430/60231468-40ef7880-9867-11e9-9b13-b685b8f19bd9.png)

Note that this is mostly intended for future purposes; for now, a notification "badge" will only be displayed to signal a pending/unread "newscap" message (however, the same functionality may be used for other/additional purposes later on -- e.g., to communicate software updates, to highlight a magic-folder conflict, to remind users to export a Recovery Key, to notify of an expiring subscription to a commercial service provider, and so on).