### PR TITLE
Pin/downgrade PyQt5 to 5.14.2 on macOS

### DIFF
--- a/requirements/gridsync.txt
+++ b/requirements/gridsync.txt
@@ -145,7 +145,15 @@ PyNaCl==1.4.0 \
 pyOpenSSL==19.1.0 \
     --hash=sha256:621880965a720b8ece2f1b2f54ea2071966ab00e2970ad2ce11d596102063504 \
     --hash=sha256:9a24494b2602aaf402be5c9e30a0b82d4a5c67528fe8fb475e3f3bc00dd69507
-PyQt5==5.15.0 \
+# (Py)Qt5 version 5.15.0 introduced a regression breaking stylized QPushButtons
+# on macOS. See/follow https://bugreports.qt.io/browse/QTBUG-84852
+PyQt5==5.14.2 ; sys_platform == "darwin" \
+    --hash=sha256:3b91dd1d0cbfaea85ad057247ba621187e511434b0c9d6d40de69fd5e833b109 \
+    --hash=sha256:a9bdc46ab1f6397770e6b8dca84ac07a0250d26b1a31587f25619cf31a075532 \
+    --hash=sha256:bd230c6fd699eabf1ceb51e13a8b79b74c00a80272c622427b80141a22269eb0 \
+    --hash=sha256:ee168a486c9a758511568147815e2959652cd0aabea832fa5e87cf6b241d2180 \
+    --hash=sha256:f61ddc78547d6ca763323ccd4a9e374c71b29feda1f5ce2d3e91e4f8d2cf1942
+PyQt5==5.15.0 ; sys_platform != "darwin" \
     --hash=sha256:14be35c0c1bcc804791a096d2ef9950f12c6fd34dd11dbe61b8c769fefcdf98c \
     --hash=sha256:3605d34ba6291b9194c46035e228d6d01f39d120cf5ecc70301c11e7900fed21 \
     --hash=sha256:5bac0fab1e9891d73400c2470a9cb810e6bdbc7027a84ae4d3ec83436f1109ec \


### PR DESCRIPTION
A workaround for a Qt bug that breaks stylized buttons:
https://bugreports.qt.io/browse/QTBUG-84852
https://bugreports.qt.io/browse/QTBUG-84879

Fixes #298