### PR TITLE
Fix status indicators when offline

### DIFF
--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -222,7 +222,10 @@ class Model(QStandardItemModel):
         if status == MagicFolderChecker.LOADING:
             item.setIcon(self.icon_blank)
             item.setText("Loading...")
-        elif status == MagicFolderChecker.SYNCING:
+        elif status in (
+            MagicFolderChecker.SYNCING,
+            MagicFolderChecker.SCANNING,
+        ):
             item.setIcon(self.icon_blank)
             item.setText("Syncing")
             item.setToolTip(
@@ -247,10 +250,6 @@ class Model(QStandardItemModel):
                 'Right-click and select "Download" to sync it with your '
                 "local computer.".format(self.gateway.name)
             )
-        elif status == MagicFolderChecker.SCANNING:
-            item.setIcon(self.icon_blank)
-            item.setText("Scanning")
-            item.setToolTip("This folder is being scanned for changes.")
         item.setData(status, Qt.UserRole)
         self.status_dict[name] = status
 

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import QAction, QFileIconProvider, QToolBar
 
 from gridsync import resource, config_dir
 from gridsync.gui.pixmap import CompositePixmap
+from gridsync.monitor import MagicFolderChecker
 from gridsync.preferences import get_preference
 from gridsync.util import humanized_list
 
@@ -218,17 +219,17 @@ class Model(QStandardItemModel):
         if not items:
             return
         item = self.item(items[0].row(), 1)
-        if not status:
+        if status == MagicFolderChecker.LOADING:
             item.setIcon(self.icon_blank)
             item.setText("Loading...")
-        elif status == 1:
+        elif status == MagicFolderChecker.SYNCING:
             item.setIcon(self.icon_blank)
             item.setText("Syncing")
             item.setToolTip(
                 "This folder is syncing. New files are being uploaded or "
                 "downloaded."
             )
-        elif status == 2:
+        elif status == MagicFolderChecker.UP_TO_DATE:
             item.setIcon(self.icon_up_to_date)
             item.setText("Up to date")
             item.setToolTip(
@@ -246,7 +247,7 @@ class Model(QStandardItemModel):
                 'Right-click and select "Download" to sync it with your '
                 "local computer.".format(self.gateway.name)
             )
-        elif status == 99:
+        elif status == MagicFolderChecker.SCANNING:
             item.setIcon(self.icon_blank)
             item.setText("Scanning")
             item.setToolTip("This folder is being scanned for changes.")

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -108,33 +108,35 @@ class StatusPanel(QWidget):
         self.gateway.monitor.nodes_updated.connect(self.on_nodes_updated)
 
     def _update_status_label(self):
-        text = ""
         if self.state == 0:
             if self.gateway.shares_happy:
                 if self.num_connected < self.gateway.shares_happy:
