### PR TITLE
Desktop notification fallbacks

### DIFF
--- a/gridsync/desktop.py
+++ b/gridsync/desktop.py
@@ -50,9 +50,14 @@ def notify(systray, title, message, duration=5000):
             yield _txdbus_notify(title, message, duration)
         except Exception as exc:  # pylint: disable=broad-except
             logging.warning("%s; falling back to showMessage()...", str(exc))
-            systray.showMessage(title, message, msecs=duration)
-    else:
+            if systray and systray.supportsMessages():
+                systray.showMessage(title, message, msecs=duration)
+            else:
+                logging.info("%s: %s", title, message)
+    elif systray and systray.supportsMessages():
         systray.showMessage(title, message, msecs=duration)
+    else:
+        logging.info("%s: %s", title, message)
 
 
 def _desktop_open(path):

--- a/gridsync/desktop.py
+++ b/gridsync/desktop.py
@@ -42,11 +42,12 @@ def _txdbus_notify(title, message, duration=5000):
     yield conn.disconnect()
 
 
+@inlineCallbacks
 def notify(systray, title, message, duration=5000):
     logging.debug("Sending desktop notification...")
     if sys.platform not in ("darwin", "win32"):
         try:
-            _txdbus_notify(title, message, duration)
+            yield _txdbus_notify(title, message, duration)
         except Exception as exc:  # pylint: disable=broad-except
             logging.warning("%s; falling back to showMessage()...", str(exc))
             systray.showMessage(title, message, msecs=duration)


### PR DESCRIPTION
This PR makes some minor adjustments to `desktop.notify` with the aim of providing working fallback mechanisms for desktop environments that don't support traditional desktop notifications:

* On Linux-like systems, actually catch and handle exceptions raised by txbus calls in the event that, e.g., the host operating system lacks DBus (these exceptions were previously uncaught due to missing `yield` statement...)
* Show a popup message via `QSystemTray.showMessage` iff the systray actually supports messages
* Fall back to logging the message, if all else fails