### PR TITLE
define the plugin name once, re-use it most everywhere else

### DIFF
--- a/gridsync/setup.py
+++ b/gridsync/setup.py
@@ -21,6 +21,7 @@ from gridsync.config import Config
 from gridsync.errors import AbortedByUserError, TorError, UpgradeRequiredError
 from gridsync.tahoe import Tahoe
 from gridsync.tor import get_tor, get_tor_with_prompt, tor_required
+from gridsync.zkapauthorizer import PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME
 
 
 def is_onion_grid(settings):
@@ -52,7 +53,7 @@ def is_zkap_grid(settings: dict) -> Tuple[bool, Set]:
             if not storage_options:
                 continue
             for group in storage_options:
-                if group.get("name") == "privatestorageio-zkapauthz-v1":
+                if group.get("name") == ZKAPAUTHZ_PLUGIN_NAME:
                     zkapauthz = True
                 url = group.get("ristretto-issuer-root-url")
                 if url:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -26,7 +26,10 @@ from gridsync.streamedlogs import StreamedLogs
 from gridsync.system import SubprocessProtocol, kill, which
 from gridsync.types import TwistedDeferred
 from gridsync.util import Poller
-from gridsync.zkapauthorizer import ZKAPAuthorizer
+from gridsync.zkapauthorizer import (
+    PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME,
+    ZKAPAuthorizer,
+)
 
 
 def is_valid_furl(furl):
@@ -425,13 +428,13 @@ class Tahoe:
         if tcp and tcp.lower() == "tor":
             self.use_tor = True
         if self.config_get(
-            "storageclient.plugins.privatestorageio-zkapauthz-v1",
+            f"storageclient.plugins.{ZKAPAUTHZ_PLUGIN_NAME}",
             "ristretto-issuer-root-url",
         ):
             self.zkap_auth_required = True
         if self.zkap_auth_required:
             default_token_count = self.config_get(
-                "storageclient.plugins.privatestorageio-zkapauthz-v1",
+                f"storageclient.plugins.{ZKAPAUTHZ_PLUGIN_NAME}",
                 "default-token-count",
             )
             if default_token_count:
@@ -713,7 +716,7 @@ def storage_options_to_config(options: Dict) -> Optional[Dict]:
     configuration dictionary.
     """
     name = options.get("name")
-    if name == "privatestorageio-zkapauthz-v1":
+    if name == ZKAPAUTHZ_PLUGIN_NAME:
         zkapauthz = {
             "redeemer": "ristretto",
             "ristretto-issuer-root-url": options.get(
@@ -733,7 +736,7 @@ def storage_options_to_config(options: Dict) -> Optional[Dict]:
                 # TODO: Append name instead of setting/overriding?
                 "storage.plugins": name,
             },
-            "storageclient.plugins.privatestorageio-zkapauthz-v1": zkapauthz,
+            f"storageclient.plugins.{ZKAPAUTHZ_PLUGIN_NAME}": zkapauthz,
         }
 
     return None

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -26,10 +26,8 @@ from gridsync.streamedlogs import StreamedLogs
 from gridsync.system import SubprocessProtocol, kill, which
 from gridsync.types import TwistedDeferred
 from gridsync.util import Poller
-from gridsync.zkapauthorizer import (
-    PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME,
-    ZKAPAuthorizer,
-)
+from gridsync.zkapauthorizer import PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME
+from gridsync.zkapauthorizer import ZKAPAuthorizer
 
 
 def is_valid_furl(furl):

--- a/gridsync/zkapauthorizer.py
+++ b/gridsync/zkapauthorizer.py
@@ -20,6 +20,8 @@ from gridsync.voucher import generate_voucher
 if TYPE_CHECKING:
     from gridsync.tahoe import Tahoe  # pylint: disable=cyclic-import
 
+PLUGIN_NAME = "privatestorageio-zkapauthz-v1"
+
 
 class ZKAPAuthorizer:
     def __init__(self, gateway: Tahoe) -> None:
@@ -41,7 +43,7 @@ class ZKAPAuthorizer:
         api_token = self.gateway.api_token
         resp = yield treq.request(
             method,
-            f"{nodeurl}storage-plugins/privatestorageio-zkapauthz-v1{path}",
+            f"{nodeurl}storage-plugins/{PLUGIN_NAME}{path}",
             headers={
                 "Authorization": f"tahoe-lafs {api_token}",
                 "Content-Type": "application/json",

--- a/tests/integration/test_zkapauthorizer_plugin.py
+++ b/tests/integration/test_zkapauthorizer_plugin.py
@@ -1,6 +1,7 @@
 from pytest_twisted import async_yield_fixture, inlineCallbacks
 
 from gridsync.tahoe import Tahoe
+from gridsync.zkapauthorizer import PLUGIN_NAME
 
 
 @async_yield_fixture(scope="module")
@@ -18,7 +19,7 @@ async def zkapauthorizer(tmp_path_factory, tahoe_server):
                 "nickname": "test-grid-storage-server-1",
                 "storage-options": [
                     {
-                        "name": "privatestorageio-zkapauthz-v1",
+                        "name": PLUGIN_NAME,
                         "ristretto-issuer-root-url": "https://example.org/",
                         "storage-server-FURL": tahoe_server.storage_furl,
                         "allowed-public-keys": "AAAAAAAAAAAAAAAA",

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -21,6 +21,7 @@ from gridsync.tahoe import (
     is_valid_furl,
     storage_options_to_config,
 )
+from gridsync.zkapauthorizer import PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME
 
 
 def fake_get(*args, **kwargs):
@@ -254,9 +255,7 @@ def test_storage_options_to_config_unknown():
 
 # The name of the tahoe.cfg section where ZKAPAuthorizer client plugin config
 # goes.
-zkapauthz_plugin_section = (
-    "storageclient.plugins.privatestorageio-zkapauthz-v1"
-)
+zkapauthz_plugin_section = f"storageclient.plugins.{ZKAPAUTHZ_PLUGIN_NAME}"
 
 
 def test_storage_options_to_config_no_optional_values():
@@ -267,12 +266,10 @@ def test_storage_options_to_config_no_optional_values():
     """
     config = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
         }
     )