-                    text = (
+                    self.status_label.setText(
                         f"Connecting to {self.gateway.name} ("
                         f"{self.num_connected}/{self.gateway.shares_happy})..."
                     )
                 else:
-                    text = f"Connected to {self.gateway.name}"
+                    self.status_label.setText(
+                        f"Connected to {self.gateway.name}"
+                    )
 
             else:
-                text = f"Connecting to {self.gateway.name}..."
+                self.status_label.setText(
+                    f"Connecting to {self.gateway.name}..."
+                )
             self.sync_movie.setPaused(True)
             self.syncing_icon.hide()
             self.checkmark_icon.hide()
         elif self.state == 1:
-            text = "Syncing"
+            self.status_label.setText("Syncing")
             self.checkmark_icon.hide()
             self.syncing_icon.show()
             self.sync_movie.setPaused(False)
         elif self.state == 2:
-            text = "Up to date"
+            self.status_label.setText("Up to date")
             self.sync_movie.setPaused(True)
             self.syncing_icon.hide()
             self.checkmark_icon.show()
-        self.status_label.setText(text)
         if self.available_space:
             self.status_label.setToolTip(
                 "Connected to {} of {} storage nodes\n{} available".format(

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -74,11 +74,6 @@ class StatusPanel(QWidget):
         if not self.gateway.use_tor:
             self.tor_button.hide()
 
-        self.globe_button = QToolButton()
-        self.globe_button.setIconSize(QSize(20, 20))
-        self.globe_action = QAction(QIcon(resource("globe.png")), "")
-        self.globe_button.setDefaultAction(self.globe_action)
-
         preferences_button = QToolButton(self)
         preferences_button.setIcon(QIcon(resource("preferences.png")))
         preferences_button.setIconSize(QSize(20, 20))
@@ -96,7 +91,6 @@ class StatusPanel(QWidget):
         layout.addWidget(self.status_label, 1, 2)
         layout.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, 0), 1, 3)
         layout.addWidget(self.tor_button, 1, 4)
-        layout.addWidget(self.globe_button, 1, 5)
         layout.addWidget(preferences_button, 1, 6)
 
         self.gateway.monitor.total_sync_state_updated.connect(

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -33,6 +33,17 @@ class StatusPanel(QWidget):
         self.checkmark_icon = QLabel()
         self.checkmark_icon.setPixmap(Pixmap("checkmark.png", 20))
 
+        self.loading_icon = QLabel(self)
+        self.loading_movie = QMovie(resource("waiting.gif"))
+        self.loading_movie.setCacheMode(True)
+        self.loading_movie.updated.connect(
+            lambda: self.loading_icon.setPixmap(
+                self.loading_movie.currentPixmap().scaled(
+                    20, 20, Qt.KeepAspectRatio, Qt.SmoothTransformation
+                )
+            )
+        )
+
         self.syncing_icon = QLabel()
 
         self.sync_movie = QMovie(resource("sync.gif"))
@@ -93,6 +104,7 @@ class StatusPanel(QWidget):
         left, _, right, bottom = layout.getContentsMargins()
         layout.setContentsMargins(left, 0, right, bottom - 2)
         layout.addWidget(self.checkmark_icon, 1, 1)
+        layout.addWidget(self.loading_icon, 1, 1)
         layout.addWidget(self.syncing_icon, 1, 1)
         layout.addWidget(self.status_label, 1, 2)
         layout.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, 0), 1, 3)
@@ -112,14 +124,20 @@ class StatusPanel(QWidget):
             self.sync_movie.setPaused(True)
             self.syncing_icon.hide()
             self.checkmark_icon.hide()
+            self.loading_icon.show()
+            self.loading_movie.setPaused(False)
         elif state == 1:
             self.status_label.setText("Syncing")
+            self.loading_movie.setPaused(True)
+            self.loading_icon.hide()
             self.checkmark_icon.hide()
             self.syncing_icon.show()
             self.sync_movie.setPaused(False)
         elif state == 2:
             self.status_label.setText("Up to date")
+            self.loading_movie.setPaused(True)
             self.sync_movie.setPaused(True)
+            self.loading_icon.hide()
             self.syncing_icon.hide()
             self.checkmark_icon.show()
 

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -31,22 +31,8 @@ class StatusPanel(QWidget):
         self.num_known = 0
         self.available_space = 0
 
-        self.globe_icon = QLabel(self)
-        self.globe_icon.setPixmap(Pixmap("globe.png", 20))
-
         self.checkmark_icon = QLabel()
         self.checkmark_icon.setPixmap(Pixmap("checkmark.png", 20))
-
-        self.loading_icon = QLabel(self)
-        self.loading_movie = QMovie(resource("waiting.gif"))
-        self.loading_movie.setCacheMode(True)
-        self.loading_movie.updated.connect(
-            lambda: self.loading_icon.setPixmap(
-                self.loading_movie.currentPixmap().scaled(
-                    20, 20, Qt.KeepAspectRatio, Qt.SmoothTransformation
-                )
-            )
-        )
 
         self.syncing_icon = QLabel()
 
@@ -107,9 +93,7 @@ class StatusPanel(QWidget):
         layout = QGridLayout(self)
         left, _, right, bottom = layout.getContentsMargins()
         layout.setContentsMargins(left, 0, right, bottom - 2)
