### PR TITLE
Add support for deploying AppImage packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ install:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target / || true; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get -y update; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get -y install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev libxkbcommon-x11-0; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then linuxdeploy --version; fi
   - rm -rf ~/.pyenv
   - git clone https://github.com/pyenv/pyenv.git ~/.pyenv
   - mkdir -p ~/.cache/pyenv/versions
@@ -54,11 +57,6 @@ install:
   - which python3.6 && python3.6 --version
   - python2 -m pip install --upgrade setuptools pip
   - python3 -m pip install --upgrade setuptools pip tox coveralls
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -v -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
-  - env | grep PATH
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ls -al ~/bin; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then linuxdeploy --help; fi
 script:
   - make test
   - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - which python3.6 && python3.6 --version
   - python2 -m pip install --upgrade setuptools pip
   - python3 -m pip install --upgrade setuptools pip tox coveralls
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy-x86_64.AppImage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -v -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy-x86_64.AppImage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
   - env | grep PATH
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ls -al ~/bin; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,14 @@ install:
   - which python3.6 && python3.6 --version
   - python2 -m pip install --upgrade setuptools pip
   - python3 -m pip install --upgrade setuptools pip tox coveralls
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy-x86_64.AppImage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
 script:
   - make test
   - make all
   - dist/Tahoe-LAFS/tahoe --version-and-path
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a dist/Gridsync/gridsync --version; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a dist/Gridsync.AppImage --version; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then dist/Gridsync.app/Contents/MacOS/Gridsync --version; fi
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       osx_image: xcode8
       env: PYTHON_CONFIGURE_OPTS="--enable-framework"
 install:
+  - env | grep PATH
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sw_vers; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target / || true; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get -y update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       osx_image: xcode8
       env: PYTHON_CONFIGURE_OPTS="--enable-framework"
 install:
-  - env | grep PATH
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sw_vers; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target / || true; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get -y update; fi
@@ -57,6 +56,9 @@ install:
   - python3 -m pip install --upgrade setuptools pip tox coveralls
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy-x86_64.AppImage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
+  - env | grep PATH
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ls -al ~/bin; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then linuxdeploy --help; fi
 script:
   - make test
   - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - which python3.6 && python3.6 --version
   - python2 -m pip install --upgrade setuptools pip
   - python3 -m pip install --upgrade setuptools pip tox coveralls
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -v -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy-x86_64.AppImage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -v -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
   - env | grep PATH
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ls -al ~/bin; fi

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,20 @@ codesign-dmg:
 codesign-all:
 	$(MAKE) codesign-app dmg codesign-dmg
 
