### PR TITLE
Make leaving magic-folders (and removing folder backups) idempotent

### DIFF
--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -299,7 +299,9 @@ class View(QTreeView):
     @inlineCallbacks
     def remove_folder(self, folder_name, unlink=False):
         try:
-            yield self.gateway.magic_folder.leave_folder(folder_name)
+            yield self.gateway.magic_folder.leave_folder(
+                folder_name, missing_ok=True
+            )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
             error(

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -249,7 +249,7 @@ class View(QTreeView):
         error(self, str(failure.type.__name__), str(failure.value))
 
     @inlineCallbacks
-    def unlink_folder(self, folder_name):
+    def remove_folder_backup(self, folder_name):
         try:
             yield self.gateway.magic_folder.remove_folder_backup(folder_name)
         except Exception as e:  # pylint: disable=broad-except
@@ -293,11 +293,11 @@ class View(QTreeView):
         if msgbox.exec_() == QMessageBox.Yes:
             tasks = []
             for folder in folders:
-                tasks.append(self.unlink_folder(folder))
+                tasks.append(self.remove_folder_backup(folder))
             DeferredList(tasks)
 
     @inlineCallbacks
-    def remove_folder(self, folder_name, unlink=False):
+    def remove_folder(self, folder_name, remove_backup=False):
         try:
             yield self.gateway.magic_folder.leave_folder(
                 folder_name, missing_ok=True
@@ -316,8 +316,8 @@ class View(QTreeView):
         # self.model().remove_folder(folder_name)
         self.model().on_folder_removed(folder_name)
         logging.debug('Successfully removed folder "%s"', folder_name)
-        if unlink:
-            yield self.unlink_folder(folder_name)
+        if remove_backup:
+            yield self.remove_folder_backup(folder_name)
 
     def confirm_stop_syncing(self, folders):
         msgbox = QMessageBox(self)
@@ -366,10 +366,10 @@ class View(QTreeView):
             tasks = []
             if checkbox.checkState() == Qt.Checked:
                 for folder in folders:
-                    tasks.append(self.remove_folder(folder, unlink=False))
+                    tasks.append(self.remove_folder(folder, remove_backup=False))
             else:
                 for folder in folders:
-                    tasks.append(self.remove_folder(folder, unlink=True))
+                    tasks.append(self.remove_folder(folder, remove_backup=True))
             DeferredList(tasks)
 
     def open_folders(self, folders):

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -313,7 +313,6 @@ class View(QTreeView):
                 ),
             )
             return
-        # self.model().remove_folder(folder_name)
         self.model().on_folder_removed(folder_name)
         logging.debug('Successfully removed folder "%s"', folder_name)
         if remove_backup:
@@ -366,10 +365,14 @@ class View(QTreeView):
             tasks = []
             if checkbox.checkState() == Qt.Checked:
                 for folder in folders:
-                    tasks.append(self.remove_folder(folder, remove_backup=False))
+                    tasks.append(
+                        self.remove_folder(folder, remove_backup=False)
+                    )
             else:
                 for folder in folders:
-                    tasks.append(self.remove_folder(folder, remove_backup=True))
+                    tasks.append(
+                        self.remove_folder(folder, remove_backup=True)
+                    )
             DeferredList(tasks)
 
     def open_folders(self, folders):

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -256,8 +256,8 @@ class View(QTreeView):
             logging.error("%s: %s", type(e).__name__, str(e))
             error(
                 self,
-                'Error unlinking folder "{}"'.format(folder_name),
-                'An exception was raised when unlinking the "{}" folder:\n\n'
+                'Error removing "{}" backup'.format(folder_name),
+                'An exception was raised when removing the "{}" backup:\n\n'
                 "{}: {}\n\nPlease try again later.".format(
                     folder_name, type(e).__name__, str(e)
                 ),

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -264,9 +264,9 @@ class View(QTreeView):
             )
             return
         self.model().remove_folder(folder_name)
