### PR TITLE
Add support for building via Vagrant/VirtualBox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,24 @@ dmg:
 	python -m pip install dmgbuild && \
 	python misc/call_dmgbuild.py
 
+vagrant-linux:
+	pushd vagrantfiles/linux && \
+	vagrant up ; \
+	popd
+
+vagrant-macos:
+	pushd vagrantfiles/macos && \
+	vagrant up ; \
+	popd
+
+vagrant-windows:
+	rm vagrantfiles/windows/GridsyncSource.zip ; \
+	python3 scripts/make_source_zip.py . vagrantfiles/windows/GridsyncSource.zip && \
+	pushd vagrantfiles/windows && \
+	vagrant up ; \
+	rm GridsyncSource.zip ; \
+	popd
+
 # https://developer.apple.com/library/archive/technotes/tn2206/_index.html
 codesign-app:
 	codesign --force --deep -s "Developer ID Application: Christopher Wood" dist/Gridsync.app

--- a/README.rst
+++ b/README.rst
@@ -125,10 +125,31 @@ Users of other distributions and operating systems should modify the above steps
 
 .. _make.bat: https://github.com/gridsync/gridsync/blob/master/make.bat
 
-Alternatively, users can build a more portable binary distribution of Gridsync and Tahoe-LAFS (suitable for running on other machines of the same architecture) by installing the above dependencies and typing `make` in the top-level of the source tree. This will create a "frozen" distribution of Gridsync and all of its dependencies (including python and Tahoe-LAFS) using `PyInstaller`_, placing the resultant executable files/installers in the `dist/` subdirectory.
+Alternatively, users can use `PyInstaller`_ to generate a more "portable" binary distribution of Gridsync and Tahoe-LAFS (suitable for running on other machines of the same platform) by installing the required dependencies and typing `make` in the top-level of the source tree. This will create a standalone executable distribution of Gridsync and all of its dependencies (including a "frozen" python interpreter and Tahoe-LAFS), placing the resultant files/installers in the `dist/` subdirectory.
 
 .. _PyInstaller: http://www.pyinstaller.org/
 
