### PR TITLE
Wrap log-buffer deque in list() during iteration

### DIFF
--- a/gridsync/streamedlogs.py
+++ b/gridsync/streamedlogs.py
@@ -78,7 +78,7 @@ class StreamedLogs(MultiService):
         """
         :return list[str]: The messages currently in the message buffer.
         """
-        return list(msg.decode("utf-8") for msg in self._buffer)
+        return list(msg.decode("utf-8") for msg in list(self._buffer))
 
     def _create_client_service(self, nodeurl, api_token):
         url = parse(nodeurl)


### PR DESCRIPTION
A guard against "RuntimeError: deque mutated during iteration"

Fixes #249