### PR TITLE
Handle new lease crawler configuration items

### DIFF
--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -704,6 +704,9 @@ _ZKAPAUTHZ_OPTIONAL_ITEMS = {
     "pass-value",
     "default-token-count",
     "allowed-public-keys",
+    "lease.crawl-interval.mean",
+    "lease.crawl-interval.range",
+    "lease.min-time-remaining",
 }
 def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -697,6 +697,14 @@ class Tahoe:
             log.debug("No storage plugins found")
 
 
+# The names of all of the optional items in a ZKAPAuthorizer configuration
+# section.  These are optional both in the storage options object and the
+# tahoe.cfg section.
+_ZKAPAUTHZ_OPTIONAL_ITEMS = {
+    "pass-value",
+    "default-token-count",
+    "allowed-public-keys",
+}
 def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
     Reshape a storage-options configuration dictionary into a tahoe.cfg
@@ -712,12 +720,12 @@ def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, An
             "redeemer": "ristretto",
             "ristretto-issuer-root-url": options.get("ristretto-issuer-root-url"),
         }
-        if pass_value:
-            zkapauthz["pass-value"] = pass_value
-        if default_token_count:
-            zkapauthz["default-token-count"] = default_token_count
-        if allowed_public_keys:
-            zkapauthz["allowed-public-keys"] = allowed_public_keys
+        zkapauthz.update({
+            optional_item: options.get(optional_item)
+            for optional_item
+            in _ZKAPAUTHZ_OPTIONAL_ITEMS
+            if options.get(optional_item) is not None
+        })
 
         return {
             "client": {

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
 
 import treq
 import yaml
@@ -708,7 +708,11 @@ _ZKAPAUTHZ_OPTIONAL_ITEMS = {
     "lease.crawl-interval.range",
     "lease.min-time-remaining",
 }
-def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+
+def storage_options_to_config(
+    options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
     """
     Reshape a storage-options configuration dictionary into a tahoe.cfg
     configuration dictionary.
@@ -721,14 +725,17 @@ def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, An
 
         zkapauthz = {
             "redeemer": "ristretto",
-            "ristretto-issuer-root-url": options.get("ristretto-issuer-root-url"),
+            "ristretto-issuer-root-url": options.get(
+                "ristretto-issuer-root-url"
+            ),
         }
-        zkapauthz.update({
-            optional_item: options.get(optional_item)
-            for optional_item
-            in _ZKAPAUTHZ_OPTIONAL_ITEMS
-            if options.get(optional_item) is not None
-        })
+        zkapauthz.update(
+            {
+                optional_item: options.get(optional_item)
+                for optional_item in _ZKAPAUTHZ_OPTIONAL_ITEMS
+                if options.get(optional_item) is not None
+            }
+        )
 
         return {
             "client": {

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import treq
 import yaml
@@ -710,9 +710,7 @@ _ZKAPAUTHZ_OPTIONAL_ITEMS = {
 }
 
 
-def storage_options_to_config(
-    options: Dict[str, Any]
-) -> Optional[Dict[str, Any]]:
+def storage_options_to_config(options: Dict) -> Optional[Dict]:
     """
     Reshape a storage-options configuration dictionary into a tahoe.cfg
     configuration dictionary.
@@ -740,3 +738,5 @@ def storage_options_to_config(
             },
             "storageclient.plugins.privatestorageio-zkapauthz-v1": zkapauthz,
         }
+
+    return None

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Any, Optional
 
 import treq
 import yaml
@@ -264,45 +264,13 @@ class Tahoe:
                     "Skipping unknown storage plugin option: %s", options
                 )
                 continue
-            name = options.get("name")
-            if name == "privatestorageio-zkapauthz-v1":
-                # TODO: Append name instead of setting/overriding?
-                self.config_set("client", "storage.plugins", name)
-                self.config_set(
-                    "storageclient.plugins.privatestorageio-zkapauthz-v1",
-                    "redeemer",
-                    "ristretto",
-                )
-                self.config_set(
-                    "storageclient.plugins.privatestorageio-zkapauthz-v1",
-                    "ristretto-issuer-root-url",
-                    options.get("ristretto-issuer-root-url"),
-                )
-                pass_value = options.get("pass-value")
-                if pass_value:
-                    self.config_set(
-                        "storageclient.plugins.privatestorageio-zkapauthz-v1",
-                        "pass-value",
-                        pass_value,
-                    )
-                default_token_count = options.get("default-token-count")
-                if default_token_count:
-                    self.config_set(
-                        "storageclient.plugins.privatestorageio-zkapauthz-v1",
-                        "default-token-count",
-                        default_token_count,
-                    )
-                allowed_public_keys = options.get("allowed-public-keys")
-                if allowed_public_keys:
-                    self.config_set(
-                        "storageclient.plugins.privatestorageio-zkapauthz-v1",
-                        "allowed-public-keys",
-                        allowed_public_keys,
-                    )
-            else:
+            config = storage_options_to_config(options)
+            if config is None:
                 log.warning(
                     "Skipping unknown storage plugin option: %s", options
                 )
+            else:
+                self.config.save(config)
 
     def add_storage_server(
         self, server_id, furl, nickname=None, storage_options=None
@@ -727,3 +695,34 @@ class Tahoe:
             log.debug("Found storage plugins: %s", plugins)
         else:
             log.debug("No storage plugins found")
+
+
+def storage_options_to_config(options : Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Reshape a storage-options configuration dictionary into a tahoe.cfg
+    configuration dictionary.
+    """
+    name = options.get("name")
+    if name == "privatestorageio-zkapauthz-v1":
+        pass_value = options.get("pass-value")
+        default_token_count = options.get("default-token-count")
+        allowed_public_keys = options.get("allowed-public-keys")
+
+        zkapauthz = {
+            "redeemer": "ristretto",
+            "ristretto-issuer-root-url": options.get("ristretto-issuer-root-url"),
+        }
+        if pass_value:
+            zkapauthz["pass-value"] = pass_value
+        if default_token_count:
+            zkapauthz["default-token-count"] = default_token_count
+        if allowed_public_keys:
+            zkapauthz["allowed-public-keys"] = allowed_public_keys
+
+        return {
+            "client": {
+                # TODO: Append name instead of setting/overriding?
+                "storage.plugins": name,
+            },
+            "storageclient.plugins.privatestorageio-zkapauthz-v1": zkapauthz,
+        }

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -719,10 +719,6 @@ def storage_options_to_config(
     """
     name = options.get("name")
     if name == "privatestorageio-zkapauthz-v1":
-        pass_value = options.get("pass-value")
-        default_token_count = options.get("default-token-count")
-        allowed_public_keys = options.get("allowed-public-keys")
-
         zkapauthz = {
             "redeemer": "ristretto",
             "ristretto-issuer-root-url": options.get(

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -15,7 +15,12 @@ from twisted.internet.testing import MemoryReactorClock
 
 from gridsync.crypto import randstr
 from gridsync.errors import TahoeCommandError, TahoeError, TahoeWebError
-from gridsync.tahoe import Tahoe, get_nodedirs, is_valid_furl, storage_options_to_config
+from gridsync.tahoe import (
+    Tahoe,
+    get_nodedirs,
+    is_valid_furl,
+    storage_options_to_config,
+)
 
 
 def fake_get(*args, **kwargs):
@@ -237,13 +242,22 @@ def test_storage_options_to_config_unknown():
     If a storage option name is unrecognized ``storage_options_to_config``
     returns ``None``.
     """
-    assert storage_options_to_config({
-        "name": "privatestorageio-imaginary-v1",
-    }) is None
+    assert (
+        storage_options_to_config(
+            {
+                "name": "privatestorageio-imaginary-v1",
+            }
+        )
+        is None
+    )
+
 
 # The name of the tahoe.cfg section where ZKAPAuthorizer client plugin config
 # goes.
-zkapauthz_plugin_section = "storageclient.plugins.privatestorageio-zkapauthz-v1"
+zkapauthz_plugin_section = (
+    "storageclient.plugins.privatestorageio-zkapauthz-v1"
+)
+
 
 def test_storage_options_to_config_no_optional_values():
     """
@@ -251,14 +265,19 @@ def test_storage_options_to_config_no_optional_values():
     then the resulting tahoe.cfg enables the ZKAPAuthorizer plugin but has
     none of the missing options.
     """
-    config = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-    })
-    assert config["client"]["storage.plugins"] == "privatestorageio-zkapauthz-v1"
+    config = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+        }
+    )
+    assert (
+        config["client"]["storage.plugins"] == "privatestorageio-zkapauthz-v1"
+    )
     zkapauthz = config[zkapauthz_plugin_section]
     assert "pass_value" not in zkapauthz
     assert "default-token-count" not in zkapauthz
     assert "allowed-public-keys" not in zkapauthz
+
 
 def test_storage_options_to_config_pass_value():
     """
@@ -267,11 +286,14 @@ def test_storage_options_to_config_pass_value():
     """
     pass_value = 12345
     key = "pass-value"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: pass_value,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: pass_value,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == pass_value
+
 
 def test_storage_options_to_config_default_token_count():
     """
@@ -281,11 +303,14 @@ def test_storage_options_to_config_default_token_count():
     """
     default_token_count = 54321
     key = "default-token-count"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: default_token_count,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: default_token_count,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == default_token_count
+
 
 def test_storage_options_to_config_allowed_public_keys():
     """
@@ -295,11 +320,14 @@ def test_storage_options_to_config_allowed_public_keys():
     """
     allowed_public_keys = "Key1,Key2,Key3,Key4"
     key = "allowed-public-keys"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: allowed_public_keys,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: allowed_public_keys,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == allowed_public_keys
+
 
 def test_storage_options_to_config_lease_crawl_interval_mean():
     """
@@ -309,11 +337,14 @@ def test_storage_options_to_config_lease_crawl_interval_mean():
     """
     mean = 234
     key = "lease.crawl-interval.mean"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: mean,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: mean,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == mean
+
 
 def test_storage_options_to_config_lease_crawl_interval_range():
     """
@@ -323,11 +354,14 @@ def test_storage_options_to_config_lease_crawl_interval_range():
     """
     range_ = 456
     key = "lease.crawl-interval.range"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: range_,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: range_,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == range_
+
 
 def test_storage_options_to_config_lease_min_time_remaining():
     """
@@ -337,11 +371,14 @@ def test_storage_options_to_config_lease_min_time_remaining():
     """
     min_time = 789
     key = "lease.min-time-remaining"
-    zkapauthz = storage_options_to_config({
-        "name": "privatestorageio-zkapauthz-v1",
-        key: min_time,
-    })[zkapauthz_plugin_section]
+    zkapauthz = storage_options_to_config(
+        {
+            "name": "privatestorageio-zkapauthz-v1",
+            key: min_time,
+        }
+    )[zkapauthz_plugin_section]
     assert zkapauthz[key] == min_time
+
 
 def test_add_storage_servers_writes_zkapauthorizer_allowed_public_keys(tmpdir):
     nodedir = str(tmpdir.mkdir("TestGrid"))

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -301,6 +301,48 @@ def test_storage_options_to_config_allowed_public_keys():
     })[zkapauthz_plugin_section]
     assert zkapauthz[key] == allowed_public_keys
 
+def test_storage_options_to_config_lease_crawl_interval_mean():
+    """
+    If ``lease.crawl-interval.mean`` is present in the storage options then it
+    is included in the resulting configuration's ZKAPAuthorizer client plugin
+    section.
+    """
+    mean = 234
+    key = "lease.crawl-interval.mean"
+    zkapauthz = storage_options_to_config({
+        "name": "privatestorageio-zkapauthz-v1",
+        key: mean,
+    })[zkapauthz_plugin_section]
+    assert zkapauthz[key] == mean
+
+def test_storage_options_to_config_lease_crawl_interval_range():
+    """
+    If ``lease.crawl-interval.range`` is present in the storage options then it
+    is included in the resulting configuration's ZKAPAuthorizer client plugin
+    section.
+    """
+    range_ = 456
+    key = "lease.crawl-interval.range"
+    zkapauthz = storage_options_to_config({
+        "name": "privatestorageio-zkapauthz-v1",
+        key: range_,
+    })[zkapauthz_plugin_section]
+    assert zkapauthz[key] == range_
+
+def test_storage_options_to_config_lease_min_time_remaining():
+    """
+    If ``lease.min-time-remaining`` is present in the storage options then it
+    is included in the resulting configuration's ZKAPAuthorizer client plugin
+    section.
+    """
+    min_time = 789
+    key = "lease.min-time-remaining"
+    zkapauthz = storage_options_to_config({
+        "name": "privatestorageio-zkapauthz-v1",
+        key: min_time,
+    })[zkapauthz_plugin_section]
+    assert zkapauthz[key] == min_time
+
 def test_add_storage_servers_writes_zkapauthorizer_allowed_public_keys(tmpdir):
     nodedir = str(tmpdir.mkdir("TestGrid"))
     os.makedirs(os.path.join(nodedir, "private"))


### PR DESCRIPTION
Fixes #417 

These items are all optional.  It's not necessary to update ZKAPAuthorizer for these changes to be valid (they just won't do anything until ZKAPAuthorizer is updated).  There is still at least one more related ZKAPAuthorizer change to make before any of this will particularly help GridSync so it's not worth making that update yet.