-        layout.addWidget(self.globe_icon, 1, 1)
         layout.addWidget(self.checkmark_icon, 1, 1)
-        layout.addWidget(self.loading_icon, 1, 1)
         layout.addWidget(self.syncing_icon, 1, 1)
         layout.addWidget(self.status_label, 1, 2)
         layout.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, 0), 1, 3)
@@ -126,44 +110,29 @@ class StatusPanel(QWidget):
     def _update_status_label(self):
         text = ""
         if self.state == 0:
-            self.sync_movie.setPaused(True)
-            self.syncing_icon.hide()
-            self.checkmark_icon.hide()
             if self.gateway.shares_happy:
                 if self.num_connected < self.gateway.shares_happy:
                     text = (
                         f"Connecting to {self.gateway.name} ("
                         f"{self.num_connected}/{self.gateway.shares_happy})..."
                     )
-                    self.globe_icon.hide()
-                    self.loading_icon.show()
-                    self.loading_movie.setPaused(False)
                 else:
                     text = f"Connected to {self.gateway.name}"
-                    self.globe_icon.show()
-                    self.loading_icon.hide()
-                    self.loading_movie.setPaused(True)
 
             else:
                 text = f"Connecting to {self.gateway.name}..."
-                self.globe_icon.hide()
-                self.loading_icon.show()
-                self.loading_movie.setPaused(False)
+            self.sync_movie.setPaused(True)
+            self.syncing_icon.hide()
+            self.checkmark_icon.hide()
         elif self.state == 1:
             text = "Syncing"
-            self.loading_movie.setPaused(True)
-            self.loading_icon.hide()
-            self.globe_icon.hide()
             self.checkmark_icon.hide()
             self.syncing_icon.show()
             self.sync_movie.setPaused(False)
         elif self.state == 2:
             text = "Up to date"
-            self.loading_movie.setPaused(True)
             self.sync_movie.setPaused(True)
-            self.loading_icon.hide()
             self.syncing_icon.hide()
-            self.globe_icon.hide()
             self.checkmark_icon.show()
         self.status_label.setText(text)
         if self.available_space:

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -51,7 +51,7 @@ class StatusPanel(QWidget):
         dimmer_grey = BlendedColor(
             p.windowText().color(), p.window().color(), 0.6
         ).name()
-        self.status_label.setStyleSheet("color: {}".format(dimmer_grey))
+        self.status_label.setStyleSheet(f"QLabel {{ color: {dimmer_grey} }}")
         self.status_label.setFont(Font(10))
 
         self.setStyleSheet("QToolButton { border: none }")

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -54,8 +54,6 @@ class StatusPanel(QWidget):
         self.status_label.setStyleSheet("color: {}".format(dimmer_grey))
         self.status_label.setFont(Font(10))
 
-        self.on_sync_state_updated(0)
-
         self.setStyleSheet("QToolButton { border: none }")
         # self.setStyleSheet("""
         #    QToolButton { color: dimgrey; border: none; }
@@ -106,6 +104,8 @@ class StatusPanel(QWidget):
         )
         self.gateway.monitor.space_updated.connect(self.on_space_updated)
         self.gateway.monitor.nodes_updated.connect(self.on_nodes_updated)
+
+        self.on_sync_state_updated(0)
 
     def _update_status_label(self):
         if self.state == 0:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -29,6 +29,7 @@ from gridsync.desktop import open_path
 from gridsync.gui.font import Font
 from gridsync.gui.model import Model
 from gridsync.gui.share import InviteSenderDialog
+from gridsync.monitor import MagicFolderChecker
 from gridsync.msg import error
 from gridsync.util import humanized_list
 
@@ -46,7 +47,11 @@ class Delegate(QStyledItemDelegate):
 
     def on_frame_changed(self):
         values = self.parent.model().status_dict.values()
