### PR TITLE
Allow adding Magic-Folders for empty directories

### DIFF
--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 import traceback
-from pathlib import Path
 
 from qtpy.QtCore import QEvent, QItemSelectionModel, QPoint, QSize, Qt, QTimer
 from qtpy.QtGui import QColor, QCursor, QIcon, QMovie, QPainter, QPen
@@ -527,13 +526,6 @@ class View(QTreeView):
                     "rename it and try again.".format(
                         basename, self.gateway.name
                     ),
-                )
-            elif not any(Path(path).iterdir()):
-                error(
-                    self,
-                    "Folder is empty",
-                    f'The "{basename}" folder is empty. Please add some files '
-                    "to it -- or select a different folder -- and try again.",
                 )
             else:
                 paths_to_add.append(path)


### PR DESCRIPTION
PR #457 disallowed adding empty folders in order to compensate for some
limitations with the Magic-Folder "status" API. Those limitations have
since been resolved (specifically, by the addition of  `last-scan` and
`last-poll` fields), making it possible to make determinations about
the sync status of empty folders. Accordingly, this change reverts #457,
allowing empty Magic-Folders to be added again (without those folders
appearing to be stuck in a "Loading..." state).