### PR TITLE
Ensure `pip check` passes before calling PyInstaller

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ setenv =
     PYTHONHASHSEED=1
 commands =
     pip list
+    {envpython} -m pip check
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-magic-folder]
@@ -50,6 +51,7 @@ setenv =
     PYTHONHASHSEED=1
 commands =
     pip list
+    {envpython} -m pip check
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-gridsync]
@@ -62,6 +64,7 @@ setenv =
     PYTHONHASHSEED=1
 commands =
     pip list
+    {envpython} -m pip check
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller]
@@ -76,6 +79,7 @@ setenv =
     PYTHONHASHSEED=1
 commands =
     pip list
+    {envpython} -m pip check
     pyinstaller -y pyinstaller.spec
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
 setenv =
     PYTHONHASHSEED=1
 commands =
+    {envpython} -m pip install tahoe-lafs==1.17.0
     pip list
     {envpython} -m pip check
     pyinstaller -y pyinstaller.spec

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,6 @@ deps =
 setenv =
     PYTHONHASHSEED=1
 commands =
-    {envpython} -m pip install tahoe-lafs==1.17.0
     pip list
     {envpython} -m pip check
     pyinstaller -y pyinstaller.spec

--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,7 @@ commands =
     {envpython} -m pip install --editable .
     {envpython} -m pipdeptree --local-only
     {envpython} -m pip list --outdated
+    {envpython} -m pip check
 
 
 [testenv:update-hashes]


### PR DESCRIPTION
Fixes #434 