### PR TITLE
test `_ZKAPChecker._maybe_load_last_redeemed` and fix the AttributeError

### DIFF
--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -184,7 +184,7 @@ class ZKAPChecker(QObject):
                 last_redeemed = f.read()
         except FileNotFoundError:
             return
-        self.update_zkaps_last_redeemed(last_redeemed)
+        self._update_zkaps_last_redeemed(last_redeemed)
 
     def _update_unpaid_vouchers(self, unpaid_vouchers):
         """

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import MagicMock, Mock, call
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, Mock, call
 
 from pytest_twisted import inlineCallbacks
 


### PR DESCRIPTION
Fixes an `AttributeError` introduced in 407b57c44b96bae00b629595f84484e2735855e9 in the `last-redeemed` file handling code path.
