### PR TITLE
Run the test suite during Nix package build

### DIFF
--- a/nix/gridsync.nix
+++ b/nix/gridsync.nix
@@ -32,6 +32,8 @@ python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   src = ../.;
 
+  patches = [ ./test_network.patch ];
+
   nativeBuildInputs = [
     wrapQtAppsHook
   ];

--- a/nix/gridsync.nix
+++ b/nix/gridsync.nix
@@ -78,9 +78,12 @@ python3Packages.buildPythonApplication rec {
     wrapProgram "$out/bin/gridsync" "''${qtWrapperArgs[@]}"
   '';
 
-  doCheck = false;
-
-  # checkPhase = ''
-  # ${xvfb_run}/bin/xvfb-run -a pytest tests
-  # '';
+  # The test suite also needs Qt to work.  So wrap up the command for running
+  # the test suite with the same Qt wrapper args and then run that wrapper.
+  checkPhase = ''
+    echo ${xvfb_run}/bin/xvfb-run -a pytest tests > run-tests.sh
+    chmod u+x run-tests.sh
+    wrapProgram run-tests.sh "''${qtWrapperArgs[@]}"
+    ./run-tests.sh
+  '';
 }

--- a/nix/pytesttwisted.nix
+++ b/nix/pytesttwisted.nix
@@ -1,10 +1,10 @@
 # Copied and modified from https://github.com/garbas/nixpkgs-python/blob/master/pytest/requirements.nix
 { stdenv, fetchurl, python3Packages }:
 python3Packages.buildPythonPackage {
-  name = "pytest-twisted-1.10";
+  name = "pytest-twisted-1.13.3";
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/17/42/7a08d581834054c909b9604ec97ff2d9e923c7eaa1ea7012248fb8e6045e/pytest-twisted-1.10.zip";
-    sha256 = "b13a8c53c1763ce5a7497dfe60b67d766dafe2b50f1353be0dd098cf76be2eac";
+    url = "https://files.pythonhosted.org/packages/2b/05/fb4addd4e1f86fad3bb52064139db15174f56b00df4ff8c2ad3c5edb01b6/pytest-twisted-1.13.3.tar.gz";
+    sha256 = "08k3gqp9zn58ybhhs7f38pk756qmynmf86sczbrb0dw9q6h5c8x8";
   };
   doCheck = false;
   checkPhase = "";

--- a/nix/test_network.patch
+++ b/nix/test_network.patch
@@ -1,0 +1,18 @@
+diff --git a/tests/test_network.py b/tests/test_network.py
+index 57c3188e..c16bc318 100644
+--- a/tests/test_network.py
++++ b/tests/test_network.py
+@@ -6,11 +6,12 @@ import pytest
+ 
+ from gridsync.network import get_free_port, get_local_network_ip
+ 
+-
++@pytest.mark.skip(reason="network is unavailable")
+ def test_get_local_network_ip_returns_str():
+     assert type(get_local_network_ip()) is str
+ 
+ 
++@pytest.mark.skip(reason="network is unavailable")
+ def test_get_local_network_ip_is_ip_address():
+     address = ip_address(get_local_network_ip())
+     assert type(address) in (IPv4Address, IPv6Address)


### PR DESCRIPTION
It is idiomatic to run test suites as part of Nix package builds.  This enables that behavior.  The test suite passes on my local system:

```
===== 614 passed, 2 skipped, 2 deselected, 1 xpassed, 8 warnings in 7.05s ======
```

I would be happy to see this running on CI but I'm not sure if anyone else would.