-        logging.debug('Successfully unlinked folder "%s"', folder_name)
+        logging.debug('Successfully removed "%s" folder backup', folder_name)
 
-    def confirm_unlink(self, folders):
+    def confirm_remove_folder_backup(self, folders):
         msgbox = QMessageBox(self)
         msgbox.setIcon(QMessageBox.Question)
         humanized_folders = humanized_list(folders, "folders")
@@ -467,7 +467,7 @@ class View(QTreeView):
             open_action.setEnabled(False)
             share_menu.setEnabled(False)
             remove_action.triggered.connect(
-                lambda: self.confirm_unlink(selected)
+                lambda: self.confirm_remove_folder_backup(selected)
             )
         else:
             for folder in selected:

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -643,11 +643,10 @@ class MagicFolder:
             body=json.dumps({"really-delete-write-capability": True}).encode(),
             error_404_ok=missing_ok,
         )
-        # XXX
-        # try:
-        #    del self.magic_folders[folder_name]
-        # except KeyError:
-        #    pass
+        try:
+            del self.magic_folders[folder_name]
+        except KeyError:
+            pass
 
     def get_directory(self, folder_name: str) -> str:
         return self.magic_folders.get(folder_name, {}).get("magic_path", "")

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -634,12 +634,14 @@ class MagicFolder:
         yield self.create_folder_backup(name)  # XXX
 
     @inlineCallbacks
-    def leave_folder(self, folder_name: str) -> TwistedDeferred[None]:
+    def leave_folder(
+        self, folder_name: str, missing_ok=False
+    ) -> TwistedDeferred[None]:
         yield self._request(
             "DELETE",
             f"/magic-folder/{folder_name}",
             body=json.dumps({"really-delete-write-capability": True}).encode(),
-            code_404_ok=True,
+            code_404_ok=missing_ok,
         )
         # XXX
         # try:

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -577,7 +577,11 @@ class MagicFolder:
 
     @inlineCallbacks
     def _request(
-        self, method: str, path: str, body: bytes = b""
+        self,
+        method: str,
+        path: str,
+        body: bytes = b"",
+        code_404_ok: bool = False,
     ) -> TwistedDeferred[dict]:
         if not self.api_token:
             raise MagicFolderWebError("API token not found")
@@ -590,7 +594,7 @@ class MagicFolder:
             data=body,
         )
         content = yield treq.content(resp)
-        if resp.code in (200, 201):
+        if resp.code in (200, 201) or (resp.code == 404 and code_404_ok):
             return json.loads(content)
         raise MagicFolderWebError(
             f"Error {resp.code} requesting {method} /v1{path}: {content}"

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -275,7 +275,6 @@ class MagicFolderMonitor(QObject):
         for folder, data in current_folders.items():
             if folder not in previous_folders:
                 self.folder_added.emit(folder)
-                print("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADDED", folder)
                 magic_path = data.get("magic_path", "")
                 try:
                     self._watchdog.add_watch(magic_path)
@@ -286,7 +285,6 @@ class MagicFolderMonitor(QObject):
         for folder, data in previous_folders.items():
             if folder not in current_folders:
                 self.folder_removed.emit(folder)
-                print("RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRREMOVED", folder)
                 magic_path = data.get("magic_path", "")
                 try:
                     self._watchdog.remove_watch(magic_path)

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -581,7 +581,7 @@ class MagicFolder:
         method: str,
         path: str,
         body: bytes = b"",
-        code_404_ok: bool = False,
+        error_404_ok: bool = False,
     ) -> TwistedDeferred[dict]:
         if not self.api_token:
             raise MagicFolderWebError("API token not found")
@@ -594,7 +594,7 @@ class MagicFolder:
             data=body,
         )
         content = yield treq.content(resp)