-        if 0 in values or 1 in values or 99 in values:
+        if (
+            MagicFolderChecker.LOADING in values
+            or MagicFolderChecker.SYNCING in values
+            or MagicFolderChecker.SCANNING in values
+        ):
             self.parent.viewport().update()
         else:
             self.waiting_movie.setPaused(True)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -62,12 +62,15 @@ class Delegate(QStyledItemDelegate):
         if column == 1:
             pixmap = None
             status = index.data(Qt.UserRole)
-            if not status:  # "Loading..."
+            if status == MagicFolderChecker.LOADING:
                 self.waiting_movie.setPaused(False)
                 pixmap = self.waiting_movie.currentPixmap().scaled(
                     20, 20, Qt.KeepAspectRatio, Qt.SmoothTransformation
                 )
-            elif status in (1, 99):  # "Syncing", "Scanning"
+            elif status in (
+                MagicFolderChecker.SYNCING,
+                MagicFolderChecker.SCANNING,
+            ):
                 self.sync_movie.setPaused(False)
                 pixmap = self.sync_movie.currentPixmap().scaled(
                     20, 20, Qt.KeepAspectRatio, Qt.SmoothTransformation

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -128,9 +128,13 @@ class MagicFolderChecker(QObject):
                 elif status == "failure":
                     failures.append(task)
                 self.operations["{}@{}".format(path, queued_at)] = task
-            if not state:
-                state = MagicFolderChecker.UP_TO_DATE
-                self.sync_time_started = 0
+            if state == MagicFolderChecker.LOADING:
+                if (
+                    self.gateway.monitor.grid_checker.is_connected  # XXX
+                    and self.initial_scan_completed
+                ):
+                    state = MagicFolderChecker.UP_TO_DATE
+                    self.sync_time_started = 0
         return state, kind, filepath, failures
 
     def process_status(self, status):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -35,7 +35,7 @@ class MagicFolderChecker(QObject):
         self.name = name
         self.remote = remote
 
-        self.state = None
+        self.state = 0
         self.mtime = 0
         self.size = 0
 

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -301,7 +301,7 @@ class Monitor(QObject):
         self.grid_checker = GridChecker(self.gateway)
         self.grid_checker.connected.connect(self.connected.emit)
         self.grid_checker.connected.connect(self.scan_rootcap)  # XXX
-        self.grid_checker.disconnected.connect(self.connected.emit)
+        self.grid_checker.disconnected.connect(self.disconnected.emit)
         self.grid_checker.nodes_updated.connect(self.nodes_updated.emit)
         self.grid_checker.space_updated.connect(self.space_updated.emit)
         self.magic_folder_checkers = {}

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -113,7 +113,7 @@ class Tahoe:
         self.config = Config(os.path.join(self.nodedir, "tahoe.cfg"))
         self.pidfile = os.path.join(self.nodedir, "twistd.pid")
         self.nodeurl = None
-        self.shares_happy = None
+        self.shares_happy = 0
         self.name = os.path.basename(self.nodedir)
         self.api_token = None
         self.magic_folders_dir = os.path.join(self.nodedir, "magic-folders")

--- a/tests/gui/test_history.py
+++ b/tests/gui/test_history.py
@@ -217,5 +217,7 @@ def test_history_list_widget_update_visible_widgets_on_show_event(
 
 
 def test_history_view_init():
-    hv = HistoryView(MagicMock(), MagicMock())
+    mock_gateway = MagicMock()
+    mock_gateway.shares_happy = 1
+    hv = HistoryView(mock_gateway, MagicMock())
     assert hv

--- a/tests/gui/test_status.py
+++ b/tests/gui/test_status.py
@@ -7,18 +7,31 @@ import pytest
 from gridsync.gui.status import StatusPanel
 
 
-def test_status_panel_hide_tor_button():
-    gateway = MagicMock()
-    gateway.use_tor = False
-    sp = StatusPanel(gateway, MagicMock())
+@pytest.fixture()
+def fake_tahoe():
+    t = Mock()
+    t.name = "TestGrid"
+    t.shares_happy = 3
+    return t
+
+
+def test_status_panel_hide_tor_button(fake_tahoe):
+    # gateway = MagicMock()
+    fake_tahoe.use_tor = False
+    sp = StatusPanel(fake_tahoe, MagicMock())
     assert sp.tor_button.isHidden() is True
 
 
 @pytest.mark.parametrize(
-    "state,text", [[0, "Connecting..."], [1, "Syncing"], [2, "Up to date"]]
+    "state,text",
+    [
+        [0, "Connecting to TestGrid (0/3)..."],
+        [1, "Syncing"],
+        [2, "Up to date"],
+    ],
 )
-def test_on_sync_state_updated(state, text):
-    sp = StatusPanel(MagicMock(), MagicMock())
+def test_on_sync_state_updated(state, text, fake_tahoe):
+    sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_sync_state_updated(state)
     assert sp.status_label.text() == text
 
@@ -30,42 +43,46 @@ def test_on_sync_state_updated(state, text):
         [1, 2, None, "Connected to 1 of 2 storage nodes"],
     ],
 )
