### PR TITLE
Reduce AppImage filesize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/linuxdeploy; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then linuxdeploy --version; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then curl -L --create-dirs -o ~/bin/appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then chmod +x ~/bin/appimagetool; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then appimagetool --version; fi
   - rm -rf ~/.pyenv
   - git clone https://github.com/pyenv/pyenv.git ~/.pyenv
   - mkdir -p ~/.cache/pyenv/versions

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ all:
 	$(MAKE) pyinstaller
 	@case `uname` in \
 		Darwin)	$(MAKE) dmg ;; \
-		*) $(MAKE) appimage && python3 scripts/make_archive.py ;; \
+		*) $(MAKE) appimage ;; \
 	esac
 	python3 scripts/sha256sum.py dist/*.*
 

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -85,16 +85,14 @@ def deduplicate_libs():
     os.remove(appimage)
     shutil.rmtree('build/AppDir')
     shutil.move('squashfs-root', 'build/AppDir')
-    for _, _, files, in os.walk('build/AppDir/usr/lib', followlinks=True):
-        for file in sorted(files):
-            if file.startswith('libpython') or file.startswith('libQt'):
-                continue
-            path = os.path.abspath('build/AppDir/usr/bin/{}'.format(file))
+    for file in sorted(os.listdir('build/AppDir/usr/bin')):
+        path = 'build/AppDir/usr/lib/{}'.format(file)
+        if os.path.exists(path):
             print('Removing duplicate library: ', path)
             try:
                 os.remove(path)
             except OSError:
-                print('WARNING: Could not remove {}; not found'.format(path))
+                print('WARNING: Could not remove file {}'.format(path))
     subprocess.call(linuxdeploy_args)
     size_after = os.path.getsize(appimage)
     print('Reduced filesize by {} bytes.'.format(size_before - size_after))

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -93,7 +93,7 @@ def deduplicate_libs():
                 os.remove(path)
             except OSError:
                 print('WARNING: Could not remove file {}'.format(path))
-    subprocess.call(linuxdeploy_args)
+    subprocess.call(['appimagetool', 'build/AppDir', appimage])
     size_after = os.path.getsize(appimage)
     print('Reduced filesize by {} bytes.'.format(size_before - size_after))
 

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -33,7 +33,10 @@ try:
     os.makedirs(appdir_usr)
 except OSError:
     pass
-shutil.copytree(os.path.join('dist', name), appdir_bin)
+try:
+    shutil.copytree(os.path.join('dist', name), appdir_bin)
+except OSError:
+    pass
 
 
 _, ext = os.path.splitext(linux_icon)

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -88,7 +88,7 @@ def deduplicate_libs():
     for file in sorted(os.listdir('build/AppDir/usr/bin')):
         path = 'build/AppDir/usr/lib/{}'.format(file)
         if os.path.exists(path):
-            print('Removing duplicate library: ', path)
+            print('Removing duplicate library:', path)
             try:
                 os.remove(path)
             except OSError:

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -54,14 +54,12 @@ Icon={1}
 
 
 os.environ['LD_LIBRARY_PATH'] = appdir_bin
-os.environ['VERSION'] = 'Linux'
 linuxdeploy_args = [
     'linuxdeploy',
     '--appdir=build/AppDir',
     '--executable={}'.format(os.path.join(appdir_usr, 'bin', name_lower)),
     '--icon-file={}'.format(icon_filepath),
     '--desktop-file={}'.format(desktop_filepath),
-    '--output=appimage'
 ]
 try:
     returncode = subprocess.call(linuxdeploy_args)
@@ -79,12 +77,6 @@ if returncode:
 
 
 def deduplicate_libs():
-    appimage = os.path.abspath('{}-Linux-x86_64.AppImage'.format(name))
-    size_before = os.path.getsize(appimage)
-    subprocess.call([appimage, '--appimage-extract'])
-    os.remove(appimage)
-    shutil.rmtree('build/AppDir')
-    shutil.move('squashfs-root', 'build/AppDir')
     for file in sorted(os.listdir('build/AppDir/usr/bin')):
         path = 'build/AppDir/usr/lib/{}'.format(file)
         if os.path.exists(path):
@@ -93,9 +85,7 @@ def deduplicate_libs():
                 os.remove(path)
             except OSError:
                 print('WARNING: Could not remove file {}'.format(path))
-    subprocess.call(['appimagetool', 'build/AppDir', appimage])
-    size_after = os.path.getsize(appimage)
-    print('Reduced filesize by {} bytes.'.format(size_before - size_after))
+    subprocess.call(['appimagetool', 'build/AppDir'])
 
 deduplicate_libs()
 
@@ -105,6 +95,6 @@ try:
 except OSError:
     pass
 shutil.move(
-    '{}-Linux-x86_64.AppImage'.format(name),
+    '{}-x86_64.AppImage'.format(name),
     os.path.join('dist', '{}.AppImage'.format(name))
 )

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -79,23 +79,20 @@ if returncode:
     subprocess.call(linuxdeploy_args)
 
 
-def deduplicate_libs():
-    for file in sorted(os.listdir(appdir_bin)):
-        dst = 'build/AppDir/usr/lib/{}'.format(file)
-        if os.path.exists(dst):
-            try:
-                os.remove(dst)
-            except OSError:
-                print('WARNING: Could not remove file {}'.format(dst))
-                continue
-            src = '../bin/{}'.format(file)
-            print('Creating symlink: {} -> {}'.format(dst, src))
-            try:
-                os.symlink(src, dst)
-            except OSError:
-                print('WARNING: Could not create symlink for {}'.format(dst))
-
-deduplicate_libs()
+for file in sorted(os.listdir(appdir_bin)):
+    dst = 'build/AppDir/usr/lib/{}'.format(file)
+    if os.path.exists(dst):
+        try:
+            os.remove(dst)
+        except OSError:
+            print('WARNING: Could not remove file {}'.format(dst))
+            continue
+        src = '../bin/{}'.format(file)
+        print('Creating symlink: {} -> {}'.format(dst, src))
+        try:
+            os.symlink(src, dst)
+        except OSError:
+            print('WARNING: Could not create symlink for {}'.format(dst))
 
 
 try:

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -77,14 +77,20 @@ if returncode:
 
 
 def deduplicate_libs():
-    for file in sorted(os.listdir('build/AppDir/usr/bin')):
-        path = 'build/AppDir/usr/lib/{}'.format(file)
-        if os.path.exists(path):
-            print('Removing duplicate library:', path)
+    for file in sorted(os.listdir(appdir_bin)):
+        dst = 'build/AppDir/usr/lib/{}'.format(file)
+        if os.path.exists(dst):
             try:
-                os.remove(path)
+                os.remove(dst)
             except OSError:
-                print('WARNING: Could not remove file {}'.format(path))
+                print('WARNING: Could not remove file {}'.format(dst))
+                continue
+            src = '../bin/{}'.format(file)
+            print('Creating symlink: {} -> {}'.format(dst, src))
+            try:
+                os.symlink(src, dst)
+            except OSError:
+                print('WARNING: Could not create symlink for {}'.format(dst))
 
 deduplicate_libs()
 

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -105,7 +105,14 @@ try:
     os.mkdir('dist')
 except OSError:
     pass
-
-subprocess.call([
-    'appimagetool', 'build/AppDir', 'dist/{}.AppImage'.format(name)
-])
+try:
+    subprocess.call([
+        'appimagetool', 'build/AppDir', 'dist/{}.AppImage'.format(name)
+    ])
+except OSError:
+    sys.exit(
+        'ERROR: `appimagetool` utility not found. Please ensure that it is '
+        'on your $PATH and executable as `appimagetool` and try again.\n'
+        '`appimagetool` can be downloaded from https://github.com/AppImage/A'
+        'ppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage'
+    )

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -80,6 +80,12 @@ if returncode:
 
 
 for file in sorted(os.listdir(appdir_bin)):
+    # The `linuxdeploy` utility adds a copy of each library to AppDir/usr/lib,
+    # however, the main PyInstaller-generated ("gridsync") executable expects
+    # these libraries to be located in the same directory as the ("gridsync")
+    # executable itself (resulting in *two* copies of each library and thus
+    # wasted disk-space); removing the copies inserted by `linuxdeploy` -- and
+    # and replacing them with symlinks to the originals -- saves disk-space.
     dst = 'build/AppDir/usr/lib/{}'.format(file)
     if os.path.exists(dst):
         try:

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -85,7 +85,6 @@ def deduplicate_libs():
                 os.remove(path)
             except OSError:
                 print('WARNING: Could not remove file {}'.format(path))
-    subprocess.call(['appimagetool', 'build/AppDir'])
 
 deduplicate_libs()
 
@@ -94,7 +93,7 @@ try:
     os.mkdir('dist')
 except OSError:
     pass
-shutil.move(
-    '{}-x86_64.AppImage'.format(name),
-    os.path.join('dist', '{}.AppImage'.format(name))
-)
+
+subprocess.call([
+    'appimagetool', 'build/AppDir', 'dist/{}.AppImage'.format(name)
+])

--- a/vagrantfiles/linux/Vagrantfile
+++ b/vagrantfiles/linux/Vagrantfile
@@ -41,6 +41,8 @@ Vagrant.configure("2") do |config|
     python3 -m pip install --upgrade setuptools pip tox
     curl -L --create-dirs -o ~/bin/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
     chmod +x ~/bin/linuxdeploy
+    curl -L --create-dirs -o ~/bin/appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+    chmod +x ~/bin/appimagetool
   SHELL
   config.vm.provision "file", source: "../..", destination: "~/gridsync"
   config.vm.provision "shell", privileged: false, inline: <<-SHELL


### PR DESCRIPTION
This PR updates the `make_appimage` script to remove the seemingly-superfluous secondary copies of various libraries inserted by the `linuxdeploy` utility (replacing them instead with symlinks to the originals) and repack the resultant deduplicated AppDir with the vanilla/upstream `appimagetool` (in order to avoid re-insertion). On a CentOS7 buildbot-worker run, this shaved a whopping 43.6 MB off of the final AppImage file with no discernible issues or downsides (testing Debian 9, Debian 10, Fedora 29, and Fedora 30).
                                                             
Closes #251