### PR TITLE
Fix the `await_ready` polling rate

### DIFF
--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -13,7 +13,6 @@ import yaml
 from atomicwrites import atomic_write
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.error import ConnectError
-from twisted.internet.task import deferLater
 from twisted.python.procutils import which
 
 from gridsync import settings as global_settings

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -118,6 +118,7 @@ class Tahoe:
             else:
                 log.debug('Connecting to "%s"...', self.name)
             return ready
+
         self._ready_poller = Poller(reactor, poll, 0.2)
 
     def load_newscap(self):

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -106,11 +106,12 @@ class Poller(object):
     :ivar _waiting: The ``Deferred`` instances which will be fired to signal
         completion of the current polling attempt.
     """
-    clock : IReactorTime = attr.ib()
-    target : Callable[None, Deferred[bool]] = attr.ib()
-    interval : float = attr.ib()
-    _idle : bool = attr.ib(default=True)
-    _waiting : List[Deferred[None]] = attr.ib(default=attr.Factory(list))
+
+    clock: IReactorTime = attr.ib()
+    target: Callable[None, Deferred[bool]] = attr.ib()
+    interval: float = attr.ib()
+    _idle: bool = attr.ib(default=True)
+    _waiting: List[Deferred[None]] = attr.ib(default=attr.Factory(list))
 
     def wait_for_completion(self):
         """

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -143,7 +143,7 @@ class Poller:
                 self._completed()
             else:
                 self._schedule()
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self._deliver_result(Failure())
 
     def _completed(self):

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -87,7 +87,7 @@ def strip_html_tags(s):
 
 
 @attr.s
-class Poller(object):
+class Poller:
     """
     Poll some asynchronous function until it signals completion, then publish
     a notification to as many Deferreds as are waiting.

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -106,7 +106,7 @@ class Poller(object):
     """
 
     clock: IReactorTime = attr.ib()
-    target: Callable[None, Deferred[bool]] = attr.ib()
+    target: Callable[[], Deferred[bool]] = attr.ib()
     interval: float = attr.ib()
     _idle: bool = attr.ib(default=True)
     _waiting: List[Deferred[None]] = attr.ib(default=attr.Factory(list))

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -143,7 +143,7 @@ class Poller:
                 self._completed()
             else:
                 self._schedule()
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             self._deliver_result(Failure())
 
     def _completed(self):

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -2,14 +2,12 @@
 
 from binascii import hexlify, unhexlify
 from html.parser import HTMLParser
-
 from typing import Callable, List
 
 import attr
-
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.interfaces import IReactorTime
 from twisted.internet.task import deferLater
-from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.python.failure import Failure
 
 B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -434,8 +434,6 @@ def test_concurrent_await_ready(tahoe, monkeypatch):
     The rate of polling the Tahoe node for readiness is independent of the
     number of ``await_ready`` calls made.
     """
-    from twisted.internet.task import deferLater
-
     # The tahoe fixture gets the mock reactor fixture which can't schedule
     # anything.  Replace it with a scheduler we control.
     clock = MemoryReactorClock()

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -445,10 +445,12 @@ def test_concurrent_await_ready(tahoe, monkeypatch):
     def measure_poll_count(how_many_waiters):
         is_ready = False
         poll_count = 0
+
         def check_ready(self):
             nonlocal poll_count
             poll_count += 1
             return is_ready
+
         monkeypatch.setattr("gridsync.tahoe.Tahoe.is_ready", check_ready)
 
         # Start the polling operations


### PR DESCRIPTION
Fixes #414 

This brings CPU usage all the way down to 30% - comparable to where pulseaudio or Firefox idles :(  I guess that's what passes for industry standard now.

Maybe at some future point we can actually get rid of polling to address this the rest of the way.
