### PR TITLE
Update frozen/PyInstaller Tahoe-LAFS bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,12 @@ gif: pngs
 frozen-tahoe:
 	mkdir -p dist
 	mkdir -p build/tahoe-lafs
-	#git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
-	git clone https://github.com/crwood/tahoe-lafs.git build/tahoe-lafs
+	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	cp misc/tahoe.spec build/tahoe-lafs/pyinstaller.spec
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout 88ddd67c10be86524c05edcee5c3a38bdc70b89c && \
+	git checkout d6f0ce91233349759984b40fc721df7eef148f63 && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,6 @@ frozen-tahoe:
 	case `uname` in \
 		Darwin) python ../../scripts/maybe_rebuild_libsodium.py ;; \
 	esac &&	\
-	python -m pip install packaging && \
-	python -m pip install dis3 && \
 	python -m pip install --no-use-pep517 pyinstaller==3.5 && \
 	python -m pip list && \
 	export PYTHONHASHSEED=1 && \

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,13 @@ gif: pngs
 frozen-tahoe:
 	mkdir -p dist
 	mkdir -p build/tahoe-lafs
-	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
+	#git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
+	git clone https://github.com/crwood/tahoe-lafs.git build/tahoe-lafs
 	cp misc/tahoe.spec build/tahoe-lafs/pyinstaller.spec
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout ede9fc7b312a4a1b510e0d17e783de6de699fe9c && \
+	git checkout 88ddd67c10be86524c05edcee5c3a38bdc70b89c && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ frozen-tahoe:
 	case `uname` in \
 		Darwin) python ../../scripts/maybe_rebuild_libsodium.py ;; \
 	esac &&	\
-	python -m pip install --no-use-pep517 pyinstaller==3.5 && \
+	python -m pip install pyinstaller==3.5 && \
 	python -m pip list && \
 	export PYTHONHASHSEED=1 && \
 	pyinstaller pyinstaller.spec && \

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ frozen-tahoe:
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
 	pushd build/tahoe-lafs && \
-	git checkout 7263ceb1d112c6a90d90dcc6303eb425051fff50 && \
+	git checkout ede9fc7b312a4a1b510e0d17e783de6de699fe9c && \
 	python setup.py update_version && \
 	python -m pip install . && \
 	case `uname` in \

--- a/make.bat
+++ b/make.bat
@@ -70,8 +70,7 @@ call pushd .\build\tahoe-lafs
 call git checkout d6f0ce91233349759984b40fc721df7eef148f63
 call python setup.py update_version
 call python -m pip install .
-:: Adding --no-use-pep517 suggested by https://github.com/pypa/pip/issues/6163
-call python -m pip install --no-use-pep517 pyinstaller==3.5
+call python -m pip install pyinstaller==3.5
 call python -m pip list
 call set PYTHONHASHSEED=1
 call pyinstaller pyinstaller.spec

--- a/make.bat
+++ b/make.bat
@@ -64,11 +64,10 @@ call %PYTHON2% -m pip install --upgrade setuptools pip virtualenv
 call %PYTHON2% -m virtualenv --clear .\build\venv-tahoe
 call .\build\venv-tahoe\Scripts\activate
 call python -m pip install --upgrade setuptools pip
-::call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
-call git clone https://github.com/crwood/tahoe-lafs.git .\build\tahoe-lafs
+call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout 88ddd67c10be86524c05edcee5c3a38bdc70b89c
+call git checkout d6f0ce91233349759984b40fc721df7eef148f63
 call python setup.py update_version
 call python -m pip install pyrsistent==0.14.11
 call python -m pip install .

--- a/make.bat
+++ b/make.bat
@@ -69,7 +69,6 @@ call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
 call git checkout d6f0ce91233349759984b40fc721df7eef148f63
 call python setup.py update_version
-call python -m pip install pyrsistent==0.14.11
 call python -m pip install .
 :: Adding --no-use-pep517 suggested by https://github.com/pypa/pip/issues/6163
 call python -m pip install --no-use-pep517 pyinstaller==3.5

--- a/make.bat
+++ b/make.bat
@@ -71,7 +71,6 @@ call git checkout d6f0ce91233349759984b40fc721df7eef148f63
 call python setup.py update_version
 call python -m pip install pyrsistent==0.14.11
 call python -m pip install .
-call python -m pip install packaging
 :: Adding --no-use-pep517 suggested by https://github.com/pypa/pip/issues/6163
 call python -m pip install --no-use-pep517 pyinstaller==3.5
 call python -m pip list

--- a/make.bat
+++ b/make.bat
@@ -67,7 +67,7 @@ call python -m pip install --upgrade setuptools pip
 call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout 7263ceb1d112c6a90d90dcc6303eb425051fff50
+call git checkout ede9fc7b312a4a1b510e0d17e783de6de699fe9c
 call python setup.py update_version
 call python -m pip install pyrsistent==0.14.11
 call python -m pip install .

--- a/make.bat
+++ b/make.bat
@@ -64,10 +64,11 @@ call %PYTHON2% -m pip install --upgrade setuptools pip virtualenv
 call %PYTHON2% -m virtualenv --clear .\build\venv-tahoe
 call .\build\venv-tahoe\Scripts\activate
 call python -m pip install --upgrade setuptools pip
-call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
+::call git clone https://github.com/tahoe-lafs/tahoe-lafs.git .\build\tahoe-lafs
+call git clone https://github.com/crwood/tahoe-lafs.git .\build\tahoe-lafs
 call copy .\misc\tahoe.spec .\build\tahoe-lafs\pyinstaller.spec
 call pushd .\build\tahoe-lafs
-call git checkout ede9fc7b312a4a1b510e0d17e783de6de699fe9c
+call git checkout 88ddd67c10be86524c05edcee5c3a38bdc70b89c
 call python setup.py update_version
 call python -m pip install pyrsistent==0.14.11
 call python -m pip install .

--- a/misc/tahoe.spec
+++ b/misc/tahoe.spec
@@ -24,25 +24,13 @@ added_files = [
     ('src/allmydata/web/static/css/*', 'allmydata/web/static/css'),
     ('src/allmydata/web/static/img/*.png', 'allmydata/web/static/img')]
 
-hidden_imports = [
-    'allmydata.client',
-    'allmydata.introducer',
-    'allmydata.stats',
-    'cffi',
-    'characteristic',
-    'Crypto',
-    'packaging.specifiers',
-    'six.moves.html_parser',
-    'yaml',
-    'zfec'
-]
 
 a = Analysis(
     ['static/tahoe.py'],
     pathex=[],
     binaries=None,
     datas=added_files,
-    hiddenimports=hidden_imports,
+    hiddenimports=['cffi', 'characteristic'],
     hookspath=[],
     runtime_hooks=[],
     excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],


### PR DESCRIPTION
This PR updates and "pins" the frozen/PyInstaller builds of Tahoe-LAFS to a [much newer revision](https://github.com/tahoe-lafs/tahoe-lafs/commit/d6f0ce91233349759984b40fc721df7eef148f63) and removes a number of workarounds that appear to no longer be necessary as of the latest (3.5) release of PyInstaller.

Closes #237 