### PR TITLE
Adjust Storage-time chart legend

### DIFF
--- a/gridsync/gui/charts.py
+++ b/gridsync/gui/charts.py
@@ -16,6 +16,7 @@ from PyQt5.QtCore import QMargins, Qt
 from PyQt5.QtGui import QColor, QPainter, QPalette, QPen
 
 from gridsync.gui.color import is_dark
+from gridsync.gui.font import Font
 
 COLOR_USED = "#D42020"
 COLOR_COST = "#EE9A1D"
@@ -122,6 +123,7 @@ class ZKAPBarChart(QChart):
             legend.setLabelColor(palette.color(QPalette.Text))
         legend.setAlignment(Qt.AlignBottom)
         legend.setShowToolTips(True)
+        legend.setFont(Font(9))
         legend_layout = legend.layout()
         _, top, _, bottom = legend_layout.getContentsMargins()
         legend_layout.setContentsMargins(0, top, 0, bottom)

--- a/gridsync/gui/charts.py
+++ b/gridsync/gui/charts.py
@@ -122,6 +122,9 @@ class ZKAPBarChart(QChart):
             legend.setLabelColor(palette.color(QPalette.Text))
         legend.setAlignment(Qt.AlignBottom)
         legend.setShowToolTips(True)
+        legend_layout = legend.layout()
+        _, top, _, bottom = legend_layout.getContentsMargins()
+        legend_layout.setContentsMargins(0, top, 0, bottom)
         legend.markers(series)[-1].setVisible(False)  # Hide set_expected
 
         self.update(10, 30, 40)  # XXX

--- a/gridsync/gui/charts.py
+++ b/gridsync/gui/charts.py
@@ -121,6 +121,7 @@ class ZKAPBarChart(QChart):
             # PyQtChart. In any case, override it here..
             legend.setLabelColor(palette.color(QPalette.Text))
         legend.setAlignment(Qt.AlignBottom)
+        legend.setShowToolTips(True)
         legend.markers(series)[-1].setVisible(False)  # Hide set_expected
 
         self.update(10, 30, 40)  # XXX

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -97,7 +97,7 @@ class MainWindow(QMainWindow):
         self.pending_news_message = ()
 
         self.setWindowTitle(APP_NAME)
-        self.setMinimumSize(QSize(740, 465))
+        self.setMinimumSize(QSize(755, 470))
         self.setUnifiedTitleAndToolBarOnMac(True)
         self.setContextMenuPolicy(Qt.NoContextMenu)
 


### PR DESCRIPTION
This PR provides a number of small UI adjustments (to layout margins, font-size, window dimensions) for the purposes of preventing the labels in the legend of the "Storage-time" chart from becoming truncated by default or common values:

![chart](https://user-images.githubusercontent.com/882430/153111973-066807e1-ab71-4a64-a39d-fc8b06d11dc7.png)

In the event that the labels _do_ become truncated (e.g., due to especially large values), tooltips are now available to make the underlying values visible without needing to resize the main window.

Fixes #453 