+appimage:
+	mkdir -p build/AppDir/usr/bin
+	curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o build/linuxdeploy-x86_64.AppImage
+	echo "5cd6e75f987abfbe60adef89d75bc536c6076653ffa0673e90579ed25cbe19dd  build/linuxdeploy-x86_64.AppImage" | sha256sum --check
+	chmod +x build/linuxdeploy-x86_64.AppImage
+	cp -r dist/Gridsync/* build/AppDir/usr/bin
+	LD_LIBRARY_PATH=build/AppDir/usr/bin VERSION=Linux build/linuxdeploy-x86_64.AppImage \
+		--appdir=build/AppDir \
+		--executable=build/AppDir/usr/bin/gridsync \
+		--desktop-file=Gridsync.desktop \
+		--icon-file=images/gridsync.svg \
+		--output=appimage
+	mv Gridsync-Linux-x86_64.AppImage dist
+
 all:
 	$(MAKE) pyinstaller
 	@case `uname` in \

--- a/Makefile
+++ b/Makefile
@@ -209,18 +209,7 @@ codesign-all:
 	$(MAKE) codesign-app dmg codesign-dmg
 
 appimage:
-	mkdir -p build/AppDir/usr/bin
-	curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o build/linuxdeploy-x86_64.AppImage
-	echo "5cd6e75f987abfbe60adef89d75bc536c6076653ffa0673e90579ed25cbe19dd  build/linuxdeploy-x86_64.AppImage" | sha256sum --check
-	chmod +x build/linuxdeploy-x86_64.AppImage
-	cp -r dist/Gridsync/* build/AppDir/usr/bin
-	LD_LIBRARY_PATH=build/AppDir/usr/bin VERSION=Linux build/linuxdeploy-x86_64.AppImage \
-		--appdir=build/AppDir \
-		--executable=build/AppDir/usr/bin/gridsync \
-		--desktop-file=Gridsync.desktop \
-		--icon-file=images/gridsync.svg \
-		--output=appimage
-	mv Gridsync-Linux-x86_64.AppImage dist
+	python3 scripts/make_appimage.py
 
 all:
 	$(MAKE) pyinstaller

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ all:
 	$(MAKE) pyinstaller
 	@case `uname` in \
 		Darwin)	$(MAKE) dmg ;; \
-		*) python3 scripts/make_archive.py ;; \
+		*) $(MAKE) appimage && python3 scripts/make_archive.py ;; \
 	esac
 	python3 scripts/sha256sum.py dist/*.*
 

--- a/README.rst
+++ b/README.rst
@@ -70,11 +70,11 @@ Downloads for "stable" releases of Gridsync can be found on the project's `GitHu
 
 To install and run Gridsync on GNU/Linux (64-bit only; supporting glibc 2.17 and above -- including Debian 9+, Ubuntu 16.04 LTS+, CentOS 7+, and Fedora 28+):
 
-1. Download `Gridsync-Linux.tar.gz`_ (and `verify`_ its signature)
-2. Extract the enclosed "Gridsync" directory anywhere (``tar xvf Gridsync-Linux.tar.gz``)
-3. Run the contained ``gridsync`` binary
+1. Download `Gridsync-Linux.AppImage`_ (and `verify`_ its signature)
+2. Make the AppImage executable (``chmod +x Gridsync-Linux.AppImage``)
+3. Run ``Gridsync-Linux.AppImage``
 
-.. _Gridsync-Linux.tar.gz: https://github.com/gridsync/gridsync/releases
+.. _Gridsync-Linux.AppImage: https://github.com/gridsync/gridsync/releases
 .. _verify: https://github.com/gridsync/gridsync/blob/master/docs/verifying-signatures.md
 
 To install and run Gridsync on macOS (64-bit only; supporting macOS 10.12 "Sierra" and above):

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -8,6 +8,7 @@ tray_icon_sync = gridsync.gif
 mac_bundle_identifier = io.gridsync.Gridsync
 mac_icon = images/gridsync.icns
 win_icon = images/gridsync.ico
+linux_icon = images/gridsync.svg
 
 [debug]
 log_maxlen = 100000

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -7,10 +7,11 @@ try:
     from configparser import RawConfigParser
 except ImportError:
     from ConfigParser import RawConfigParser
-import subprocess
+import glob
 import hashlib
 import os
 import shutil
+import subprocess
 import sys
 try:
     from urllib.request import urlretrieve
@@ -86,14 +87,19 @@ Icon={1}
 
 os.environ['LD_LIBRARY_PATH'] = appdir_bin
 os.environ['VERSION'] = 'Linux'
-subprocess.call([
+linuxdeploy_args = [
     linuxdeploy_path,
     '--appdir=build/AppDir',
     '--executable={}'.format(os.path.join(appdir_usr, 'bin', name_lower)),
     '--icon-file={}'.format(icon_filepath),
     '--desktop-file={}'.format(desktop_filepath),
     '--output=appimage'
-])
+]
+returncode = subprocess.call(linuxdeploy_args)
+if returncode:
+    # XXX Ugly hack/workaround for "ERROR: Strip call failed: /tmp/.mount_linuxdns8a8k/usr/bin/strip: unable to copy file 'build/AppDir/usr/lib/libpython3.7m.so.1.0'; reason: Permission denied" observed on Travis-CI
+    os.chmod(glob.glob('build/AppDir/usr/lib/libpython*.so.*')[0], 0o755)
+    subprocess.call(linuxdeploy_args)
 
 
 try:

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+try:
+    from configparser import RawConfigParser
+except ImportError:
+    from ConfigParser import RawConfigParser
+import subprocess
+import hashlib
+import os
+import shutil
+import sys
+try:
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
+
+
+LINUXDEPLOY_URL = 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
+LINUXDEPLOY_HASH = '5cd6e75f987abfbe60adef89d75bc536c6076653ffa0673e90579ed25cbe19dd'
+
+
+appdir_usr = os.path.join('build', 'AppDir', 'usr')
+appdir_bin = os.path.join(appdir_usr, 'bin')
+try:
+    os.makedirs(appdir_usr)
+except OSError:
+    pass
+
+
+linuxdeploy_path = os.path.join('build', 'linuxdeploy-x86_64.AppImage')
+urlretrieve(LINUXDEPLOY_URL, linuxdeploy_path)
+
+
+hasher = hashlib.sha256()
+with open(linuxdeploy_path, 'rb') as f:
+    for block in iter(lambda: f.read(4096), b''):
+        hasher.update(block)
+sha256sum = hasher.hexdigest()
+if sha256sum != LINUXDEPLOY_HASH:
+    sys.exit(
+        "Checksum of {} failed!\n"
+        "Expected: {}\n"
+        "Received: {}".format(linuxdeploy_path, LINUXDEPLOY_HASH, sha256sum)
+    )
+
+
+os.chmod(linuxdeploy_path, 0o755)
+
+
+config = RawConfigParser(allow_no_value=True)
+config.read(os.path.join('gridsync', 'resources', 'config.txt'))
+settings = {}
+for section in config.sections():
+    if section not in settings:
+        settings[section] = {}
+    for option, value in config.items(section):
+        settings[section][option] = value
+
+name = settings['application']['name']
+name_lower = name.lower()
+linux_icon = settings['build']['linux_icon']
+
+
+shutil.copytree(os.path.join('dist', name), appdir_bin)
+
+
+_, ext = os.path.splitext(linux_icon)
+icon_filepath = os.path.abspath(os.path.join('build', name_lower + ext))
+shutil.copy2(linux_icon, icon_filepath)
+
+
+desktop_filepath = os.path.join('build', '{}.desktop'.format(name))
+with open(desktop_filepath, 'w') as f:
+    f.write('''[Desktop Entry]
+Categories=Utility;
+Type=Application
+Name={0}
+Exec={1}
+Icon={1}
+'''.format(name, name_lower)
+    )
+
+
+os.environ['LD_LIBRARY_PATH'] = appdir_bin
+os.environ['VERSION'] = 'Linux'
+subprocess.call([
+    linuxdeploy_path,
+    '--appdir=build/AppDir',
+    '--executable={}'.format(os.path.join(appdir_usr, 'bin', name_lower)),
+    '--icon-file={}'.format(icon_filepath),
+    '--desktop-file={}'.format(desktop_filepath),
+    '--output=appimage'
+])
+
+
+try:
+    os.mkdir('dist')
+except OSError:
+    pass
+shutil.move(
+    '{}-Linux-x86_64.AppImage'.format(name),
+    os.path.join('dist', '{}.AppImage'.format(name))
+)

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 LINUXDEPLOY_URL = 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
-LINUXDEPLOY_HASH = '5cd6e75f987abfbe60adef89d75bc536c6076653ffa0673e90579ed25cbe19dd'
+LINUXDEPLOY_HASH = '3513c4b8ef190f6cf0c2d2665ada478e4c71ca1266f9bc8c2adfe2f0b13a0fbc'
 
 
 appdir_usr = os.path.join('build', 'AppDir', 'usr')

--- a/vagrantfiles/linux/Vagrantfile
+++ b/vagrantfiles/linux/Vagrantfile
@@ -39,6 +39,8 @@ Vagrant.configure("2") do |config|
     pyenv global 2.7.16 3.7.4 3.6.9
     python2 -m pip install --upgrade setuptools pip
     python3 -m pip install --upgrade setuptools pip tox
+    curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+    chmod +x ~/bin/linuxdeploy
   SHELL
   config.vm.provision "file", source: "../..", destination: "~/gridsync"
   config.vm.provision "shell", privileged: false, inline: <<-SHELL


### PR DESCRIPTION
This PR adds a rudimentary `make_appimage` script (called by the `make appimage` command) that uses [`linuxdeploy`](https://github.com/linuxdeploy/linuxdeploy/) to package [PyInstaller](https://www.pyinstaller.org/)-generated binaries into a single, standalone, executable Gridsync [AppImage](https://appimage.org/) file. Pending further testing and integration with CI/CD, this preliminarily allows for Gridsync AppImages to be offered alongside future releases, making it considerably easier for GNU/Linux users to install and run the application.

Closes #245 