-def test__update_grid_info(num_connected, num_known, available_space, tooltip):
-    sp = StatusPanel(MagicMock(), MagicMock())
+def test__update_grid_info(
+    num_connected, num_known, available_space, tooltip, fake_tahoe
+):
+    sp = StatusPanel(fake_tahoe, MagicMock())
     sp.num_connected = num_connected
     sp.num_known = num_known
     sp.available_space = available_space
-    sp._update_grid_info_tooltip()
-    assert sp.globe_action.toolTip() == tooltip
+    sp._update_status_label()
+    assert sp.status_label.toolTip() == tooltip
 
 
-def test_on_space_updated_humanize():
-    sp = StatusPanel(MagicMock(), MagicMock())
+def test_on_space_updated_humanize(fake_tahoe):
+    sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_space_updated(1024)
     assert sp.available_space == "1.0 kB"
 
 
-def test_on_nodes_updated_set_num_connected_and_num_known():
-    fake_tahoe = Mock()
-    fake_tahoe.name = "TestGrid"
-    fake_tahoe.shares_happy = 3
+def test_on_nodes_updated_set_num_connected_and_num_known(fake_tahoe):
+    # fake_tahoe = Mock()
+    # fake_tahoe.name = "TestGrid"
+    # fake_tahoe.shares_happy = 3
     sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_nodes_updated(4, 5)
     assert (sp.num_connected, sp.num_known) == (4, 5)
 
 
-def test_on_nodes_updated_grid_name_in_status_label():
-    fake_tahoe = Mock()
-    fake_tahoe.name = "TestGrid"
-    fake_tahoe.shares_happy = 3
+def test_on_nodes_updated_grid_name_in_status_label(fake_tahoe):
+    # fake_tahoe = Mock()
+    # fake_tahoe.name = "TestGrid"
+    # fake_tahoe.shares_happy = 3
     sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_nodes_updated(4, 5)
     assert sp.status_label.text() == "Connected to TestGrid"
 
 
-def test_on_nodes_updated_node_count_in_status_label_when_connecting():
-    fake_tahoe = Mock()
-    fake_tahoe.name = "TestGrid"
+def test_on_nodes_updated_node_count_in_status_label_when_connecting(
+    fake_tahoe,
+):
+    # fake_tahoe = Mock()
+    # fake_tahoe.name = "TestGrid"
     fake_tahoe.shares_happy = 5
     sp = StatusPanel(fake_tahoe, MagicMock())
     sp.on_nodes_updated(4, 5)

--- a/tests/gui/test_status.py
+++ b/tests/gui/test_status.py
@@ -23,15 +23,20 @@ def test_status_panel_hide_tor_button(fake_tahoe):
 
 
 @pytest.mark.parametrize(
-    "state,text",
+    "state,num_connected,shares_happy,text",
     [
-        [0, "Connecting to TestGrid (0/3)..."],
-        [1, "Syncing"],
-        [2, "Up to date"],
+        [0, 0, 0, "Connecting to TestGrid..."],
+        [0, 3, 5, "Connecting to TestGrid (3/5)..."],
+        [1, 5, 5, "Syncing"],
+        [2, 5, 5, "Up to date"],
     ],
 )