-    assert (
-        config["client"]["storage.plugins"] == "privatestorageio-zkapauthz-v1"
-    )
+    assert config["client"]["storage.plugins"] == ZKAPAUTHZ_PLUGIN_NAME
     zkapauthz = config[zkapauthz_plugin_section]
     assert "pass_value" not in zkapauthz
     assert "default-token-count" not in zkapauthz
@@ -288,7 +285,7 @@ def test_storage_options_to_config_pass_value():
     key = "pass-value"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: pass_value,
         }
     )[zkapauthz_plugin_section]
@@ -305,7 +302,7 @@ def test_storage_options_to_config_default_token_count():
     key = "default-token-count"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: default_token_count,
         }
     )[zkapauthz_plugin_section]
@@ -322,7 +319,7 @@ def test_storage_options_to_config_allowed_public_keys():
     key = "allowed-public-keys"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: allowed_public_keys,
         }
     )[zkapauthz_plugin_section]
@@ -339,7 +336,7 @@ def test_storage_options_to_config_lease_crawl_interval_mean():
     key = "lease.crawl-interval.mean"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: mean,
         }
     )[zkapauthz_plugin_section]
@@ -356,7 +353,7 @@ def test_storage_options_to_config_lease_crawl_interval_range():
     key = "lease.crawl-interval.range"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: range_,
         }
     )[zkapauthz_plugin_section]
@@ -373,7 +370,7 @@ def test_storage_options_to_config_lease_min_time_remaining():
     key = "lease.min-time-remaining"
     zkapauthz = storage_options_to_config(
         {
-            "name": "privatestorageio-zkapauthz-v1",
+            "name": ZKAPAUTHZ_PLUGIN_NAME,
             key: min_time,
         }
     )[zkapauthz_plugin_section]
@@ -390,7 +387,7 @@ def test_add_storage_servers_writes_zkapauthorizer_allowed_public_keys(tmpdir):
             "nickname": "One",
             "storage-options": [
                 {
-                    "name": "privatestorageio-zkapauthz-v1",
+                    "name": ZKAPAUTHZ_PLUGIN_NAME,
                     "allowed-public-keys": "Key1,Key2,Key3,Key4",
                 }
             ],
@@ -398,7 +395,7 @@ def test_add_storage_servers_writes_zkapauthorizer_allowed_public_keys(tmpdir):
     }
     client.add_storage_servers(storage_servers)
     allowed_public_keys = client.config_get(
-        "storageclient.plugins.privatestorageio-zkapauthz-v1",
+        f"storageclient.plugins.{ZKAPAUTHZ_PLUGIN_NAME}",
         "allowed-public-keys",
     )
     assert allowed_public_keys == "Key1,Key2,Key3,Key4"

--- a/tests/test_zkapauthorizer.py
+++ b/tests/test_zkapauthorizer.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_twisted import inlineCallbacks
 
 from gridsync.tahoe import TahoeWebError
-from gridsync.zkapauthorizer import ZKAPAuthorizer
+from gridsync.zkapauthorizer import PLUGIN_NAME, ZKAPAuthorizer
 
 
 def fake_treq_request_resp_code_200(*args, **kwargs):
@@ -31,7 +31,7 @@ def test__request_url(tahoe, monkeypatch):
     monkeypatch.setattr("treq.request", fake_request)
     yield ZKAPAuthorizer(tahoe)._request("GET", "/test")
     assert fake_request.call_args[0][1] == (
-        tahoe.nodeurl + "storage-plugins/privatestorageio-zkapauthz-v1/test"
+        tahoe.nodeurl + f"storage-plugins/{PLUGIN_NAME}/test"
     )
 
 


### PR DESCRIPTION
ZKAPAuthorizer's new backup API is sufficiently different from the old one that I'm bumping the API version number.

In preparation, here's a refactoring that removes the duplication of the string "privatestorageio-zkapauthz-v1" throughout GridSync and centralizes the definition of the supported API version of ZKAPAuthorizer.  The value is left as-is for now.  The likely path forward is a future PR that switches GridSync to the new backup API and bumps the version in the string to 2.