### PR TITLE
Encourage lease-renewal

### DIFF
--- a/gridsync/__init__.py
+++ b/gridsync/__init__.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 from gridsync._version import get_versions  # type: ignore
 from gridsync.config import Config
+from gridsync.util import to_bool
 
 __author__ = "Christopher R. Wood"
 __url__ = "https://github.com/gridsync/gridsync"
@@ -52,6 +53,8 @@ try:
     APP_NAME = settings["application"]["name"]
 except KeyError:
     APP_NAME = "Gridsync"
+
+DEFAULT_AUTOSTART = to_bool(settings.get("defaults", {}).get("autostart", ""))
 
 
 grid_invites_enabled: bool = True

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -43,6 +43,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.python.log import PythonLoggingObserver, startLogging
 
 from gridsync import APP_NAME, config_dir, msg, resource, settings
+from gridsync.desktop import autostart_enable
 from gridsync.gui import Gui
 from gridsync.lock import FilesystemLock
 from gridsync.magic_folder import MagicFolder
@@ -50,6 +51,7 @@ from gridsync.preferences import get_preference, set_preference
 from gridsync.tahoe import Tahoe, get_nodedirs
 from gridsync.tor import get_tor
 from gridsync.types import TwistedDeferred
+from gridsync.util import to_bool
 
 app.setWindowIcon(QIcon(resource(settings["application"]["tray_icon"])))
 
@@ -139,6 +141,9 @@ class Core:
             self.gui.populate(self.gateways)
         else:
             self.gui.show_welcome_dialog()
+            if to_bool(settings.get("defaults", {}).get("autostart", "")):
+                autostart_enable()
+                self.gui.preferences_window.general_pane.load_preferences()
         try:
             yield self.get_tahoe_version()
         except Exception as e:  # pylint: disable=broad-except

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -42,7 +42,14 @@ from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.log import PythonLoggingObserver, startLogging
 
-from gridsync import APP_NAME, config_dir, msg, resource, settings
+from gridsync import (
+    APP_NAME,
+    DEFAULT_AUTOSTART,
+    config_dir,
+    msg,
+    resource,
+    settings,
+)
 from gridsync.desktop import autostart_enable
 from gridsync.gui import Gui
 from gridsync.lock import FilesystemLock
@@ -51,7 +58,6 @@ from gridsync.preferences import get_preference, set_preference
 from gridsync.tahoe import Tahoe, get_nodedirs
 from gridsync.tor import get_tor
 from gridsync.types import TwistedDeferred
-from gridsync.util import to_bool
 
 app.setWindowIcon(QIcon(resource(settings["application"]["tray_icon"])))
 
@@ -141,7 +147,7 @@ class Core:
             self.gui.populate(self.gateways)
         else:
             self.gui.show_welcome_dialog()
-            if to_bool(settings.get("defaults", {}).get("autostart", "")):
+            if DEFAULT_AUTOSTART:
                 autostart_enable()
                 self.gui.preferences_window.general_pane.load_preferences()
         try:

--- a/gridsync/gui/model.py
+++ b/gridsync/gui/model.py
@@ -235,6 +235,12 @@ class Model(QStandardItemModel):
             lines.append(f"{s} ({datetime.fromtimestamp(t)})")
         return "\n".join(lines)
 
+    def is_folder_syncing(self) -> bool:
+        for row in range(self.rowCount()):
+            if self.item(row, 1).data(Qt.UserRole) == MagicFolderState.SYNCING:
+                return True
+        return False
+
     @pyqtSlot(str, int)
     def set_status(self, name, status):
         items = self.findItems(name)

--- a/gridsync/gui/preferences.py
+++ b/gridsync/gui/preferences.py
@@ -18,12 +18,13 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from gridsync import APP_NAME, features, resource
+from gridsync import APP_NAME, DEFAULT_AUTOSTART, features, resource
 from gridsync.desktop import (
     autostart_disable,
     autostart_enable,
     autostart_is_enabled,
 )
+from gridsync.msg import question
 from gridsync.preferences import Preferences
 
 
@@ -70,9 +71,19 @@ class GeneralPane(QWidget):
         else:
             self.preferences.set("startup", "minimize", "false")
 
-    @staticmethod
-    def on_checkbox_autostart_changed(state):
-        if state:
+    def on_checkbox_autostart_changed(self, state):
+        if DEFAULT_AUTOSTART and not state:
+            if question(
+                self,
+                "Are you sure you wish to disable autostart?",
+                f"{APP_NAME} will only update and renew folders while it is "
+                f"running. Failing to launch {APP_NAME} for extended periods "
+                "of time may result in data-loss.",
+            ):
+                autostart_disable()
+            else:
+                self.checkbox_autostart.setCheckState(Qt.Checked)
+        elif state:
             autostart_enable()
         else:
             autostart_disable()

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -13,6 +13,9 @@ linux_icon = images/gridsync.svg
 [debug]
 log_maxlen = 100000
 
+[defaults]
+autostart = false
+
 [features]
 grid_invites = true
 # Disable invites (at least) until new Magic-Folder re-implements them.

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -54,6 +54,12 @@ def b58decode(s):  # Adapted from python-bitcoinlib
     return b"\x00" * pad + res
 
 
+def to_bool(s: str) -> bool:
+    if s.lower() in ("false", "f", "no", "n", "off", "0", "none", ""):
+        return False
+    return True
+
+
 def humanized_list(list_, kind="files"):
     if not list_:
         return None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,13 @@ from binascii import hexlify, unhexlify
 
 import pytest
 
-from gridsync.util import b58decode, b58encode, humanized_list, strip_html_tags
+from gridsync.util import (
+    b58decode,
+    b58encode,
+    humanized_list,
+    strip_html_tags,
+    to_bool,
+)
 
 # From https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
 base58_test_pairs = [
@@ -42,6 +48,31 @@ def test_b58decode(decoded, s):
 def test_b58decode_value_error():
     with pytest.raises(ValueError):
         b58decode("abcl23")
+
+
+@pytest.mark.parametrize(
+    "s, result",
+    [
+        ("True", True),
+        ("False", False),
+        ("FaLsE", False),
+        ("f", False),
+        ("t", True),
+        ("No", False),
+        ("Yes", True),
+        ("N", False),
+        ("Y", True),
+        ("off", False),
+        ("on", True),
+        ("None", False),
+        ("0", False),
+        ("1", True),
+        ("", False),
+        ("X", True),
+    ],
+)
+def test_to_bool(s, result):
+    assert to_bool(s) == result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR implements three small measures aimed at encouraging users to keep the application running in the background for the purposes of increasing the likelihood of successful lease-renewal. These consist of:

* _If the user is connected to at least one ZKAPAuthorizer-enabled storage grid_, upon exiting the application, display a warning (informing users that the application will stop renewing data if it is not running -- and that doing so over extended periods can result in data-loss) and require user-confirmation in order to proceed.
* _If the `[default] autostart` value is set to `true` in `config.txt`_, enable autostart by default, launching the application automatically upon login.
* _if the `[default] autostart` value is set to `true` in `config.txt`_, display a warning and require user-confirmation in order to disable autostart.

Note that the above-described option to enable autostart by default is primarily intended for customized builds of Gridsync (such as [PrivateStorageDesktop](https://github.com/PrivateStorageio/PrivateStorageDesktop)) that might wish to deploy stricter or different default behaviors; Gridsync itself will continue to ship with autostart disabled by default.