### PR TITLE
Make some functions disableable via config.txt

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -94,7 +94,7 @@ class CentralWidget(QStackedWidget):
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, gui):
+    def __init__(self, gui):  # noqa: max-complexity
         super(MainWindow, self).__init__()
         self.gui = gui
         self.gateways = []
@@ -111,8 +111,24 @@ class MainWindow(QMainWindow):
             # See https://github.com/gridsync/gridsync/issues/241
             self.setWindowFlags(Qt.Dialog)
 
-        self.shortcut_new = QShortcut(QKeySequence.New, self)
-        self.shortcut_new.activated.connect(self.show_welcome_dialog)
+        grid_invites_enabled = True
+        invites_enabled = True
+        multiple_grids_enabled = True
+        features_settings = settings.get("features")
+        if features_settings:
+            grid_invites = features_settings.get("grid_invites")
+            if grid_invites and grid_invites.lower() == "false":
+                grid_invites_enabled = False
+            invites = features_settings.get("invites")
+            if invites and invites.lower() == "false":
+                invites_enabled = False
+            multiple_grids = features_settings.get("multiple_grids")
+            if multiple_grids and multiple_grids.lower() == "false":
+                multiple_grids_enabled = False
+
+        if multiple_grids_enabled:
+            self.shortcut_new = QShortcut(QKeySequence.New, self)
+            self.shortcut_new.activated.connect(self.show_welcome_dialog)
 
         self.shortcut_open = QShortcut(QKeySequence.Open, self)
         self.shortcut_open.activated.connect(self.select_folder)
@@ -143,13 +159,6 @@ class MainWindow(QMainWindow):
         folder_action.setToolTip("Add a Folder...")
         folder_action.setFont(font)
         folder_action.triggered.connect(self.select_folder)
-
-        grid_invites_enabled = True
-        features_settings = settings.get("features")
-        if features_settings:
-            grid_invites = features_settings.get("grid_invites")
-            if grid_invites and grid_invites.lower() == "false":
-                grid_invites_enabled = False
 
         if grid_invites_enabled:
             invites_action = QAction(
@@ -185,7 +194,7 @@ class MainWindow(QMainWindow):
             )
             invites_button.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
 
-        else:
+        elif invites_enabled:
             invite_action = QAction(
                 QIcon(resource("invite.png")), "Enter Code", self
             )
@@ -198,6 +207,8 @@ class MainWindow(QMainWindow):
 
         self.combo_box = ComboBox()
         self.combo_box.currentIndexChanged.connect(self.on_grid_selected)
+        if not multiple_grids_enabled:
+            self.combo_box.hide()
 
         spacer_right = QWidget()
         spacer_right.setSizePolicy(QSizePolicy.Expanding, 0)
@@ -262,7 +273,7 @@ class MainWindow(QMainWindow):
         self.toolbar.addAction(folder_action)
         if grid_invites_enabled:
             self.toolbar.addWidget(invites_button)
-        else:
+        elif invites_enabled:
             self.toolbar.addAction(invite_action)
         self.toolbar.addWidget(spacer_left)
         self.toolbar.addWidget(self.combo_box)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import (
 )
 from twisted.internet.defer import DeferredList, inlineCallbacks
 
-from gridsync import resource, APP_NAME
+from gridsync import resource, APP_NAME, settings
 from gridsync.desktop import open_path
 from gridsync.gui.font import Font
 from gridsync.gui.model import Model
@@ -466,7 +466,13 @@ class View(QTreeView):
             QIcon(resource("close.png")), "Remove from Recovery Key..."
         )
         menu.addAction(open_action)
-        menu.addMenu(share_menu)
+        features_settings = settings.get("features")
+        if features_settings:
+            invites_setting = features_settings.get("invites")
+            if invites_setting and invites_setting.lower() != "false":
+                menu.addMenu(share_menu)
+        else:
+            menu.addMenu(share_menu)
         menu.addSeparator()
         menu.addAction(remove_action)
         if selection_is_remote:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -417,7 +417,7 @@ class View(QTreeView):
                     folders.append(item.text())
         return folders
 
-    def on_right_click(self, position):
+    def on_right_click(self, position):  # noqa: max-complexity
         if not position:  # From left-click on "Action" button
             position = self.viewport().mapFromGlobal(QCursor().pos())
             self.deselect_remote_folders()

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -13,6 +13,12 @@ linux_icon = images/gridsync.svg
 [debug]
 log_maxlen = 100000
 
+[features]
+grid_invites = true
+invites = true
+multiple_grids = true
+tor = true
+
 [help]
 docs_url = docs.gridsync.io
 issues_url = https://github.com/gridsync/gridsync/issues

--- a/gridsync/tor.py
+++ b/gridsync/tor.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import QMessageBox
 from twisted.internet.defer import inlineCallbacks
 import txtorcon
 
+from gridsync import settings
 
 # From https://styleguide.torproject.org/visuals/
 # "The main Tor Project color is Purple. Use Dark Purple as a secondary option"
@@ -32,6 +33,11 @@ def tor_required(furl):
 @inlineCallbacks
 def get_tor(reactor):  # TODO: Add launch option?
     tor = None
+    features_settings = settings.get("features")
+    if features_settings:
+        tor_setting = features_settings.get("tor")
+        if tor_setting and tor_setting.lower() == "false":
+            return tor
     logging.debug("Looking for a running Tor daemon...")
     try:
         tor = yield txtorcon.connect(reactor)
@@ -51,7 +57,7 @@ def get_tor_with_prompt(reactor, parent=None):
         msgbox.setWindowTitle("Tor Required")
         msgbox.setText(
             "This connection can only be made over the Tor network, however, "
-            "no running Tor daemon was found."
+            "no running Tor daemon was found or Tor has been disabled."
         )
         msgbox.setInformativeText(
             "Please ensure that Tor is running and try again.<p>For help "

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -47,6 +47,15 @@ def test_get_tor_return_none(monkeypatch):
 
 
 @inlineCallbacks
+def test_get_tor_return_none_feature_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "gridsync.tor.settings", {"features": {"tor": "false"}}
+    )
+    tor = yield get_tor(None)
+    assert tor is None
+
+
+@inlineCallbacks
 def test_get_tor_with_prompt_retry(monkeypatch):
     monkeypatch.setattr(
         "gridsync.tor.get_tor", MagicMock(side_effect=[None, "FakeTxtorcon"])


### PR DESCRIPTION
This PR adds support for disabling certain features via `config.txt` as follows:

```
[features] 
grid_invites = false  
invites = false                    
multiple_grids = false             
tor = false                          
```

Like in the case of #292, these options are intended to be used for custom deployments of Gridsync; by default, all disableable features are enabled.