### PR TITLE
Disable fullscreen mode on macOS

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -95,6 +95,11 @@ class MainWindow(QMainWindow):
         self.setUnifiedTitleAndToolBarOnMac(True)
         self.setContextMenuPolicy(Qt.NoContextMenu)
 
+        if sys.platform == 'darwin':
+            # To disable the broken/buggy "full screen" mode on macOS.
+            # See https://github.com/gridsync/gridsync/issues/241
+            self.setWindowFlags(Qt.Dialog)
+
         self.shortcut_new = QShortcut(QKeySequence.New, self)
         self.shortcut_new.activated.connect(self.show_welcome_dialog)
 


### PR DESCRIPTION
Because this is poorly supported by Qt and can lead to a situation
in which the user cannot exit fullscreen mode by normal means.

Fixes #241