-def test_on_sync_state_updated(state, text, fake_tahoe):
+def test_on_sync_state_updated(
+    state, num_connected, shares_happy, text, fake_tahoe
+):
+    fake_tahoe.shares_happy = shares_happy
     sp = StatusPanel(fake_tahoe, MagicMock())
+    sp.num_connected = num_connected
     sp.on_sync_state_updated(state)
     assert sp.status_label.text() == text
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 from pytest_twisted import inlineCallbacks
@@ -10,7 +10,10 @@ from gridsync.monitor import MagicFolderChecker, GridChecker, Monitor
 
 @pytest.fixture(scope="function")
 def mfc():
-    return MagicFolderChecker(None, "TestFolder")
+    mock_gateway = Mock()
+    mock_gateway.monitor.grid_checker.is_connected = True
+    checker = MagicFolderChecker(mock_gateway, "TestFolder")
+    return checker
 
 
 def test_magic_folder_checker_name(mfc):
@@ -134,6 +137,7 @@ def test_parse_status_return_values_syncing(mfc):
 
 
 def test_parse_status_state_up_to_date(mfc):
+    mfc.initial_scan_completed = True
     state, _, _, _ = mfc.parse_status({})
     assert state == 2
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -166,31 +166,31 @@ def test_process_status_still_syncing_no_emit_status_updated(mfc, qtbot):
 
 
 def test_process_status_emit_status_updated_scanning(mfc, monkeypatch, qtbot):
-    mfc.state = 1
+    mfc.state = mfc.SYNCING
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.parse_status",
         lambda x, y: (2, "upload", "file_0", []),
     )
     with qtbot.wait_signal(mfc.status_updated) as blocker:
         mfc.process_status(status_data)
-    assert blocker.args == [99]
+    assert blocker.args == [mfc.SCANNING]
 
 
 def test_process_status_emit_status_updated_up_to_date(
     mfc, monkeypatch, qtbot
 ):
-    mfc.state = 99
+    mfc.state = mfc.SCANNING
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.parse_status",
         lambda x, y: (2, "upload", "file_0", []),
     )
     with qtbot.wait_signal(mfc.status_updated) as blocker:
         mfc.process_status(status_data)
-    assert blocker.args == [2]
+    assert blocker.args == [mfc.UP_TO_DATE]
 
 
 def test_process_status_emit_sync_finished(mfc, monkeypatch, qtbot):
-    mfc.state = 99
+    mfc.state = mfc.SCANNING
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.parse_status",
         lambda x, y: (2, "upload", "file_0", []),
@@ -200,7 +200,7 @@ def test_process_status_emit_sync_finished(mfc, monkeypatch, qtbot):
 
 
 def test_process_status_emit_sync_started(mfc, monkeypatch, qtbot):
-    mfc.state = 99
+    mfc.state = mfc.SCANNING
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.parse_status",
         lambda x, y: (1, "upload", "file_0", []),


### PR DESCRIPTION
This PR fixes #300, ensuring that no magic-folders will be marked as "Up to date" in the UI unless their corresponding `tahoe` client is sufficiently connected to the storage grid (as determined by whether it has connected to enough nodes to satisfy the `shares.happy` threshold _and_ has successfully completed a remote scan/crawl of the rootcap). The distinction between "Syncing" and "Scanning" has also been removed from the UI, since there was no functional difference between them from the user's perspective. Lastly, the total number of "connected" and "known" storage nodes -- along with the total amount of storage space available -- will now always be visible via the status label's tooltip (instead of via the now-removed "globe" button -- which served no other function).

Some additional -- and very minor -- code-quality improvements have also been included, in particular, constants (`LOADING`, `SYNCING`, `UP_TO_DATE`, etc.) are now used to more clearly represent folder-states instead of bare `int`s (`0`, `1`, `2`, etc.).