### PR TITLE
Build support for Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ frozen-tahoe:
 	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
+	python --version || deactivate && export PATH=$$HOME/Library/Python/2.7/bin:$$PATH && \
 	pushd build/tahoe-lafs && \
 	git checkout tahoe-lafs-1.14.0 && \
 	cp ../../misc/rsa-public-exponent.patch . && \

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ frozen-tahoe:
 	mkdir -p build/tahoe-lafs
 	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
+	# CPython2 virtualenvs are (irredeemably?) broken on Apple Silicon
+	# so allow falling back to the user environment.
+	# https://github.com/pypa/virtualenv/issues/2023
+	# https://github.com/pypa/virtualenv/issues/2024
 	source build/venv-tahoe/bin/activate && \
 	python --version || deactivate && \
 	pushd build/tahoe-lafs && \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 test:
 	@case `uname` in \
-		Darwin)	python3 -m tox ;; \
+		Darwin)	arch -x86_64 python3 -m tox ;; \
 		*) xvfb-run -a python3 -m tox ;; \
 	esac
 
@@ -259,10 +259,9 @@ appimage:
 	python3 scripts/make_appimage.py
 
 all:
-	$(MAKE) pyinstaller
 	@case `uname` in \
-		Darwin)	$(MAKE) dmg ;; \
-		*) $(MAKE) appimage ;; \
+		Darwin)	arch -x86_64 $(MAKE) pyinstaller dmg ;; \
+		*) $(MAKE) pyinstaller appimage ;; \
 	esac
 	python3 scripts/sha256sum.py dist/*.*
 

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ frozen-tahoe:
 	git clone https://github.com/tahoe-lafs/tahoe-lafs.git build/tahoe-lafs
 	python3 -m virtualenv --clear --python=python2 build/venv-tahoe
 	source build/venv-tahoe/bin/activate && \
-	python --version || deactivate && export PATH=$$HOME/Library/Python/2.7/bin:$$PATH && \
+	python --version || deactivate && \
 	pushd build/tahoe-lafs && \
 	git checkout tahoe-lafs-1.14.0 && \
 	cp ../../misc/rsa-public-exponent.patch . && \
@@ -156,7 +156,7 @@ frozen-tahoe:
 	python -m pip list && \
 	cp ../../misc/tahoe.spec pyinstaller.spec && \
 	export PYTHONHASHSEED=1 && \
-	pyinstaller pyinstaller.spec && \
+	python -m PyInstaller pyinstaller.spec && \
 	rm -rf dist/Tahoe-LAFS/cryptography-*-py2.7.egg-info && \
 	rm -rf dist/Tahoe-LAFS/include/python2.7 && \
 	rm -rf dist/Tahoe-LAFS/lib/python2.7 && \

--- a/misc/tahoe.spec
+++ b/misc/tahoe.spec
@@ -6,8 +6,8 @@ from distutils.sysconfig import get_python_lib
 import sys
 
 
-if not hasattr(sys, 'real_prefix'):
-    sys.exit("Please run inside a virtualenv with Tahoe-LAFS installed.")
+# if not hasattr(sys, 'real_prefix'):
+#    sys.exit("Please run inside a virtualenv with Tahoe-LAFS installed.")
 
 
 # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-remove-tkinter-tcl

--- a/misc/tahoe.spec
+++ b/misc/tahoe.spec
@@ -6,10 +6,6 @@ from distutils.sysconfig import get_python_lib
 import sys
 
 
-# if not hasattr(sys, 'real_prefix'):
-#    sys.exit("Please run inside a virtualenv with Tahoe-LAFS installed.")
-
-
 # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-remove-tkinter-tcl
 sys.modules['FixTk'] = None
 


### PR DESCRIPTION
This PR updates `make` targets and associated files to enable users of "Apple Silicon" (macOS arm64) machines to test and build the Gridsync application and it's dependencies from source. As per #322, support for macOS arm64 is presently very limited within the Python ecosystem and so this PR does _not_ aim to enable "native" compilation of arm64 binaries; instead it relies on Apple's "Rosetta" translation environment to produce x86_64 binaries that can both be built by and will run upon arm64 macOS machines. 