### PR TITLE
Add GPG and Authenticode signing scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,14 +295,10 @@ all:
 	python3 scripts/sha256sum.py dist/*.*
 
 gpg-sign:
-	gpg2 -a --detach-sign --default-key 0xD38A20A62777E1A5 release/Gridsync-Linux.AppImage
-	gpg2 -a --detach-sign --default-key 0xD38A20A62777E1A5 release/Gridsync-macOS.dmg
-	gpg2 -a --detach-sign --default-key 0xD38A20A62777E1A5 release/Gridsync-Windows-setup.exe
+	python3 scripts/gpg.py --sign
 
 gpg-verify:
-	gpg2 --verify release/Gridsync-Linux.AppImage{.asc,}
-	gpg2 --verify release/Gridsync-macOS.dmg{.asc,}
-	gpg2 --verify release/Gridsync-Windows-setup.exe{.asc,}
+	python3 scripts/gpg.py --verify
 
 pypi-release:
 	python setup.py sdist bdist_wheel

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -25,6 +25,7 @@ issues_url = https://github.com/gridsync/gridsync/issues
 
 [sign]
 mac_developer_id = Christopher Wood
+gpg_key = 0xD38A20A62777E1A5
 
 [wormhole]
 appid = tahoe-lafs.org/invite

--- a/scripts/gpg.py
+++ b/scripts/gpg.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import sys
+from configparser import RawConfigParser
+from pathlib import Path
+from subprocess import run
+
+config = RawConfigParser(allow_no_value=True)
+config.read(Path("gridsync", "resources", "config.txt"))
+settings: dict = {}
+for section in config.sections():
+    if section not in settings:
+        settings[section] = {}
+    for option, value in config.items(section):
+        settings[section][option] = value
+
+application_name = settings["application"]["name"]
+gpg_key = settings["sign"]["gpg_key"]
+
+paths = []
+for p in Path("dist").glob(application_name + "*.*"):
+    path = str(p)
+    if not path.endswith(".asc"):
+        paths.append(path)
+if not paths:
+    sys.exit("No files to sign; exiting")
+
+
+if len(sys.argv) < 2:
+    sys.exit(f"Usage: {sys.argv[0]} [--sign] [--verify]")
+if sys.argv[1] == "--sign":
+    for path in paths:
+        proc = run(
+            [
+                "gpg",
+                "--yes",
+                "--armor",
+                "--detach-sign",
+                "--default-key",
+                gpg_key,
+                path,
+            ]
+        )
+        if proc.returncode:
+            sys.exit(f"Error signing {path}")
+elif sys.argv[1] == "--verify":
+    for path in paths:
+        proc = run(["gpg", "--verify", path + ".asc", path])
+        if proc.returncode:
+            sys.exit(f"Error verifying {path}")

--- a/scripts/signtool.py
+++ b/scripts/signtool.py
@@ -33,23 +33,31 @@ paths.extend(
 if not paths:
     sys.exit("No files to sign; exiting")
 
-for path in paths:
-    proc = run(
-        [
-            signtool_path,
-            "sign",
-            "/n",
-            signtool_name,
-            "/sha1",
-            signtool_sha1,
-            "/tr",
-            signtool_timestamp_server,
-            "/td",
-            "sha256",
-            "/fd",
-            "sha256",
-            path,
-        ]
-    )
-    if proc.returncode:
-        sys.exit(f"Error signing {path}")
+if len(sys.argv) < 2:
+    sys.exit(f"Usage: {sys.argv[0]} [--sign] [--verify]")
+if sys.argv[1] == "--sign":
+    for path in paths:
+        proc = run(
+            [
+                signtool_path,
+                "sign",
+                "/n",
+                signtool_name,
+                "/sha1",
+                signtool_sha1,
+                "/tr",
+                signtool_timestamp_server,
+                "/td",
+                "sha256",
+                "/fd",
+                "sha256",
+                path,
+            ]
+        )
+        if proc.returncode:
+            sys.exit(f"Error signing {path}")
+elif sys.argv[1] == "--verify":
+    for path in paths:
+        proc = run([signtool_path, "Verify", "/pa", path])
+        if proc.returncode:
+            sys.exit(f"Error verifying {path}")

--- a/scripts/signtool.py
+++ b/scripts/signtool.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from configparser import RawConfigParser
+from pathlib import Path
+from subprocess import run
+
+config = RawConfigParser(allow_no_value=True)
+config.read(Path("gridsync", "resources", "config.txt"))
+settings: dict = {}
+for section in config.sections():
+    if section not in settings:
+        settings[section] = {}
+    for option, value in config.items(section):
+        settings[section][option] = value
+
+application_name = settings["application"]["name"]
+signtool_name = settings["sign"]["signtool_name"]
+signtool_sha1 = settings["sign"]["signtool_sha1"]
+signtool_timestamp_server = settings["sign"]["signtool_timestamp_server"]
+
+kits_bin = Path(os.environ["PROGRAMFILES(X86)"], "Windows Kits", "10", "bin")
+signtools = sorted(list(kits_bin.glob("10.*/x64/signtool.exe")), reverse=True)
+if not signtools:
+    sys.exit("signtool.exe not found")
+signtool_path = str(signtools[0])
+
+paths = [str(p) for p in list(Path("dist", application_name).glob("**/*.exe"))]
+paths.extend(
+    [str(p) for p in list(Path("dist").glob(application_name + "*.exe"))]
+)
+if not paths:
+    sys.exit("No files to sign; exiting")
+
+for path in paths:
+    proc = run(
+        [
+            signtool_path,
+            "sign",
+            "/n",
+            signtool_name,
+            "/sha1",
+            signtool_sha1,
+            "/tr",
+            signtool_timestamp_server,
+            "/td",
+            "sha256",
+            "/fd",
+            "sha256",
+            path,
+        ]
+    )
+    if proc.returncode:
+        sys.exit(f"Error signing {path}")

--- a/scripts/signtool.py
+++ b/scripts/signtool.py
@@ -41,6 +41,7 @@ if sys.argv[1] == "--sign":
             [
                 signtool_path,
                 "sign",
+                "/v",
                 "/n",
                 signtool_name,
                 "/sha1",
@@ -58,6 +59,6 @@ if sys.argv[1] == "--sign":
             sys.exit(f"Error signing {path}")
 elif sys.argv[1] == "--verify":
     for path in paths:
-        proc = run([signtool_path, "Verify", "/pa", path])
+        proc = run([signtool_path, "Verify", "/v", "/pa", path])
         if proc.returncode:
             sys.exit(f"Error verifying {path}")


### PR DESCRIPTION
This PR adds and makes use of a couple of basic wrappers/scripts around the `gpg` and `signtool` utilities, intended to facilitate the automation of signing- and release-related tasks -- especially on "rebranded" builds of the Gridsync application. More specifically, these scripts support reading additional signing-related parameters from `config.txt`, allowing, e.g., signing keys/identities to be declared in a single location. This allows individuals who wish to build and sign the application under a different identity to do so more easily -- namely, by updating the relevant values in `gridsync/resources/config.txt` (instead of hunting for and changing the previously-hardcoded values in the `Makefile`, batch scripts, etc.).