-        if resp.code in (200, 201) or (resp.code == 404 and code_404_ok):
+        if resp.code in (200, 201) or (resp.code == 404 and error_404_ok):
             return json.loads(content)
         raise MagicFolderWebError(
             f"Error {resp.code} requesting {method} /v1{path}: {content}"
@@ -641,7 +641,7 @@ class MagicFolder:
             "DELETE",
             f"/magic-folder/{folder_name}",
             body=json.dumps({"really-delete-write-capability": True}).encode(),
-            code_404_ok=missing_ok,
+            error_404_ok=missing_ok,
         )
         # XXX
         # try:

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -781,6 +781,10 @@ class MagicFolder:
                 ),
             ]
         )
+        try:
+            del self.remote_magic_folders[folder_name]
+        except KeyError:
+            pass
 
     @inlineCallbacks
     def restore_folder_backup(

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -635,7 +635,7 @@ class MagicFolder:
 
     @inlineCallbacks
     def leave_folder(
-        self, folder_name: str, missing_ok=False
+        self, folder_name: str, missing_ok: bool = False
     ) -> TwistedDeferred[None]:
         yield self._request(
             "DELETE",

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -639,6 +639,7 @@ class MagicFolder:
             "DELETE",
             f"/magic-folder/{folder_name}",
             body=json.dumps({"really-delete-write-capability": True}).encode(),
+            code_404_ok=True,
         )
         # XXX
         # try:

--- a/gridsync/rootcap.py
+++ b/gridsync/rootcap.py
@@ -149,6 +149,6 @@ class RootcapManager:
         backup_cap = yield self.get_backup_cap(dirname)
         yield self.lock.acquire()
         try:
-            yield self.gateway.unlink(backup_cap, name)
+            yield self.gateway.unlink(backup_cap, name, missing_ok=True)
         finally:
             yield self.lock.release()  # type: ignore

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -625,7 +625,7 @@ class Tahoe:
         )
 
     @inlineCallbacks
-    def unlink(self, dircap, childname):
+    def unlink(self, dircap, childname, missing_ok=False):
         dircap_hash = trunchash(dircap)
         log.debug('Unlinking "%s" from %s...', childname, dircap_hash)
         yield self.await_ready()
@@ -634,7 +634,9 @@ class Tahoe:
                 self.nodeurl, dircap, childname
             )
         )
-        if resp.code != 200:
+        if resp.code == 404 and missing_ok:
+            pass
+        elif resp.code != 200:
             content = yield treq.content(resp)
             raise TahoeWebError(content.decode("utf-8"))
         log.debug('Done unlinking "%s" from %s', childname, dircap_hash)

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -464,7 +464,6 @@ def test_remote_magic_folders_dict_is_updated_by_folder_backups(magic_folder):
     folders = yield magic_folder.get_folders()
     folder_name = next(iter(folders))
     yield magic_folder.create_folder_backup(folder_name)
