### PR TITLE
Prevent/handle TypeError in `Tahoe.ls`

### DIFF
--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -842,6 +842,10 @@ class MagicFolder:
     ) -> TwistedDeferred[None]:
         logging.debug('Restoring "%s" Magic-Folder...', folder_name)
         backups = yield self.get_folder_backups()
+        if backups is None:
+            raise MagicFolderError(
+                f"Error restoring folder {folder_name}; could not read backups"
+            )
         data = backups.get(folder_name, {})
         upload_dircap = data.get("upload_dircap")
         personal_dmd = yield self.gateway.diminish(upload_dircap)

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -434,10 +434,11 @@ class MagicFolderMonitor(QObject):
         self._known_folders = current_folders
 
         backups = yield self.magic_folder.get_folder_backups()
-        current_backups = list(backups)
-        previous_backups = list(self._known_backups)
-        self.compare_backups(current_backups, previous_backups)
-        self._known_backups = current_backups
+        if backups is not None:
+            current_backups = list(backups)
+            previous_backups = list(self._known_backups)
+            self.compare_backups(current_backups, previous_backups)
+            self._known_backups = current_backups
 
         results = yield DeferredList(
             [self._get_file_status(f) for f in current_folders],

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -434,7 +434,9 @@ class MagicFolderMonitor(QObject):
         self._known_folders = current_folders
 
         backups = yield self.magic_folder.get_folder_backups()
-        if backups is not None:
+        if backups is None:
+            logging.warning("Could not read Magic-Folder backups during check")
+        else:
             current_backups = list(backups)
             previous_backups = list(self._known_backups)
             self.compare_backups(current_backups, previous_backups)

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -803,9 +803,11 @@ class MagicFolder:
         )
 
     @inlineCallbacks
-    def get_folder_backups(self) -> TwistedDeferred[Dict[str, dict]]:
+    def get_folder_backups(self) -> TwistedDeferred[Optional[Dict[str, dict]]]:
         folders: DefaultDict[str, dict] = defaultdict(dict)
         backups = yield self.rootcap_manager.get_backups(".magic-folders")
+        if backups is None:
+            return None
         for name, data in backups.items():
             if name.endswith(" (collective)"):
                 prefix = name.split(" (collective)")[0]

--- a/gridsync/rootcap.py
+++ b/gridsync/rootcap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from atomicwrites import atomic_write
 from twisted.internet.defer import DeferredLock, inlineCallbacks
@@ -139,7 +139,7 @@ class RootcapManager:
         return cap
 
     @inlineCallbacks
-    def get_backups(self, dirname: str) -> TwistedDeferred[None]:
+    def get_backups(self, dirname: str) -> TwistedDeferred[Optional[dict]]:
         backup_cap = yield self.get_backup_cap(dirname)
         ls_output = yield self.gateway.ls(backup_cap)
         return ls_output

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -665,6 +665,8 @@ class Tahoe:
     ) -> TwistedDeferred[Dict[str, dict]]:
         yield self.await_ready()
         json_output = yield self.get_json(cap)
+        if json_output is None:
+            return None
         results = {}
         for name, data in json_output[1]["children"].items():
             node_type = data[0]

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -662,7 +662,7 @@ class Tahoe:
         cap: str,
         exclude_dirnodes: bool = False,
         exclude_filenodes: bool = False,
-    ) -> TwistedDeferred[Dict[str, dict]]:
+    ) -> TwistedDeferred[Optional[Dict[str, dict]]]:
         yield self.await_ready()
         json_output = yield self.get_json(cap)
         if json_output is None:

--- a/tests/integration/test_tahoe_integration.py
+++ b/tests/integration/test_tahoe_integration.py
@@ -154,3 +154,10 @@ def test_ls_includes_most_authoritative_cap(tahoe_client, tmp_path):
     yield tahoe_client.upload(local_path, dircap)
     output = yield tahoe_client.ls(dircap)
     assert output.get("TestFile.txt").get("cap").startswith("URI:CHK:")
+
+
+@inlineCallbacks
+def test_ls_nonexistent_path(tahoe_client, tmp_path):
+    dircap = yield tahoe_client.mkdir()
+    output = yield tahoe_client.ls(dircap + "/Path/Does/Not/Exist")
+    assert output is None


### PR DESCRIPTION
This PR handles the TypeError that would previously raise (and go uncaught) when `Tahoe.ls` was unable to read JSON from the Tahoe-LAFS web API (for example, due to connection problems). With these changes, `Tahoe.ls` will return a `None` type in such situations that can be handled (more) appropriately by higher-level callers: in the case of attempting (and failing) to list/compare magic-folder backups during a periodic MagicFolderMonitor check, a warning will be logged; in the case of attempting (and failing) to restore a magic-folder backup that cannot be read, a slightly more friendly error message will be propagated to the user.