### PR TITLE
Show grid name in status panel when "connected" (instead of connected/known node-count)

### DIFF
--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -142,9 +142,12 @@ class StatusPanel(QWidget):
         self._update_grid_info_tooltip()
 
     def on_nodes_updated(self, connected, known):
-        self.status_label.setText(
-            "Connected to {} of {} storage nodes".format(connected, known)
-        )
+        if connected >= self.gateway.shares_happy:
+            self.status_label.setText(f"Connected to {self.gateway.name}")
+        else:
+            self.status_label.setText(
+                f"Connecting to {self.gateway.name} ({connected}/{known})..."
+            )
         self.num_connected = connected
         self.num_known = known
         self._update_grid_info_tooltip()

--- a/tests/gui/test_status.py
+++ b/tests/gui/test_status.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -45,7 +45,28 @@ def test_on_space_updated_humanize():
     assert sp.available_space == "1.0 kB"
 
 
-def test_on_nodes_updated():
-    sp = StatusPanel(MagicMock(), MagicMock())
+def test_on_nodes_updated_set_num_connected_and_num_known():
+    fake_tahoe = Mock()
+    fake_tahoe.name = "TestGrid"
+    fake_tahoe.shares_happy = 3
+    sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_nodes_updated(4, 5)
     assert (sp.num_connected, sp.num_known) == (4, 5)
+
+
+def test_on_nodes_updated_grid_name_in_status_label():
+    fake_tahoe = Mock()
+    fake_tahoe.name = "TestGrid"
+    fake_tahoe.shares_happy = 3
+    sp = StatusPanel(fake_tahoe, MagicMock())
+    sp.on_nodes_updated(4, 5)
+    assert sp.status_label.text() == "Connected to TestGrid"
+
+
+def test_on_nodes_updated_node_count_in_status_label_when_connecting():
+    fake_tahoe = Mock()
+    fake_tahoe.name = "TestGrid"
+    fake_tahoe.shares_happy = 5
+    sp = StatusPanel(fake_tahoe, MagicMock())
+    sp.on_nodes_updated(4, 5)
+    assert sp.status_label.text() == "Connecting to TestGrid (4/5)..."


### PR DESCRIPTION
Fixes #296 