### PR TITLE
Allow a "default" grid/connection to be specified via config.txt

### DIFF
--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -372,7 +372,7 @@ class WelcomeDialog(QStackedWidget):
         self.recovery_key_importer.done.connect(self.on_import_done)
         self.recovery_key_importer.do_import()
 
-    def go(self, code):
+    def go(self, code, settings=None):
         if self.tor_checkbox.isChecked():
             self.use_tor = True
             self.page_2.tor_label.show()
@@ -392,7 +392,7 @@ class WelcomeDialog(QStackedWidget):
             lambda gateway: self.gui.populate([gateway])
         )
         invite_receiver.done.connect(self.on_done)
-        d = invite_receiver.receive(code)
+        d = invite_receiver.receive(code, settings)
         d.addErrback(self.handle_failure)
         reactor.callLater(30, d.cancel)
 

--- a/gridsync/gui/welcome.py
+++ b/gridsync/gui/welcome.py
@@ -28,7 +28,7 @@ from wormhole.errors import (
 
 from gridsync import resource, APP_NAME
 from gridsync import settings as global_settings
-from gridsync.invite import InviteReceiver
+from gridsync.invite import InviteReceiver, load_settings_from_cheatcode
 from gridsync.errors import UpgradeRequiredError
 from gridsync.gui.color import BlendedColor
 from gridsync.gui.font import Font
@@ -75,6 +75,36 @@ class WelcomeWidget(QWidget):
         self.invite_code_widget = InviteCodeWidget(self)
         self.lineedit = self.invite_code_widget.lineedit
 
+        self.connect_button = QPushButton("Connect")
+
+        try:
+            default_code = global_settings["connection"]["default"]
+        except KeyError:
+            default_code = ""
+        grid_settings = load_settings_from_cheatcode(default_code)
+        if grid_settings:
+            self.invite_code_widget.hide()
+            nickname = grid_settings.get("nickname")
+            if nickname:
+                font = Font(11)
+                self.connect_button.setFont(font)
+                self.connect_button.setFixedHeight(32)
+                self.connect_button.setText(f"Connect to {nickname}")
+                self.connect_button.clicked.connect(
+                    lambda: self.parent.go(default_code, grid_settings)
+                )
+            primary_color = grid_settings.get("color-1")
+            if primary_color:
+                self.connect_button.setStyleSheet(
+                    f"background: {primary_color}; color: white"
+                )
+            else:
+                self.connect_button.setStyleSheet(
+                    "background: green; color: white"
+                )
+        else:
+            self.connect_button.hide()
+
         self.message = QLabel()
         self.message.setStyleSheet("color: red")
         self.message.setAlignment(Qt.AlignCenter)
@@ -117,6 +147,7 @@ class WelcomeWidget(QWidget):
         layout.addWidget(self.slogan, 2, 3)
         layout.addItem(QSpacerItem(0, 0, 0, QSizePolicy.Expanding), 3, 1)
         layout.addWidget(self.invite_code_widget, 4, 2, 1, 3)
+        layout.addWidget(self.connect_button, 4, 2, 1, 3)
         layout.addWidget(self.message, 5, 3)
         layout.addItem(QSpacerItem(0, 0, 0, QSizePolicy.Minimum), 6, 1)
         layout.addLayout(links_grid, 7, 3)

--- a/gridsync/resources/providers/demo-grid.json
+++ b/gridsync/resources/providers/demo-grid.json
@@ -1,6 +1,7 @@
 {
     "nickname": "Demo Grid",
     "icon_url": "https://raw.githubusercontent.com/gridsync/gridsync/master/gridsync/resources/gridsync.png",
+    "color-1": "#009cff",
     "shares-needed": "1",
     "shares-happy": "1",
     "shares-total": "1",


### PR DESCRIPTION
This PR adds support for optionally specifying a "default" grid/connection via `config.txt` as follows:

```
[connection] 
default = demo-grid 
```

The presence of this option at runtime replaces the "Invite Code" field/widget on the welcome widow with a "Connect to <grid-name>" button which, when clicked, creates a `tahoe` node using the settings provided by the cheat code specified (thus, in the example above, a "Connect to Demo Grid" button will appear which, when clicked, will load the grid-configuration settings found at `gridsync/resources/providers/demo-grid.json`).

This (completely optional) setting is intended to be used for custom deployments of Gridsync -- for example, in the event of a user-testing session in which the "invite code" step might need to be skipped, or for commercial deployments that may want to ship "pre-configured" builds to users.