+Note, however, that PyInstaller-generated binaries are typically `not backward-compatible`_; a PyInstaller executable that was built on a newer GNU/Linux distribution, for example (i.e., with a more recent version of `glibc`) will not run on older distributions. Accordingly, if you intend to distribute Gridsync binaries for use on a wide range operating system versions, it is recommended that you build the application on as old of a system as is reasonable for a given platform (i.e., one which can build and run Gridsync but which still receives security updates). Presently, CentOS 7, macOS "Sierra" (10.12), and Windows Server 2012 R2 arguably constitute the most suitable candidates for GNU/Linux, macOS, and Windows build systems respectively (insofar as binaries generated on these systems will be forward-compatible with all others in that platform-category that are still supported upstream).
+
+.. _not backward-compatible: https://pyinstaller.readthedocs.io/en/latest/usage.html#platform-specific-notes
+
+To help facilitate the testing, building, and distribution of forward-compatible binaries -- as well as to enable a crude form of "cross-compilation" -- a set of custom-tailored "builder" `Vagrantfiles`_ have been provided inside the Gridsync source tree; users or developers with `Vagrant`_ and `VirtualBox`_ installed[*]_ can automatically provision a complete Gridsync build environment that produces forward-compatible binaries via the following commands:
+
+.. code-block:: shell-session
+
+    make vagrant-linux
+    make vagrant-macos
+    make vagrant-windows
+
+
+These will download and configure a suitable virtual machine for the target platform (from the `public Vagrant Boxes catalog`_), provision it with all required dependencies (such compilers/SDKs, python interpreters, X11 libraries, etc.), copy the Gridsync source code into the target VM, run the Gridsync test suite, and compile a final PyInstaller-generated binary package suitable for distribution (the result of which can be found in the `~/gridsync/dist` directory of the guest VM).
+
+.. _Vagrantfiles: https://github.com/gridsync/gridsync/tree/master/vagrantfiles
+.. _Vagrant: https://www.vagrantup.com/
+.. _VirtualBox: https://www.virtualbox.org/
+.. _public Vagrant Boxes catalog: https://app.vagrantup.com/boxes/search
+
+.. [*] Note that in order to get Vagrant/VirtualBox working properly, users of GNU/Linux may need to add the current user's name to the local "vboxusers" group, while users experiencing issues with Windows guests may need to install some combination of the `winrm`, `winrm-fs`, or `winrm-elevated` Vagrant plugins (via the `vagrant plugin install winrm winrm-fs winrm-elevated` command). For further assistance with installing, configuring, or using Vagrant and/or VirtualBox on your system, please consult the appropriate upstream documentation and/or help forums. In addition, please note that Gridsync project can make no guarantees about the security or safety of public Vagrant "Boxes"; please exercise appropriate caution when relying upon third-party software.
 
 **Development builds:**
 

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Note, however, that PyInstaller-generated binaries are typically `not backward-c
 
 .. _not backward-compatible: https://pyinstaller.readthedocs.io/en/latest/usage.html#platform-specific-notes
 
-To help facilitate the testing, building, and distribution of forward-compatible binaries -- as well as to enable a crude form of "cross-compilation" -- a set of custom-tailored "builder" `Vagrantfiles`_ have been provided inside the Gridsync source tree; users or developers with `Vagrant`_ and `VirtualBox`_ installed[*]_ can automatically provision a complete Gridsync build environment that produces forward-compatible binaries via the following commands:
+To help facilitate the testing, building, and distribution of forward-compatible binaries -- as well as to enable a crude form of "cross-compilation" -- a set of custom-tailored "builder" `Vagrantfiles`_ have been provided inside the Gridsync source tree; users or developers with `Vagrant`_ and `VirtualBox`_ installed [*]_ can automatically provision a complete Gridsync build environment that produces forward-compatible binaries via the following commands:
 
 .. code-block:: shell-session
 

--- a/make.bat
+++ b/make.bat
@@ -38,6 +38,9 @@ if "%1"=="test" call :test
 if "%1"=="frozen-tahoe" call :frozen-tahoe
 if "%1"=="pyinstaller" call :pyinstaller
 if "%1"=="installer" call :installer
+if "%1"=="vagrant-linux" call :vagrant-linux
+if "%1"=="vagrant-macos" call :vagrant-macos
+if "%1"=="vagrant-windows" call :vagrant-windows
 if "%1"=="all" call :all
 if "%1"=="" call :all
 goto :eof
@@ -89,6 +92,25 @@ goto :eof
 call copy misc\InnoSetup5.iss .
 call copy misc\InnoSetup6.iss .
 call "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" .\InnoSetup6.iss || "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" .\InnoSetup5.iss
+goto :eof
+
+:vagrant-linux
+call pushd .\vagrantfiles\linux
+call vagrant up
+call popd
+goto :eof
+
+:vagrant-macos
+call pushd .\vagrantfiles\macos
+call vagrant up
+call popd
+goto :eof
+
+:vagrant-windows
+call del .\vagrantfiles\GridsyncSource.zip & py -3 .\scripts\make_source_zip.py . .\vagrantfiles\windows\GridsyncSource.zip
+call pushd .\vagrantfiles\windows
+call vagrant up
+call popd
 goto :eof
 
 :all

--- a/scripts/make_source_zip.py
+++ b/scripts/make_source_zip.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import shutil
+import sys
+import tempfile
+
+
+_, p = tempfile.mkstemp()
+shutil.make_archive(p, 'zip', sys.argv[1])
+shutil.move(p + '.zip', sys.argv[2])

--- a/vagrantfiles/linux/Vagrantfile
+++ b/vagrantfiles/linux/Vagrantfile
@@ -1,0 +1,58 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.define "gridsync-linux"
+  config.vm.box = "centos/7"
+  config.vm.synced_folder ".", "/vagrant"
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+    vb.cpus = 2
+    # Forward YubiKey to guest VM for signing
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ['usbfilter', 'add', '0',
+      '--target', :id,
+      '--name', "YubiKey",
+      '--manufacturer', "Yubico",
+      '--vendorid', "0x1050",
+      '--productid', "0x0407",
+      '--product', "Yubico YubiKey OTP+FIDO+CCID"]
+  end
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo yum -y update
+    sudo yum -y install make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb gcc-c++
+    sudo yum -y groupinstall "GNOME Desktop"
+    sudo systemctl enable gdm
+    sudo sh -c 'echo -e "[daemon]\nAutomaticLogin=vagrant\nAutomaticLoginEnable=True" > /etc/gdm/custom.conf'
+    sudo systemctl set-default graphical.target
+    sudo systemctl isolate graphical.target
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+    source ~/.bash_profile
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 2.7.16
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.3
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.8
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.7
+    pyenv rehash
+    pyenv global 2.7.16 3.7.3 3.6.8 3.5.7
+    python2 -m pip install --upgrade setuptools pip
+    python3 -m pip install --upgrade setuptools pip tox
+  SHELL
+  config.vm.provision "file", source: "../..", destination: "~/gridsync"
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    cd ~/gridsync && CI=true make test && make
+    ls -al ~/gridsync/dist
+  SHELL
+  if ENV["BUILDBOT_HOST"]
+    config.vm.provision "shell", privileged: false, inline: "python2 -m pip install buildbot-worker"
+    config.vm.provision "shell" do |s|
+      s.privileged = false
+      s.inline = "buildbot-worker create-worker ~/buildbot $1 $2 $3"
+      s.args   = "#{ENV['BUILDBOT_HOST']} #{ENV['BUILDBOT_NAME']} #{ENV['BUILDBOT_PASS']}"
+    end
+    config.vm.provision "shell", privileged: false, inline: "buildbot-worker restart ~/buildbot"
+  end
+end

--- a/vagrantfiles/macos/Vagrantfile
+++ b/vagrantfiles/macos/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.define "gridsync-macos"
+  config.vm.box = "jhcook/macos-sierra"
+  config.vm.box_url = "https://vagrantcloud.com/jhcook/boxes/macos-sierra/versions/10.12.6/providers/virtualbox.box"
+  config.vm.box_download_checksum = "6716006846b256acefc18c3d76d794f2253ac156d55e464742f87148828b88ed"
+  config.vm.box_download_checksum_type = "sha256"
+  #ipfs_cid = "QmZ4rhc34esunzbWhauiDiiozhamjK81zXotpQpB6199oa"
+  #config.vm.box_url = [
+  #  "http://127.0.0.1:8080/ipfs/#{ipfs_cid}?filename=virtualbox.box",
+  #  "https://gateway.ipfs.io/ipfs/#{ipfs_cid}?filename=virtualbox.box",
+  #  "https://cloudflare-ipfs.com/ipfs/#{ipfs_cid}?filename=virtualbox.box"
+  #]
+  # "BSD-based guests do not support the VirtualBox filesystem at this time."
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+    vb.cpus = 2
+    # Disable USB 2.0; needed to run without proprietary Oracle Extension Pack
+    vb.customize ["modifyvm", :id, "--usbehci", "off"]
+    # Forward YubiKey to guest VM for signing
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ['usbfilter', 'add', '0',
+      '--target', :id,
+      '--name', "YubiKey",
+      '--manufacturer', "Yubico",
+      '--vendorid', "0x1050",
+      '--productid', "0x0407",
+      '--product', "Yubico YubiKey OTP+FIDO+CCID"]
+  end
+  config.vm.provision "shell", inline: <<-SHELL
+    # Instantiating a QApplication without first logging in will fail (with the
+    # error message "_RegisterApplication(), FAILED TO establish the default
+    # connection to the WindowServer, _CGSDefaultConnection() is NULL."), so
+    # wait for the login screen to load and enter the default vagrant password.
+    sleep 10
+    osascript -e 'tell application "System Events" to key code 126'
+    sleep 1
+    osascript -e 'tell application "System Events" to keystroke return'
+    sleep 1
+    osascript -e 'tell application "System Events" to keystroke "vagrant"'
+    sleep 1
+    osascript -e 'tell application "System Events" to keystroke return'
+    # Add the "vagrant" password to to /etc/kcpassword and enable auto-login.
+    # Encoding hack courtesy of https://github.com/timsutton/osx-vm-templates
+    #echo '\x0b\xc3\xa85Q\xc2\xb3\xc3\x92\xc2\xa9\xc3\xaa\xc2\xa3\xc2\xb9\x1f' > /etc/kcpassword
+    #chmod 600 /etc/kcpassword
+    #sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser "vagrant"
+    #rm -rf ~vagrant/Library/Keychains/login.keychain*
+  SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    brew -v analytics off
+    brew install openssl readline sqlite3 xz zlib pyenv
+	brew cask install opensc
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+    source ~/.bash_profile
+    PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.16
+    PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.7.3
+    PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.6.8
+    PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.5.7
+    pyenv rehash
+    pyenv global 2.7.16 3.7.3 3.6.8 3.5.7
+    python2 -m pip install --upgrade setuptools pip
+    python3 -m pip install --upgrade setuptools pip tox
+  SHELL
+  config.vm.provision "file", source: "../..", destination: "~/gridsync"
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    cd ~/gridsync && CI=true make test && make
+    ls -al ~/gridsync/dist
+  SHELL
+  if ENV["BUILDBOT_HOST"]
+    config.vm.provision "shell", privileged: false, inline: "python2 -m pip install buildbot-worker"
+    config.vm.provision "shell" do |s|
+      s.privileged = false
+      s.inline = "buildbot-worker create-worker ~/buildbot $1 $2 $3"
+      s.args   = "#{ENV['BUILDBOT_HOST']} #{ENV['BUILDBOT_NAME']} #{ENV['BUILDBOT_PASS']}"
+    end
+    config.vm.provision "shell", privileged: false, inline: "buildbot-worker restart ~/buildbot"
+  end
+end

--- a/vagrantfiles/windows/Vagrantfile
+++ b/vagrantfiles/windows/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.define "gridsync-windows"
+  config.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
+  config.vm.box_url = "https://vagrantcloud.com/opentable/boxes/win-2012r2-standard-amd64-nocm/versions/1.0.0/providers/virtualbox.box"
+  config.vm.box_download_checksum = "36a059004f909a68831416cbfee0c836ce416cd4c4f6805b47ad1b6d0184d0ca"
+  config.vm.box_download_checksum_type = "sha256"
+  #ipfs_cid = "QmdPfN4HhxiHXwVgHYX3yoC6jEFs1hM1z3FjmuLdCogMkd"
+  #config.vm.box_url = [
+  #  "http://127.0.0.1:8080/ipfs/#{ipfs_cid}?filename=virtualbox.box",
+  #  "https://gateway.ipfs.io/ipfs/#{ipfs_cid}?filename=virtualbox.box",
+  #  "https://cloudflare-ipfs.com/ipfs/#{ipfs_cid}?filename=virtualbox.box"
+  #]
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+    vb.cpus = 2
+    # Forward YubiKey to guest VM for signing
+    vb.customize ['modifyvm', :id, '--usb', 'on']
+    vb.customize ['usbfilter', 'add', '0',
+      '--target', :id,
+      '--name', "YubiKey",
+      '--manufacturer', "Yubico",
+      '--vendorid', "0x1050",
+      '--productid', "0x0407",
+      '--product', "Yubico YubiKey OTP+FIDO+CCID"]
+  end
+  config.vm.provision "shell", reboot: true, inline: <<-SHELL
+    # Some CLI applications like `pip` and `curl` cannot verify certificates
+    # until Internet Explorer's "first-launch configuration" has completed, so
+    # temporarily add an IE shortcut to the "Startup" Start Menu to force IE
+    # to run -- and the process to complete -- after the first reboot...
+    cmd /c mklink '%AppData%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\iexplore.lnk' '%ProgramFiles(x86)%\\Internet Explorer\\iexplore.exe'
+    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    choco install -y --no-progress --require-checksums --execution-timeout 7200 kb2919355
+  SHELL
+  config.vm.provision "shell", reboot: true, inline: <<-SHELL
+    choco install -y --no-progress --require-checksums git
+    choco install -y --no-progress --require-checksums python2
+    choco install -y --no-progress --require-checksums -m python3 --version 3.7.3
+    choco install -y --no-progress --require-checksums -m python3 --version 3.6.8
+    choco install -y --no-progress --require-checksums -m python3 --version 3.5.4
+    choco install -y --no-progress --require-checksums vcpython27
+    choco install -y --no-progress --require-checksums --execution-timeout 7200 vcbuildtools --version 2015.4 -ia "/InstallSelectableItems Win81SDK_CppBuildSKUV1;Win10SDK_VisibleV1"
+    choco install -y --no-progress --require-checksums windows-sdk-10
+    choco install -y --no-progress --require-checksums innosetup
+    choco list --local-only
+    py -2 -m pip install --upgrade setuptools pip
+    py -3 -m pip install --upgrade setuptools pip tox
+    cmd /c del '%AppData%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\iexplore.lnk'
+  SHELL
+  #config.vm.provision "file", source: "GridsyncSource.zip", destination: "~/"
+  config.vm.provision "shell", env: {"CI" => "true"}, inline: <<-SHELL
+    cd ~
+    py -m zipfile -e C:\\vagrant\\GridsyncSource.zip .\gridsync
+    cd .\gridsync
+    .\\make.bat test
+    .\\make.bat
+    ls .\\dist
+  SHELL
+  if ENV["BUILDBOT_HOST"]
+    config.vm.provision "shell", inline: "py -2 -m pip install --upgrade buildbot-worker pywin32"
+    config.vm.provision "shell" do |s|
+      s.privileged = false
+      s.inline = "C:\\Python27\\Scripts\\buildbot-worker.exe create-worker C:\\Users\\Vagrant\\buildbot $Args"
+      s.args   = "#{ENV['BUILDBOT_HOST']} #{ENV['BUILDBOT_NAME']} #{ENV['BUILDBOT_PASS']}"
+    end
+    config.vm.provision "shell", reboot: true, inline: <<-SHELL
+      "C:\\Python27\\Scripts\\buildbot-worker.exe start C:\\Users\\vagrant\\buildbot" | Out-File -FilePath "C:\\Users\\vagrant\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\run-buildbot-worker.bat" -Encoding Ascii
+    SHELL
+  end
+end

--- a/vagrantfiles/windows/Vagrantfile
+++ b/vagrantfiles/windows/Vagrantfile
@@ -54,8 +54,8 @@ Vagrant.configure("2") do |config|
   #config.vm.provision "file", source: "GridsyncSource.zip", destination: "~/"
   config.vm.provision "shell", env: {"CI" => "true"}, inline: <<-SHELL
     cd ~
-    py -m zipfile -e C:\\vagrant\\GridsyncSource.zip .\gridsync
-    cd .\gridsync
+    py -m zipfile -e C:\\vagrant\\GridsyncSource.zip .\\gridsync
+    cd .\\gridsync
     .\\make.bat test
     .\\make.bat
     ls .\\dist


### PR DESCRIPTION
This PR adds a set of `Vagrantfile`s that, in conjunction with VirtualBox, can be used to effectively "cross-compile" strongly forward-compatible Gridsync binaries for each supported platform (via the newly-added the `make vagrant-linux`, `make vagrant-macos` and `make vagrant-windows` commands). See the relevant section of the updated README for more information.

Closes #230 