-    backups = yield magic_folder.get_folder_backups()
     folder_added = folder_name in magic_folder.remote_magic_folders
     yield magic_folder.remove_folder_backup(folder_name)
     folder_removed = folder_name not in magic_folder.remote_magic_folders

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -676,6 +676,8 @@ def test_monitor_emits_folder_added_signal_via_status_message(
 def test_monitor_emits_folder_mtime_updated_signal(
     magic_folder, tmp_path, qtbot
 ):
+    yield leave_all_folders(magic_folder)
+    yield magic_folder.monitor.do_check()
     folder_name = randstr()
     path = tmp_path / folder_name
     author = randstr()
@@ -699,6 +701,8 @@ def test_monitor_emits_folder_mtime_updated_signal(
 def test_monitor_emits_folder_size_updated_signal(
     magic_folder, tmp_path, qtbot
 ):
+    yield leave_all_folders(magic_folder)
+    yield magic_folder.monitor.do_check()
     folder_name = randstr()
     path = tmp_path / folder_name
     author = randstr()

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -464,10 +464,12 @@ def test_remote_magic_folders_dict_is_updated_by_folder_backups(magic_folder):
     folders = yield magic_folder.get_folders()
     folder_name = next(iter(folders))
     yield magic_folder.create_folder_backup(folder_name)
+    backups = yield magic_folder.get_folder_backups()
+    folder_backed_up = folder_name in backups
     folder_added = folder_name in magic_folder.remote_magic_folders
     yield magic_folder.remove_folder_backup(folder_name)
     folder_removed = folder_name not in magic_folder.remote_magic_folders
-    assert folder_added and folder_removed
+    assert folder_backed_up and folder_added and folder_removed
 
 
 @inlineCallbacks

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -170,7 +170,7 @@ def test_leave_folder_with_missing_ok_false(magic_folder, tmp_path):
 
 
 @inlineCallbacks
-def _test_leave_folder_removes_from_magic_folders_dict(magic_folder, tmp_path):
+def test_leave_folder_removes_from_magic_folders_dict(magic_folder, tmp_path):
     folder_name = randstr()
     path = tmp_path / folder_name
     author = randstr()

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -802,7 +802,7 @@ def test_monitor_emits_file_mtime_updated_signal(
         filepath.write_text(randstr() * 10)
         yield magic_folder.scan(folder_name)
         yield magic_folder.monitor.do_check()
-        yield deferLater(reactor, 1, lambda: None)  # to increment mtime
+        yield deferLater(reactor, 2, lambda: None)  # to increment mtime
         filepath.write_text(randstr() * 16)
         yield magic_folder.scan(folder_name)
         yield magic_folder.monitor.do_check()

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -164,9 +164,6 @@ def test_leave_folder_with_missing_ok_false(magic_folder, tmp_path):
     path = tmp_path / folder_name
     author = randstr()
     yield magic_folder.add_folder(path, author)
-    folders = yield magic_folder.get_folders()
-    folder_was_added = folder_name in folders
-
     yield magic_folder.leave_folder(folder_name)
     with pytest.raises(MagicFolderWebError):
         yield magic_folder.leave_folder(folder_name, missing_ok=False)

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -460,6 +460,18 @@ def test_remove_folder_backup(magic_folder):
 
 
 @inlineCallbacks
+def test_remote_magic_folders_dict_is_updated_by_folder_backups(magic_folder):
+    folders = yield magic_folder.get_folders()
+    folder_name = next(iter(folders))
+    yield magic_folder.create_folder_backup(folder_name)
+    backups = yield magic_folder.get_folder_backups()
+    folder_added = folder_name in magic_folder.remote_magic_folders
+    yield magic_folder.remove_folder_backup(folder_name)
+    folder_removed = folder_name not in magic_folder.remote_magic_folders
+    assert folder_added and folder_removed
+
+
+@inlineCallbacks
 def test_create_folder_backup_preserves_collective_writecap(magic_folder):
     folders = yield magic_folder.get_folders()
     folder_name = next(iter(folders))

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -773,6 +773,8 @@ def test_monitor_emits_file_size_updated_signal(magic_folder, tmp_path, qtbot):
 def test_monitor_emits_file_mtime_updated_signal(
     magic_folder, tmp_path, qtbot
 ):
+    yield leave_all_folders(magic_folder)
+    yield magic_folder.monitor.do_check()
     folder_name = randstr()
     path = tmp_path / folder_name
     author = randstr()
@@ -795,6 +797,8 @@ def test_monitor_emits_file_mtime_updated_signal(
 
 @inlineCallbacks
 def test_monitor_emits_file_modified_signal(magic_folder, tmp_path, qtbot):
+    yield leave_all_folders(magic_folder)
+    yield magic_folder.monitor.do_check()
     folder_name = randstr()
     path = tmp_path / folder_name
     author = randstr()

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -802,7 +802,11 @@ def test_monitor_emits_file_mtime_updated_signal(
         filepath.write_text(randstr() * 10)
         yield magic_folder.scan(folder_name)
         yield magic_folder.monitor.do_check()
-        yield deferLater(reactor, 2, lambda: None)  # to increment mtime
+        yield deferLater(reactor, 1, lambda: None)  # to increment mtime
+        filepath.write_text(randstr() * 16)
+        yield magic_folder.scan(folder_name)
+        yield magic_folder.monitor.do_check()
+        yield deferLater(reactor, 1, lambda: None)  # to increment mtime
         filepath.write_text(randstr() * 16)
         yield magic_folder.scan(folder_name)
         yield magic_folder.monitor.do_check()

--- a/tests/integration/test_rootcap_integration.py
+++ b/tests/integration/test_rootcap_integration.py
@@ -21,3 +21,30 @@ def test_create_rootcap_doesnt_override_existing_rootcap(rootcap_manager):
         _, output = result
         created_caps.add(output)
     assert len(created_caps) == 1  # Only one cap was created
+
+
+@inlineCallbacks
+def test_add_backup(tahoe_client, rootcap_manager):
+    dircap = yield tahoe_client.mkdir()
+    yield rootcap_manager.add_backup("TestBackups-1", "backup-1", dircap)
+    backups = yield rootcap_manager.get_backups("TestBackups-1")
+    assert "backup-1" in backups
+
+
+@inlineCallbacks
+def test_remove_backup(tahoe_client, rootcap_manager):
+    dircap = yield tahoe_client.mkdir()
+    yield rootcap_manager.add_backup("TestBackups-2", "backup-2", dircap)
+    yield rootcap_manager.remove_backup("TestBackups-2", "backup-2")
+    backups = yield rootcap_manager.get_backups("TestBackups-2")
+    assert "backup-2" not in backups
+
+
+@inlineCallbacks
+def test_remove_backup_is_idempotent(tahoe_client, rootcap_manager):
+    dircap = yield tahoe_client.mkdir()
+    yield rootcap_manager.add_backup("TestBackups-3", "backup-3", dircap)
+    yield rootcap_manager.remove_backup("TestBackups-3", "backup-3")
+    yield rootcap_manager.remove_backup("TestBackups-3", "backup-3")
+    backups = yield rootcap_manager.get_backups("TestBackups-3")
+    assert "backup-3" not in backups

--- a/tests/integration/test_rootcap_integration.py
+++ b/tests/integration/test_rootcap_integration.py
@@ -45,6 +45,9 @@ def test_remove_backup_is_idempotent(tahoe_client, rootcap_manager):
     dircap = yield tahoe_client.mkdir()
     yield rootcap_manager.add_backup("TestBackups-3", "backup-3", dircap)
     yield rootcap_manager.remove_backup("TestBackups-3", "backup-3")
-    yield rootcap_manager.remove_backup("TestBackups-3", "backup-3")
-    backups = yield rootcap_manager.get_backups("TestBackups-3")
-    assert "backup-3" not in backups
+    exception_raised = None
+    try:
+        yield rootcap_manager.remove_backup("TestBackups-3", "backup-3")
+    except Exception as exc:
+        exception_raised = exc
+    assert not exception_raised


### PR DESCRIPTION
Fixes #437 

Also fixes two adjacent/related issues discovered along the way:

* Leaving a magic-folder now also immediately removes that folder name from the internal Gridsync active folders list (`MagicFolder.magic_folders`). Previously, this state was only being updated when `MagicFolderMonitor.do_check` was being called -- resulting in a temporary situation in which the "Folders" view's context menu could display actions that were invalid for the given folder type (for example, offering the "stop syncing" action for a folder that was no longer active/syncing).
* Removing a folder backup now also immediately removes that folder from the internal Gridsync known backups list (`MagicFolder.remote_magic_folders`). Likewise, this state was also only being updated when `MagicFolderMonitor.do_check` was being called -- resulting in a temporary situation in which it would not be possible to immeditaley re-add a folder that was recently removed until after another action was taken.