### PR TITLE
Remove stale/conflicting pidfile

### DIFF
--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -611,7 +611,7 @@ class MagicFolder:
                 started_trigger="Completed initial Magic Folder setup",
                 stdout_line_collector=self.on_stdout_line_received,
                 stderr_line_collector=self.on_stderr_line_received,
-                process_started_callback=self._on_started,
+                call_after_start=self._on_started,
             )
         except Exception as exc:  # pylint: disable=broad-except
             critical(

--- a/gridsync/supervisor.py
+++ b/gridsync/supervisor.py
@@ -33,6 +33,7 @@ class Supervisor:
         self._started_trigger = ""
         self._stdout_line_collector: Optional[Callable] = None
         self._stderr_line_collector: Optional[Callable] = None
+        self._pre_start_callback: Optional[Callable] = None
         self._process_started_callback: Optional[Callable] = None
         self._on_process_ended: Optional[Callable] = None
 

--- a/gridsync/supervisor.py
+++ b/gridsync/supervisor.py
@@ -33,8 +33,8 @@ class Supervisor:
         self._started_trigger = ""
         self._stdout_line_collector: Optional[Callable] = None
         self._stderr_line_collector: Optional[Callable] = None
-        self._pre_start_callback: Optional[Callable] = None
-        self._process_started_callback: Optional[Callable] = None
+        self._call_before_start: Optional[Callable] = None
+        self._call_after_start: Optional[Callable] = None
         self._on_process_ended: Optional[Callable] = None
 
     def is_running(self) -> bool:
@@ -75,8 +75,8 @@ class Supervisor:
             stderr_line_collector=self._stderr_line_collector,
             on_process_ended=self._schedule_restart,
         )
-        if self._pre_start_callback:
-            self._pre_start_callback()
+        if self._call_before_start:
+            self._call_before_start()
         transport = yield reactor.spawnProcess(  # type: ignore
             protocol, self._args[0], args=self._args, env=os.environ
         )
@@ -101,8 +101,8 @@ class Supervisor:
         )
         self.pid = pid
         self.name = name
-        if self._process_started_callback:
-            self._process_started_callback()
+        if self._call_after_start:
+            self._call_after_start()
         return (pid, name)
 
     def _schedule_restart(self, _) -> None:  # type: ignore
@@ -121,15 +121,15 @@ class Supervisor:
         started_trigger: str = "",
         stdout_line_collector: Optional[Callable] = None,
         stderr_line_collector: Optional[Callable] = None,
-        pre_start_callback: Optional[Callable] = None,
-        process_started_callback: Optional[Callable] = None,
+        call_before_start: Optional[Callable] = None,
+        call_after_start: Optional[Callable] = None,
     ) -> TwistedDeferred[tuple[int, str]]:
         self._args = args
         self._started_trigger = started_trigger
         self._stdout_line_collector = stdout_line_collector
         self._stderr_line_collector = stderr_line_collector
-        self._pre_start_callback = pre_start_callback
-        self._process_started_callback = process_started_callback
+        self._call_before_start = call_before_start
+        self._call_after_start = call_after_start
 
         if self.pidfile and self.pidfile.exists():
             yield self.stop()

--- a/gridsync/supervisor.py
+++ b/gridsync/supervisor.py
@@ -74,6 +74,8 @@ class Supervisor:
             stderr_line_collector=self._stderr_line_collector,
             on_process_ended=self._schedule_restart,
         )
+        if self._pre_start_callback:
+            self._pre_start_callback()
         transport = yield reactor.spawnProcess(  # type: ignore
             protocol, self._args[0], args=self._args, env=os.environ
         )
@@ -118,12 +120,14 @@ class Supervisor:
         started_trigger: str = "",
         stdout_line_collector: Optional[Callable] = None,
         stderr_line_collector: Optional[Callable] = None,
+        pre_start_callback: Optional[Callable] = None,
         process_started_callback: Optional[Callable] = None,
     ) -> TwistedDeferred[tuple[int, str]]:
         self._args = args
         self._started_trigger = started_trigger
         self._stdout_line_collector = stdout_line_collector
         self._stderr_line_collector = stderr_line_collector
+        self._pre_start_callback = pre_start_callback
         self._process_started_callback = process_started_callback
 
         if self.pidfile and self.pidfile.exists():

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -498,8 +498,8 @@ class Tahoe:
                 [self.executable, "-d", self.nodedir, "run"],
                 started_trigger="client running",
                 stdout_line_collector=self.line_received,
