### PR TITLE
Fix intermittently-failing Supervisor "restart" test

### DIFF
--- a/gridsync/supervisor.py
+++ b/gridsync/supervisor.py
@@ -8,7 +8,12 @@ from atomicwrites import atomic_write
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 
-from gridsync.system import SubprocessProtocol, process_name, terminate
+from gridsync.system import (
+    SubprocessProtocol,
+    is_running,
+    process_name,
+    terminate,
+)
 from gridsync.types import TwistedDeferred
 
 
@@ -30,6 +35,11 @@ class Supervisor:
         self._stderr_line_collector: Optional[Callable] = None
         self._process_started_callback: Optional[Callable] = None
         self._on_process_ended: Optional[Callable] = None
+
+    def is_running(self) -> bool:
+        if not self.pid:
+            return False
+        return is_running(self.pid)
 
     @inlineCallbacks
     def stop(self) -> TwistedDeferred[None]:

--- a/gridsync/system.py
+++ b/gridsync/system.py
@@ -46,6 +46,13 @@ def process_name(pid: int) -> str:
         return ""
 
 
+def is_running(pid: int) -> bool:
+    try:
+        return Process(pid).is_running()
+    except NoSuchProcess:
+        return False
+
+
 @inlineCallbacks
 def terminate(  # noqa: max-complexity
     pid: int, kill_after: Optional[Union[int, float]] = None

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -94,13 +94,12 @@ def strip_html_tags(s):
 
 
 @inlineCallbacks
-def until(predicate, timeout=10, period=0.2, reactor=None):
+def until(predicate, result=True, timeout=10, period=0.2, reactor=None):
     if reactor is None:
         from twisted.internet import reactor
     limit = time() + timeout
     while time() < limit:
-        result = predicate()
-        if result:
+        if predicate() == result:
             return result
         yield deferLater(reactor, period, lambda: None)
     raise TimeoutError(f"Timeout {timeout} seconds hit for {predicate}")

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -102,7 +102,10 @@ def until(predicate, result=True, timeout=10, period=0.2, reactor=None):
         if predicate() == result:
             return result
         yield deferLater(reactor, period, lambda: None)
-    raise TimeoutError(f"Timeout {timeout} seconds hit for {predicate}")
+    raise TimeoutError(
+        f'{predicate} did not return a value of "{result}" after waiting '
+        f"{timeout} seconds"
+    )
 
 
 @attr.s

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -2,6 +2,7 @@
 
 from binascii import hexlify, unhexlify
 from html.parser import HTMLParser
+from time import time
 from typing import Callable, List
 
 import attr
@@ -90,6 +91,19 @@ def strip_html_tags(s):
     ts = _TagStripper()
     ts.feed(s)
     return ts.get_data()
+
+
+@inlineCallbacks
+def until(predicate, timeout=10, period=0.2, reactor=None):
+    if reactor is None:
+        from twisted.internet import reactor
+    limit = time() + timeout
+    while time() < limit:
+        result = predicate()
+        if result:
+            return result
+        yield deferLater(reactor, period, lambda: None)
+    raise TimeoutError(f"Timeout {timeout} seconds hit for {predicate}")
 
 
 @attr.s

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +11,7 @@ from gridsync import APP_NAME
 from gridsync.crypto import randstr
 from gridsync.magic_folder import MagicFolderStatus, MagicFolderWebError
 from gridsync.tahoe import Tahoe
+from gridsync.util import until
 
 if sys.platform == "darwin":
     application_bundle_path = str(
@@ -79,17 +79,6 @@ async def bob_magic_folder(tmp_path_factory, tahoe_server):
     await client.start()
     yield client.magic_folder
     await client.stop()
-
-
-@inlineCallbacks
-def until(predicate, timeout=10, period=0.2):
-    limit = time.time() + timeout
-    while time.time() < limit:
-        result = predicate()
-        if result:
-            return result
-        yield deferLater(reactor, period, lambda: None)
-    raise TimeoutError(f"Timeout {timeout} seconds hit for {predicate}")
 
 
 @inlineCallbacks


### PR DESCRIPTION
The `Supervisor` test `test_supervisor_restarts_process_when_killed` has been [failing intermittently](https://github.com/gridsync/gridsync/runs/6761540545?check_suite_focus=true#step%3A5%3A63=) on Windows, for some time -- perhaps because 3 seconds isn't enough time for a process to be killed on GitHub Actions' Windows runners, or perhaps because filesystem operations are extra slow on GHA, or perhaps because Windows re-uses PIDs more eagerly than other operating systems... In any case, it happens frequently enough to be a source of developer-frustration and, Windows-specific issues aside, it isn't a very good test anyway:

```
================================== FAILURES ===================================
________________ test_supervisor_restarts_process_when_killed _________________
tmp_path = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_supervisor_restarts_proce0')
    @inlineCallbacks
    def test_supervisor_restarts_process_when_killed(tmp_path):
        pidfile = tmp_path / "python.pid"
        supervisor = Supervisor(pidfile=pidfile, restart_delay=0)
        pid_1, _ = yield supervisor.start(PROCESS_ARGS, started_trigger="OK")
        Process(pid_1).kill()
        yield deferLater(reactor, 3, lambda: None)
        pid_2 = int(pidfile.read_text().split()[0])
>       assert pid_1 != pid_2
E       assert 3140 != 3140
tests\test_supervisor.py:82: AssertionError
```

This PR improves the intermittently-failing test by verifying (and awaiting on, for a more generous 10 seconds) the running and not-running states of the supervised process (by PID) in order to determine whether the Supervisor "restart" functionality is working correctly. The result of these changes is much closer to the intended behavior of the component being tested; it avoids the filesystem, accommodates for slower systems, and will waste less time on actually-faster ones. 