### PR TITLE
Check out the branch HEAD instead of the merge HEAD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
     - name: Restore pyenv cache
       uses: actions/cache@v2
       with:
@@ -90,6 +93,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
     - name: Restore pyenv cache
       uses: actions/cache@v2
       with:
@@ -155,6 +161,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
         # Checkout head of the branch of the PR, or the exact revision
         # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
     - name: Restore pyenv cache
       uses: actions/cache@v2
       with:
@@ -95,7 +95,7 @@ jobs:
         fetch-depth: 0
         # Checkout head of the branch of the PR, or the exact revision
         # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
     - name: Restore pyenv cache
       uses: actions/cache@v2
       with:
@@ -163,7 +163,7 @@ jobs:
         fetch-depth: 0
         # Checkout head of the branch of the PR, or the exact revision
         # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.ref }}"
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
     - name: Restore pip cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
The merge HEAD is not guaranteed to be stable across time - even the time that
passes between two jobs in the same workflow running their checkout steps.