-                pre_start_callback=self._remove_twistd_pid,
-                process_started_callback=self._on_started,
+                call_before_start=self._remove_twistd_pid,
+                call_after_start=self._on_started,
             )
         except Exception as exc:  # pylint: disable=broad-except
             critical(

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -394,9 +394,6 @@ class Tahoe:
     @inlineCallbacks
     def stop(self):
         log.debug('Stopping "%s" tahoe client...', self.name)
-        if not os.path.isfile(self.pidfile):
-            log.error('No "twistd.pid" file found in %s', self.nodedir)
-            return
         self.state = Tahoe.STOPPING
         self.streamedlogs.stop()
         if self.rootcap_manager.lock.locked:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -452,6 +452,9 @@ class Tahoe:
         if not self.is_storage_node():
             self.magic_folder.start()
 
+    def _remove_twistd_pid(self) -> None:
+        Path(self.nodedir, "twistd.pid").unlink(missing_ok=True)
+
     @inlineCallbacks
     def start(self):
         log.debug('Starting "%s" tahoe client...', self.name)
@@ -480,6 +483,7 @@ class Tahoe:
                 [self.executable, "-d", self.nodedir, "run"],
                 started_trigger="client running",
                 stdout_line_collector=self.line_received,
+                pre_start_callback=self._remove_twistd_pid,
                 process_started_callback=self._on_started,
             )
         except Exception as exc:  # pylint: disable=broad-except

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -94,7 +94,7 @@ def test_supervisor_does_not_restart_process_when_stopped(tmp_path):
 
 
 @inlineCallbacks
-def test_supervisor_calls_pre_start_callback_before_start(tmp_path):
+def test_supervisor_calls_call_before_start(tmp_path):
     supervisor = Supervisor()
     f_was_called = [False]
 
@@ -102,14 +102,14 @@ def test_supervisor_calls_pre_start_callback_before_start(tmp_path):
         f_was_called[0] = True
 
     yield supervisor.start(
-        PROCESS_ARGS, started_trigger="OK", pre_start_callback=f
+        PROCESS_ARGS, started_trigger="OK", call_before_start=f
     )
     yield supervisor.stop()
     assert f_was_called[0] is True
 
 
 @inlineCallbacks
-def test_supervisor_calls_process_started_callback_after_start(tmp_path):
+def test_supervisor_calls_call_after_start(tmp_path):
     supervisor = Supervisor()
     f_was_called = [False]
 
@@ -117,7 +117,7 @@ def test_supervisor_calls_process_started_callback_after_start(tmp_path):
         f_was_called[0] = True
 
     yield supervisor.start(
-        PROCESS_ARGS, started_trigger="OK", process_started_callback=f
+        PROCESS_ARGS, started_trigger="OK", call_after_start=f
     )
     yield supervisor.stop()
     assert f_was_called[0] is True

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -91,3 +91,33 @@ def test_supervisor_does_not_restart_process_when_stopped(tmp_path):
     yield supervisor.stop()
     yield deferLater(reactor, 0.5, lambda: None)
     assert supervisor.pid is None
+
+
+@inlineCallbacks
+def test_supervisor_calls_pre_start_callback_before_start(tmp_path):
+    supervisor = Supervisor()
+    f_was_called = [False]
+
+    def f():
+        f_was_called[0] = True
+
+    yield supervisor.start(
+        PROCESS_ARGS, started_trigger="OK", pre_start_callback=f
+    )
+    yield supervisor.stop()
+    assert f_was_called[0] is True
+
+
+@inlineCallbacks
+def test_supervisor_calls_process_started_callback_after_start(tmp_path):
+    supervisor = Supervisor()
+    f_was_called = [False]
+
+    def f():
+        f_was_called[0] = True
+
+    yield supervisor.start(
+        PROCESS_ARGS, started_trigger="OK", process_started_callback=f
+    )
+    yield supervisor.stop()
+    assert f_was_called[0] is True


### PR DESCRIPTION
This PR removes tahoe's "twistd.pid" in favor of using Gridsync's `Supervisor` for pidfile creation/management.

On non-Windows systems, Twisted/twistd will create its own pidfile ("twistd.pid") for tahoe processes and will refuse to (re)start tahoe if the pid number in the file matches *any* running process, _irrespective of the name of that process_. Gridsync's `Supervisor`, however, _also_ creates/manages pidfiles for its processes (including on Windows!) but, unlike twistd, will include and check/verify the name of the process attached to the pid in the pidfile and determine staleness accordingly (i.e., by killing/restarting the process if the name actually corresponds to that of the process it is supposed to be managing, or by removing the pidfile if it does not). Removing "twistd.pid" (in favor of using `Supervisor` pidfiles) thus 1) avoids the situation in which tahoe will refuse to (re)start because a) it terminated uncleanly previously and b) some other process has since begun using the same pid contained in that pidfile and 2) allows Windows subprocesses to be managed in a way that is more consistent with the other operating systems supported by Gridsync.