### PR TITLE
Reproducible builds for macOS and Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,15 +41,15 @@ jobs:
       run: |
         source ~/.bash_profile
         make all
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        python3 scripts/test_determinism.py
     - name: Verify
       run: |
         xvfb-run -a dist/Tahoe-LAFS/tahoe --version-and-path
         xvfb-run -a dist/Gridsync/gridsync --version
         xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        python3 scripts/test_determinism.py
     - name: Build (in container)
       run: |
         source ~/.bash_profile
@@ -104,14 +104,18 @@ jobs:
       run: |
         source ~/.bashrc
         make all
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        python3 scripts/test_determinism.py
     - name: Verify
       run: |
         dist/Gridsync.app/Contents/MacOS/Tahoe-LAFS/tahoe --version-and-path
         dist/Gridsync.app/Contents/MacOS/Gridsync --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        python3 scripts/test_determinism.py
+    - name: Make dmg
+      run: |
+        source ~/.bash_profile
+        make dmg
     - name: sha256sum
       run: python3 scripts/sha256sum.py dist/*.*
     - name: Upload artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Test determinism
       run: |
         source ~/.bash_profile
-        python3 scripts/test_determinism.py
+        make test-determinism
     - name: Build (in container)
       run: |
         source ~/.bash_profile
@@ -111,7 +111,7 @@ jobs:
     - name: Test determinism
       run: |
         source ~/.bashrc
-        python3 scripts/test_determinism.py
+        make test-determinism
     - name: Make dmg
       run: |
         source ~/.bashrc
@@ -146,13 +146,13 @@ jobs:
       run: .\make.bat test
     - name: Build
       run: .\make.bat all
-    - name: Test determinism
-      run: |
-        py -3 .\scripts\test_determinism.py
     - name: Verify
       run: |
         .\dist\Gridsync\Tahoe-LAFS\tahoe.exe --version-and-path
         .\dist\Gridsync\Gridsync.exe --version
+    - name: Test determinism
+      run: |
+        make test-determinism
     - name: sha256sum
       run: python3 scripts/sha256sum.py .\dist\*.*
     - name: Upload artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,10 +100,11 @@ jobs:
       run: |
         source ~/.bashrc
         make test
-    - name: Build
+    - name: Make pyinstaller
       run: |
         source ~/.bashrc
-        make all
+        make pyinstaller
+        make zip
     - name: Verify
       run: |
         dist/Gridsync.app/Contents/MacOS/Tahoe-LAFS/tahoe --version-and-path
@@ -144,8 +145,10 @@ jobs:
       run: py -3 -m pip install tox diffoscope
     - name: Test
       run: .\make.bat test
-    - name: Build
-      run: .\make.bat all
+    - name: Make pyinstaller
+      run: |
+        .\make.bat pyinstaller
+        .\make.bat zip
     - name: Verify
       run: |
         .\dist\Gridsync\Tahoe-LAFS\tahoe.exe --version-and-path

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,8 +83,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache${{ matrix.os.runs-on }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os.runs-on }}-
+        key: pyenv-${{ matrix.os.runs-on }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-${{ matrix.os.runs-on }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,10 @@ jobs:
       run: |
         source ~/.bash_profile
         make all
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        python3 scripts/test_determinism.py
     - name: Verify
       run: |
         xvfb-run -a dist/Tahoe-LAFS/tahoe --version-and-path
@@ -100,6 +104,10 @@ jobs:
       run: |
         source ~/.bashrc
         make all
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        python3 scripts/test_determinism.py
     - name: Verify
       run: |
         dist/Gridsync.app/Contents/MacOS/Tahoe-LAFS/tahoe --version-and-path
@@ -134,6 +142,9 @@ jobs:
       run: .\make.bat test
     - name: Build
       run: .\make.bat all
+    - name: Test determinism
+      run: |
+        py -3 .\scripts\test_determinism.py
     - name: Verify
       run: |
         .\dist\Gridsync\Tahoe-LAFS\tahoe.exe --version-and-path

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
         key: pip-${{ matrix.os.runs-on }}-${{ hashFiles('requirements/*.txt') }}
         restore-keys: pip-${{ matrix.os.runs-on }}-
     - name: Install dependencies
-      run: py -3 -m pip install tox
+      run: py -3 -m pip install tox diffoscope
     - name: Test
       run: .\make.bat test
     - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,9 @@ jobs:
     - name: Test determinism
       run: |
         make test-determinism
+    - name: Make installer
+      run: |
+        make installer
     - name: sha256sum
       run: python3 scripts/sha256sum.py .\dist\*.*
     - name: Upload artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,11 +110,11 @@ jobs:
         dist/Gridsync.app/Contents/MacOS/Gridsync --version
     - name: Test determinism
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         python3 scripts/test_determinism.py
     - name: Make dmg
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make dmg
     - name: sha256sum
       run: python3 scripts/sha256sum.py dist/*.*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         dist/Gridsync.app/Contents/MacOS/Gridsync --version
     - name: Test determinism
       run: |
-        source ~/.bash_profile
+        #source ~/.bash_profile
         python3 scripts/test_determinism.py
     - name: Make dmg
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,8 +83,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-${{ matrix.os.runs-on }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-${{ matrix.os.runs-on }}-
+        key: pyenv-cache${{ matrix.os.runs-on }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os.runs-on }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:
@@ -110,7 +110,7 @@ jobs:
         dist/Gridsync.app/Contents/MacOS/Gridsync --version
     - name: Test determinism
       run: |
-        #source ~/.bash_profile
+        source ~/.bash_profile
         python3 scripts/test_determinism.py
     - name: Make dmg
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,10 +155,10 @@ jobs:
         .\dist\Gridsync\Gridsync.exe --version
     - name: Test determinism
       run: |
-        make test-determinism
+        .\make.bat test-determinism
     - name: Make installer
       run: |
-        make installer
+        .\make.bat installer
     - name: sha256sum
       run: python3 scripts/sha256sum.py .\dist\*.*
     - name: Upload artifacts

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ pyinstaller:
 	pyinstaller -y misc/gridsync.spec
 
 zip:
+	python3 scripts/update_permissions.py dist
 	python3 scripts/update_timestamps.py dist
 	python3 scripts/make_zip.py
 

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,9 @@ zip:
 	python3 scripts/update_timestamps.py dist
 	python3 scripts/make_zip.py
 
+test-determinism:
+	python3 scripts/test_determinism.py
+
 dmg:
 	python3 -m virtualenv --clear build/venv-dmg
 	source build/venv-dmg/bin/activate && \

--- a/make.bat
+++ b/make.bat
@@ -100,6 +100,9 @@ goto :eof
 %PYTHON3% .\scripts\make_zip.py
 goto :eof
 
+:test-determinism
+%PYTHON3% .\scripts\test_determinism.py
+goto :eof
 
 :installer
 call copy misc\InnoSetup.iss .

--- a/make.bat
+++ b/make.bat
@@ -95,6 +95,7 @@ if not exist ".\dist\Tahoe-LAFS" call :frozen-tahoe
 goto :eof
 
 :zip
+%PYTHON3% .\scripts\update_permissions.py .\dist
 %PYTHON3% .\scripts\update_timestamps.py .\dist
 %PYTHON3% .\scripts\make_zip.py
 goto :eof

--- a/make.bat
+++ b/make.bat
@@ -38,6 +38,7 @@ if "%1"=="test" call :test
 if "%1"=="frozen-tahoe" call :frozen-tahoe
 if "%1"=="pyinstaller" call :pyinstaller
 if "%1"=="zip" call :zip
+if "%1"=="test-determinism" call :test-determinism
 if "%1"=="installer" call :installer
 if "%1"=="vagrant-desktop-linux" call :vagrant-desktop-linux
 if "%1"=="vagrant-desktop-macos" call :vagrant-desktop-macos

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -111,22 +111,7 @@ exec "$(dirname "$(readlink -e "$0")")/usr/bin/{}" "$@"
 os.chmod('build/AppDir/AppRun', 0o755)
 
 
-# Some distros (ubuntu-20.04, debian-10) have a default umask of 022
-# while others (ubuntu-20.10, fedora-32) use 0002. Normalizing this
-# helps to make the AppImage build deterministically/reproducibly.
-resource_dirs = [
-    "build/AppDir/usr/bin/resources",
-    "build/AppDir/usr/share/icons/hicolor/scalable/apps"
-]
-for resource_dir in resource_dirs:
-    for root, directories, files in os.walk(resource_dir):
-        for file in files:
-            os.chmod(os.path.join(root, file), 0o644)
-        for directory in directories:
-            os.chmod(os.path.join(root, directory), 0o755)
-
-
-# Created the .DirIcon symlink here/now to prevent appimagetool from
+# Create the .DirIcon symlink here/now to prevent appimagetool from
 # doing it later, thereby allowing the atime and mtime of the symlink
 # to be overriden along with all of the other files in the AppDir.
 try:
@@ -134,6 +119,8 @@ try:
 except OSError:
     pass
 
+
+subprocess.call(["python3", "scripts/update_permissions.py", "build/AppDir"])
 subprocess.call(["python3", "scripts/update_timestamps.py", "build/AppDir"])
 
 

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -6,10 +6,28 @@ try:
 except ImportError:
     from ConfigParser import RawConfigParser
 import os
-import shutil
+import zipfile
 
 
 config = RawConfigParser(allow_no_value=True)
 config.read(os.path.join("gridsync", "resources", "config.txt"))
 app_name = config.get("application", "name")
-shutil.make_archive(os.path.join("dist", app_name), "zip", "dist", app_name)
+#shutil.make_archive(os.path.join("dist", app_name), "zip", "dist", app_name)
+
+def make_zip(base_name, root_dir=None, base_dir=None):
+    zipfile_path = os.path.abspath(base_name)
+    if not root_dir:
+        root_dir = os.getcwd()
+    if not base_dir:
+        base_dir = os.getcwd()
+
+    os.chdir(root_dir)
+    paths = []
+    for root, _, files in os.walk(base_dir):
+        for file in files:
+            paths.append(os.path.join(root, file))
+    with zipfile.ZipFile(zipfile_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(paths):
+            zf.write(path)
+
+make_zip(os.path.join("dist", app_name) + ".zip", "dist", app_name)

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -38,7 +38,7 @@ def make_zip(base_name, root_dir=None, base_dir=None):
                 zf.writestr(zipfile.ZipInfo.from_file(path), "")
             elif os.path.islink(path):
                 zinfo = zipfile.ZipInfo.from_file(path)
-                zinfo.filename = path
+                zinfo.filename = path  # To strip trailing "/" from dirs
                 zinfo.create_system = 3
                 zinfo.external_attr = (0o755 | stat.S_IFLNK) << 16
                 zf.writestr(zinfo, os.readlink(path))

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -32,6 +32,10 @@ def make_zip(base_name, root_dir=None, base_dir=None):
         for path in sorted(paths):
             if path.endswith("/"):
                 zf.writestr(zipfile.ZipInfo.from_file(path), "")
+            elif os.path.islink(path):
+                zinfo = zipfile.ZipInfo.from_file(path)
+                zinfo.external_attr |= 0o120000 << 16
+                zf.writestr(zinfo, os.readlink(path))
             else:
                 zf.write(path, compresslevel=1)
 

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import zipfile
 from configparser import RawConfigParser
 
@@ -39,4 +40,10 @@ def make_zip(base_name, root_dir=None, base_dir=None):
             else:
                 zf.write(path, compresslevel=1)
 
-make_zip(os.path.join("dist", app_name) + ".zip", "dist", app_name)
+
+if sys.platform == "darwin":
+    make_zip(
+        os.path.join("dist", app_name) + ".zip", "dist", app_name + ".app"
+    )
+else:
+    make_zip(os.path.join("dist", app_name) + ".zip", "dist", app_name)

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -10,7 +10,7 @@ from configparser import RawConfigParser
 config = RawConfigParser(allow_no_value=True)
 config.read(os.path.join("gridsync", "resources", "config.txt"))
 app_name = config.get("application", "name")
-#shutil.make_archive(os.path.join("dist", app_name), "zip", "dist", app_name)
+
 
 def make_zip(base_name, root_dir=None, base_dir=None):
     zipfile_path = os.path.abspath(base_name)

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-try:
-    from configparser import RawConfigParser
-except ImportError:
-    from ConfigParser import RawConfigParser
 import os
 import zipfile
+from configparser import RawConfigParser
 
 
 config = RawConfigParser(allow_no_value=True)
@@ -28,6 +25,6 @@ def make_zip(base_name, root_dir=None, base_dir=None):
             paths.append(os.path.join(root, file))
     with zipfile.ZipFile(zipfile_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for path in sorted(paths):
-            zf.write(path)
+            zf.write(path, compresslevel=1)
 
 make_zip(os.path.join("dist", app_name) + ".zip", "dist", app_name)

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -20,11 +20,19 @@ def make_zip(base_name, root_dir=None, base_dir=None):
 
     os.chdir(root_dir)
     paths = []
-    for root, _, files in os.walk(base_dir):
+    for root, directories, files in os.walk(base_dir):
         for file in files:
             paths.append(os.path.join(root, file))
+        for directory in directories:
+            dirpath = os.path.join(root, directory)
+            if not os.listdir(dirpath):  # Directory is empty
+                paths.append(dirpath + "/")
+
     with zipfile.ZipFile(zipfile_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for path in sorted(paths):
-            zf.write(path, compresslevel=1)
+            if path.endswith("/"):
+                zf.writestr(zipfile.ZipInfo.from_file(path), "")
+            else:
+                zf.write(path, compresslevel=1)
 
 make_zip(os.path.join("dist", app_name) + ".zip", "dist", app_name)

--- a/scripts/provision_devtools.bat
+++ b/scripts/provision_devtools.bat
@@ -8,4 +8,4 @@ choco install -y --no-progress --require-checksums visualcpp-build-tools
 choco install -y --no-progress --require-checksums innosetup
 choco install -y --no-progress --require-checksums rust-ms
 py -2 -m pip install --upgrade setuptools pip
-py -3 -m pip install --upgrade setuptools pip tox
+py -3 -m pip install --upgrade setuptools pip tox diffoscope

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -61,7 +61,7 @@ fi
 pyenv versions
 
 python2 -m pip install --upgrade setuptools pip
-python3 -m pip install --upgrade setuptools pip tox
+python3 -m pip install --upgrade setuptools pip tox diffoscope
 
 rustup-init -y --default-host "$RUST_DEFAULT_HOST" --default-toolchain stable
 . $HOME/.cargo/env

--- a/scripts/test_determinism.py
+++ b/scripts/test_determinism.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from configparser import RawConfigParser
+
+
+config = RawConfigParser(allow_no_value=True)
+config.read(os.path.join("gridsync", "resources", "config.txt"))
+name = config.get("application", "name")
+
+
+def sha256sum(filepath):
+    hasher = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for block in iter(lambda: f.read(4096), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def call_make_clean_zip():
+    if sys.platform == "win32":
+        subprocess.call(["make.bat", "clean"])
+        subprocess.call(["make.bat", "pyinstaller"])
+        subprocess.call(["make.bat", "zip"])
+    else:
+        subprocess.call(["make", "clean", "pyinstaller", "zip"])
+
+
+if __name__ == "__main__":
+    zipfile = os.path.join("dist", name + ".zip")
+    if not os.path.exists(zipfile):
+        call_make_clean_zip()
+    zipfile_tmp = os.path.join(tempfile.mkdtemp(), name + "-1.zip")
+    shutil.move(zipfile, zipfile_tmp)
+    call_make_clean_zip()
+    zipfile1 = os.path.join("dist", name + "-1.zip")
+    shutil.move(zipfile_tmp, zipfile1)
+    checksum1 = sha256sum(zipfile1)
+    print("{}  {}".format(checksum1, zipfile1))
+    checksum2 = sha256sum(zipfile)
+    print("{}  {}".format(checksum2, zipfile))
+    if checksum1 == checksum2:
+        print("Hashes match; success!")
+    else:
+        print("Hashes don't match; running diffoscope...")
+        subprocess.call(["diffoscope", zipfile, zipfile1])
+        sys.exit(1)

--- a/scripts/test_determinism.py
+++ b/scripts/test_determinism.py
@@ -27,6 +27,10 @@ def call_make_clean_zip():
         subprocess.call(["make.bat", "clean"])
         subprocess.call(["make.bat", "pyinstaller"])
         subprocess.call(["make.bat", "zip"])
+    elif sys.platform == "darwin":
+        subprocess.call(
+            ["arch", "-x86_64", "make", "clean", "pyinstaller", "zip"]
+        )
     else:
         subprocess.call(["make", "clean", "pyinstaller", "zip"])
 

--- a/scripts/update_permissions.py
+++ b/scripts/update_permissions.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Some distros (ubuntu-20.04, debian-10) have a default umask of 022
+# while others (ubuntu-20.10, fedora-32) use 0002. Normalizing this
+# helps with deterministic/reproducible builds.
 
 import os
 import sys

--- a/scripts/update_permissions.py
+++ b/scripts/update_permissions.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+
+def update_permissions(path):
+    for root, directories, files, in os.walk(path):
+        for file in files:
+            filepath = os.path.join(root, file)
+            if os.access(filepath, os.X_OK):
+                os.chmod(filepath, 0o755)
+            else:
+                os.chmod(filepath, 0o644)
+        for directory in directories:
+            os.chmod(os.path.join(root, directory), 0o755)
+    os.chmod(path, 0o755)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: {} <path>".format(sys.argv[0]))
+    else:
+        update_permissions(sys.argv[1])

--- a/scripts/update_timestamps.py
+++ b/scripts/update_timestamps.py
@@ -11,20 +11,17 @@ def git_timestamp():
 
 
 def update_timestamps(path, timestamp):
+    paths = [path]
     for root, directories, files, in os.walk(path):
         for file in files:
-            os.utime(
-                os.path.join(root, file),
-                (timestamp, timestamp),
-                follow_symlinks=False
-            )
+            paths.append(os.path.join(root, file))
         for directory in directories:
-            os.utime(
-                os.path.join(root, directory),
-                (timestamp, timestamp),
-                follow_symlinks=False
-            )
-    os.utime(path, (timestamp, timestamp))
+            paths.append(os.path.join(root, directory))
+    for p in paths:
+        try:
+            os.utime(p, (timestamp, timestamp), follow_symlinks=False)
+        except NotImplementedError:  # Windows
+            os.utime(p, (timestamp, timestamp))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `make test-determinism` make target/command that sequentially "compiles" two PyInstaller bundles and compares their hashes against each other in order to verify the (local) reproducibility of the Gridsync build process. The files contained within the generated PyInstaller bundles are added (deterministically, with normalized file-permissions and timestamps) to an intermediate `Gridsync.zip` archive in order to facilitate further comparison and/or distribution of build outputs, while checks that do fail will have their outputs run through the `diffoscope` utility in order to identify any sources of variance between builds.

As it currently stands, this work is sufficient to demonstrate that PyInstaller "onedir" builds are indeed deterministic/reproducible on macOS _and_ Windows -- so long as a) the `PYTHONHASHSEED` environment variable is set to a known-value, b) the file-permissions and timestamps of the files within the bundle are normalized in advance (e.g., by using the scripts contained in this PR and #329), and c) any relevant components in build environment remain otherwise unchanged between builds.

Importantly, while this PR makes it possible to easily verify that a given on-disk install of Gridsync is bit-for-bit identical with that built on a separate system (since the hash of the archive of the installed instance will now match the hash of the intermediate archive built by, e.g., Buildbot or GitHub Actions), in the case of macOS, both `codesign`ed application bundles and disk images (`.dmg` files) contain timestamps that naturally jeopardize the determinism of the resultant files. Accordingly, the scope of this PR should be understood to only demonstrate the reproducibility of the PyInstaller-generated binaries and related build processes on a given host environment; it does not offer a means of generating reproducible `.dmg` files, nor does it provide tooling for, e.g., stripping away any `codesign` signatures prior to verification. Any such efforts will need to be made separately and later. 

Closes #331 _and_ #332.