### PR TITLE
Slightly clarify the logic for determining how many ZKAPs are available

### DIFF
--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import List, Optional
 
 import attr
-
 from PyQt5.QtCore import QObject, pyqtSignal
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.error import ConnectError

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -294,6 +294,7 @@ class _VoucherParse(object):
         time at which a voucher was seen to have been redeemed.  If no
         redemption was seen then the value is an empty string instead.
     """
+
     total_tokens = attr.ib()
     unpaid_vouchers = attr.ib()
     zkaps_last_redeemed = attr.ib()

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -290,7 +290,9 @@ class _VoucherParse(object):
     :ivar unpaid_vouchers: A list of voucher identifiers which are believed to
         not yet have been paid for.
 
-    :ivar zkaps_last_redeemed: The
+    :ivar zkaps_last_redeemed: An ISO8601 datetime string giving the latest
+        time at which a voucher was seen to have been redeemed.  If no
+        redemption was seen then the value is an empty string instead.
     """
     total_tokens = attr.ib()
     unpaid_vouchers = attr.ib()
@@ -304,6 +306,19 @@ def _parse_vouchers(
     """
     Examine a list of vouchers states from ZKAPAuthorizer to derive certain
     facts about the overall state.
+
+    :param vouchers: A representation of the vouchers to inspect.  This is
+        expected to be a value like the one returned by ZKAPAuthorizer's **GET
+        /storage-plugins/privatestorageio-zkapauthz-v1/voucher** endpoint.
+
+    :param time_started: The time at which the currently active
+        ``ZKAPChecker`` began monitoring the state of vouchers in the
+        ZKAPAuthorizer-enabled Tahoe-LAFS node.  This is used to exclude
+        vouchers older than this checker, the redemption status of which this
+        function cannot currently interpret.
+
+    :return: A summary of the state of the vouchers and the number of tokens
+        available.
     """
     total = 0
     zkaps_last_redeemed = ""

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -495,7 +495,6 @@ class ZKAPChecker(QObject):
             return  # XXX
         remaining = zkaps.get("total")
         if remaining and not total:
-            print("Remaining: {!r} total: {!r}".format(remaining, total))
             total = self._maybe_load_last_total()
         if not total or remaining > total:
             # When redeeming tokens in batches, ZKAPs become available

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -324,7 +324,7 @@ class ZKAPChecker(QObject):
                 if number and number not in unpaid_vouchers:
                     # XXX There is no reliable way of knowing whether the user
                     # intends to pay for an older voucher -- i.e., one that
-                    # was created before the before the application started --
+                    # was created before the application started --
                     # so ignore those older vouchers for now and only monitor
                     # those vouchers that were created during *this* run.
                     created = voucher.get("created")

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -5,7 +5,9 @@ import time
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+
+import attr
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from twisted.internet.defer import inlineCallbacks
@@ -277,6 +279,61 @@ class GridChecker(QObject):
             self.num_happy = num_happy
 
 
+@attr.s
+class _VoucherParse(object):
+    """
+    :ivar total_tokens: A number of spendable tokens that are expected to
+        exist due to all of the vouchers that have already been redeemed plus
+        those expected to exist when vouchers currently being redeemed finish
+        being redeemed.
+
+    :ivar unpaid_vouchers: A list of voucher identifiers which are believed to
+        not yet have been paid for.
+
+    :ivar zkaps_last_redeemed: The
+    """
+    total_tokens = attr.ib()
+    unpaid_vouchers = attr.ib()
+    zkaps_last_redeemed = attr.ib()
+
+
+def _parse_vouchers(
+    vouchers: List[dict],
+    time_started: datetime,
+) -> _VoucherParse:
+    """
+    Examine a list of vouchers states from ZKAPAuthorizer to derive certain
+    facts about the overall state.
+    """
+    total = 0
+    zkaps_last_redeemed = ""
+    unpaid_vouchers = set()
+    for voucher in vouchers:
+        number = voucher["number"]
+        state = voucher["state"]
+        name = state["name"]
+        if name == "unpaid":
+            # XXX There is no reliable way of knowing whether the user
+            # intends to pay for an older voucher -- i.e., one that
+            # was created before the application started --
+            # so ignore those older vouchers for now and only monitor
+            # those vouchers that were created during *this* run.
+            created = voucher["created"]
+            if created is None:
+                continue
+            time_created = datetime.fromisoformat(created)
+            if time_created > time_started:
+                unpaid_vouchers.add(number)
+        elif name == "redeeming":
+            total += voucher["expected-tokens"]
+        elif name == "redeemed":
+            total += state["token-count"]
+            finished = state["finished"]
+            zkaps_last_redeemed = max(zkaps_last_redeemed, finished)
+
+    return _VoucherParse(total, sorted(unpaid_vouchers), zkaps_last_redeemed)
+
+
 class ZKAPChecker(QObject):
 
     zkaps_updated = pyqtSignal(int, int)  # used, remaining
@@ -290,7 +347,7 @@ class ZKAPChecker(QObject):
         super().__init__()
         self.gateway = gateway
 
-        self._time_started: int = 0
+        self._time_started: Optional[datetime] = None
         self._low_zkaps_warning_shown: bool = False
 
         self.zkaps_remaining: int = 0
@@ -307,50 +364,6 @@ class ZKAPChecker(QObject):
         seconds = datetime.timestamp(now) - datetime.timestamp(last_redeemed)
         consumption_rate = zkaps_spent / seconds
         return consumption_rate
-
-    def _parse_vouchers(  # noqa: max-complexity
-        self, vouchers: List[dict]
-    ) -> int:
-        total = 0
-        unpaid_vouchers = self.unpaid_vouchers.copy()
-        zkaps_last_redeemed = self.zkaps_last_redeemed
-        for voucher in vouchers:
-            state = voucher.get("state")
-            if not state:
-                continue
-            name = state.get("name")
-            number = voucher.get("number")
-            if name == "unpaid":
-                if number and number not in unpaid_vouchers:
-                    # XXX There is no reliable way of knowing whether the user
-                    # intends to pay for an older voucher -- i.e., one that
-                    # was created before the application started --
-                    # so ignore those older vouchers for now and only monitor
-                    # those vouchers that were created during *this* run.
-                    created = voucher.get("created")
-                    if not created:
-                        continue
-                    time_created = datetime.timestamp(
-                        datetime.fromisoformat(created)
-                    )
-                    if time_created > self._time_started:
-                        unpaid_vouchers.append(number)
-            elif name == "redeeming":
-                total += state.get("expected-tokens", 0)
-            elif name == "redeemed":
-                if number and number in unpaid_vouchers:
-                    unpaid_vouchers.remove(number)
-                total += state.get("token-count")
-                finished = state.get("finished")
-                if finished > zkaps_last_redeemed:
-                    zkaps_last_redeemed = finished
-        if unpaid_vouchers != self.unpaid_vouchers:
-            self.unpaid_vouchers = unpaid_vouchers
-            self.unpaid_vouchers_updated.emit(self.unpaid_vouchers)
-        if zkaps_last_redeemed != self.zkaps_last_redeemed:
-            self.zkaps_last_redeemed = zkaps_last_redeemed
-            self.zkaps_redeemed.emit(self.zkaps_last_redeemed)
-        return total
 
     def _maybe_emit_low_zkaps_warning(self):
         if (
@@ -371,8 +384,25 @@ class ZKAPChecker(QObject):
                 last_redeemed = f.read()
         except FileNotFoundError:
             return
-        self.zkaps_last_redeemed = last_redeemed
-        self.zkaps_redeemed.emit(last_redeemed)
+        self.update_zkaps_last_redeemed(last_redeemed)
+
+    def _update_unpaid_vouchers(self, unpaid_vouchers):
+        """
+        Record and propagate notification about the set of unpaid vouchers
+        changing, if it has.
+        """
+        if unpaid_vouchers != self.unpaid_vouchers:
+            self.unpaid_vouchers = unpaid_vouchers
+            self.unpaid_vouchers_updated.emit(self.unpaid_vouchers)
+
+    def _update_zkaps_last_redeemed(self, zkaps_last_redeemed):
+        """
+        Record and propagate notification about last redemption time moving
+        forward, if it has.
+        """
+        if zkaps_last_redeemed > self.zkaps_last_redeemed:
+            self.zkaps_last_redeemed = zkaps_last_redeemed
+            self.zkaps_redeemed.emit(self.zkaps_last_redeemed)
 
     def _maybe_load_last_total(self) -> int:
         try:
@@ -420,8 +450,8 @@ class ZKAPChecker(QObject):
 
     @inlineCallbacks  # noqa: max-complexity
     def do_check(self):  # noqa: max-complexity
-        if not self._time_started:
-            self._time_started = time.time()
+        if self._time_started is None:
+            self._time_started = datetime.now()
         if not self.gateway.zkap_auth_required or self.gateway.nodeurl is None:
             # Either the node doesn't use ZKAPs or isn't running.
             return
@@ -434,7 +464,14 @@ class ZKAPChecker(QObject):
                 self._maybe_load_last_redeemed()
             else:
                 self.emit_zkaps_updated(self.zkaps_remaining, self.zkaps_total)
-        total = self._parse_vouchers(vouchers)
+        parse = _parse_vouchers(
+            vouchers,
+            self._time_started,
+        )
+        total = parse.total_tokens
+        self._update_unpaid_vouchers(parse.unpaid_vouchers)
+        self._update_zkaps_last_redeemed(parse.zkaps_last_redeemed)
+
         try:
             zkaps = yield self.gateway.zkapauthorizer.get_zkaps(limit=1)
         except (ConnectError, TahoeWebError):

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -279,7 +279,7 @@ class GridChecker(QObject):
 
 
 @attr.s
-class _VoucherParse(object):
+class _VoucherParse:
     """
     :ivar total_tokens: A number of spendable tokens that are expected to
         exist due to all of the vouchers that have already been redeemed plus

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -495,6 +495,7 @@ class ZKAPChecker(QObject):
             return  # XXX
         remaining = zkaps.get("total")
         if remaining and not total:
+            logging.debug("Remaining: %r total: %r", remaining, total)
             total = self._maybe_load_last_total()
         if not total or remaining > total:
             # When redeeming tokens in batches, ZKAPs become available

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -374,6 +374,8 @@ class ZKAPChecker(QObject):
 
     def consumption_rate(self):
         zkaps_spent = self.zkaps_total - self.zkaps_remaining
+        # XXX zkaps_last_redeemed starts as "0" which cannot be parsed as an
+        # ISO8601 datetime.
         last_redeemed = datetime.fromisoformat(self.zkaps_last_redeemed)
         now = datetime.now()
         seconds = datetime.timestamp(now) - datetime.timestamp(last_redeemed)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -495,7 +495,7 @@ class ZKAPChecker(QObject):
             return  # XXX
         remaining = zkaps.get("total")
         if remaining and not total:
-            logging.debug("Remaining: %r total: %r", remaining, total)
+            print("Remaining: {!r} total: {!r}".format(remaining, total))
             total = self._maybe_load_last_total()
         if not total or remaining > total:
             # When redeeming tokens in batches, ZKAPs become available

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -422,10 +422,8 @@ class ZKAPChecker(QObject):
     def do_check(self):  # noqa: max-complexity
         if not self._time_started:
             self._time_started = time.time()
-        if (
-            self.gateway.zkap_auth_required is not True
-            or not self.gateway.nodeurl
-        ):
+        if not self.gateway.zkap_auth_required or self.gateway.nodeurl is None:
+            # Either the node doesn't use ZKAPs or isn't running.
             return
         try:
             vouchers = yield self.gateway.zkapauthorizer.get_vouchers()

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -94,6 +94,15 @@ class CommandProtocol(ProcessProtocol):
 
 class Tahoe:
 
+    """
+    :ivar zkap_auth_required: ``True`` if the node is configured to use
+        ZKAPAuthorizer and spend ZKAPs for storage operations, ``False``
+        otherwise.
+
+    :ivar nodeurl: ``None`` until the Tahoe-LAFS child process is running,
+        then a string giving the root of the node's HTTP API.
+    """
+
     STOPPED = 0
     STARTING = 1
     STARTED = 2
@@ -138,7 +147,7 @@ class Tahoe:
         self.settings: dict = {}
 
         self.zkapauthorizer = ZKAPAuthorizer(self)
-        self.zkap_auth_required = False
+        self.zkap_auth_required: bool = False
 
         self.monitor.zkaps_redeemed.connect(self.zkapauthorizer.backup_zkaps)
         self.monitor.sync_finished.connect(

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import versioneer
 
 requirements = [
     "atomicwrites",
+    "attrs",
     "autobahn",
     'distro ; sys_platform != "darwin" and sys_platform != "win32"',
     "humanize",

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -469,7 +469,10 @@ def test_monitor_do_checks_add_magic_folder_checker(monkeypatch):
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.do_check", lambda _: MagicMock()
     )
-    monitor = Monitor(MagicMock(magic_folders={"TestFolder": {}}))
+    gateway = MagicMock(magic_folders={"TestFolder": {}})
+    gateway.zkap_auth_required = False
+
+    monitor = Monitor(gateway)
     monitor.grid_checker = MagicMock()
     yield monitor.do_checks()
     assert "TestFolder" in monitor.magic_folder_checkers
@@ -480,7 +483,10 @@ def test_monitor_do_checks_switch_magic_folder_checker_remote(monkeypatch):
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.do_check", lambda _: MagicMock()
     )
-    monitor = Monitor(MagicMock(magic_folders={"TestFolder": {}}))
+    gateway = MagicMock(magic_folders={"TestFolder": {}})
+    gateway.zkap_auth_required = False
+
+    monitor = Monitor(gateway)
     monitor.grid_checker = MagicMock()
     test_mfc = MagicFolderChecker(MagicMock(), "TestFolder")
     test_mfc.remote = True
@@ -494,7 +500,10 @@ def test_monitor_emit_check_finished(monkeypatch, qtbot):
     monkeypatch.setattr(
         "gridsync.monitor.MagicFolderChecker.do_check", lambda _: MagicMock()
     )
-    monitor = Monitor(MagicMock(magic_folders={"TestFolder": {}}))
+    gateway = MagicMock(magic_folders={"TestFolder": {}})
+    gateway.zkap_auth_required = False
+
+    monitor = Monitor(gateway)
     monitor.grid_checker = MagicMock()
     with qtbot.wait_signal(monitor.check_finished):
         yield monitor.do_checks()


### PR DESCRIPTION
It seems likely that https://github.com/PrivateStorageio/ZKAPAuthorizer/issues/110 will need to break some of the assumptions made by GridSync in its calculation of the number of ZKAPs available to be spent in the client.  In particular, the work there introduces the possibility of *unspendable* ZKAPs existing in the system.

In trying to understand how GridSync arrives at its understanding about how many spendable ZKAPs there are, I found it helpful to break `_parse_vouchers` out into a free function and slightly simplify it by separating the concerns of extracting information from the list of vouchers from the internal state management `ZKAPChecker` wants to do to be able to propagate change information elsewhere.

The changes in this PR are not meant to introduce any behavior changes.  They're meant as a pure refactoring only.