### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:
@@ -102,8 +102,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       QT_API: ${{ matrix.qt }}
+      PY_PYTHON: 3.10
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -171,7 +172,7 @@ jobs:
         key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
         restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
     - name: Install dependencies
-      run: py -3.9 -m pip install tox diffoscope
+      run: py -m pip install --upgrade setuptools pip tox diffoscope
     - name: Test
       run: .\make.bat test
     - name: Make pyinstaller

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -265,7 +265,7 @@ class UsageView(QWidget):
     def _traceback(exc: Exception) -> str:
         return "".join(
             traceback.format_exception(
-                etype=type(exc), value=exc, tb=exc.__traceback__
+                type(exc), value=exc, tb=exc.__traceback__
             )
         )
 
@@ -286,7 +286,7 @@ class UsageView(QWidget):
         self.status_label.setText(
             "Voucher successfully added; token redemption should begin shortly"
         )
-        reactor.callLater(10, self._reset_status)  # type: ignore
+        reactor.callLater(10, self._reset_status)
 
     @inlineCallbacks
     def _open_zkap_payment_url(self) -> TwistedDeferred[None]:

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -286,7 +286,7 @@ class UsageView(QWidget):
         self.status_label.setText(
             "Voucher successfully added; token redemption should begin shortly"
         )
-        reactor.callLater(10, self._reset_status)
+        reactor.callLater(10, self._reset_status)  # type: ignore
 
     @inlineCallbacks
     def _open_zkap_payment_url(self) -> TwistedDeferred[None]:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -177,7 +177,7 @@ class View(QTreeView):
                 f"Could not create rootcap: {str(exc)}",
                 "".join(
                     traceback.format_exception(
-                        etype=type(exc), value=exc, tb=exc.__traceback__
+                        type(exc), value=exc, tb=exc.__traceback__
                     )
                 ),
             )

--- a/make.bat
+++ b/make.bat
@@ -3,7 +3,7 @@
 
 @echo off
 
-set PY_PYTHON=3.9
+set PY_PYTHON=3.10
 
 :: To prevent some on-disk state from the (non-integration) tests from
 :: carrying over to the integration tests, possibly (but not certainly)

--- a/scripts/provision_devtools.bat
+++ b/scripts/provision_devtools.bat
@@ -1,5 +1,5 @@
 choco install -y --no-progress --require-checksums git
-choco install -y --no-progress --require-checksums -m python3 --version 3.9.12
+choco install -y --no-progress --require-checksums -m python3 --version 3.9.13
 choco install -y --no-progress --require-checksums -m python3 --version 3.10.4
 choco install -y --no-progress --require-checksums visualcpp-build-tools
 choco install -y --no-progress --require-checksums innosetup

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -42,14 +42,14 @@ echo 'eval "$(pyenv init --path)"' >> "$SHELLRC"
 
 . "$SHELLRC"
 
-pyenv install --skip-existing 3.9.11
+pyenv install --skip-existing 3.9.13
 if [ "$(awk -F= '$1=="PRETTY_NAME" { print $2 ;}' /etc/os-release)" = '"CentOS Linux 7 (Core)"' ]; then
     export CPPFLAGS="-I/usr/include/openssl11"
     export LDFLAGS="-L/usr/lib64/openssl11"
 fi
-pyenv install --skip-existing 3.10.3
+pyenv install --skip-existing 3.10.4
 pyenv rehash
-pyenv global 3.9.11 3.10.3
+pyenv global 3.9.13 3.10.4
 pyenv versions
 
 python3 -m pip install --upgrade setuptools pip tox diffoscope

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -35,7 +35,7 @@ else
     fi
 fi
 
-git clone --branch v2.2.5 https://github.com/pyenv/pyenv.git ~/.pyenv || git --git-dir=$HOME/.pyenv/.git pull --force --ff origin v2.2.5
+git clone --branch v2.3.1 https://github.com/pyenv/pyenv.git ~/.pyenv || git --git-dir=$HOME/.pyenv/.git pull --force --ff origin v2.3.1
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$SHELLRC"
 echo 'export PATH="$PYENV_ROOT/bin:$HOME/bin:$PATH"' >> "$SHELLRC"
 echo 'eval "$(pyenv init --path)"' >> "$SHELLRC"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     url=metadata["url"],
     license=metadata["license"],
     keywords="gridsync tahoe-lafs tahoe lafs allmydata-tahoe magic-wormhole",
-    python_requires=">=3.9, <3.10",
+    python_requires=">=3.9, <3.11",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: MacOS X",
@@ -89,6 +89,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Communications :: File Sharing",
         "Topic :: Desktop Environment",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39},lint
+envlist = py{39,310},lint
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@ ignore_basepython_conflict = True
 [testenv]
 usedevelop = True
 basepython = python3.10
-install_command = python -m pip install --no-deps {opts} {packages}
+install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 setenv =
+    PYTHONHASHSEED=1
     pyqt5: QT_API=pyqt5
     pyqt6: QT_API=pyqt6
     pyside2: QT_API=pyside2
@@ -17,85 +18,71 @@ deps =
     -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
     -r{toxinidir}/requirements/test.txt
 commands =
-    python -m pytest {posargs}
+    {envpython} -m pytest {posargs}
 passenv = *
 
 [testenv:lint]
-install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
     -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
     -r{toxinidir}/requirements/lint.txt
 commands =
-    black --line-length=79 --check --diff setup.py gridsync tests
-    isort --line-length=79 --check --diff setup.py gridsync tests
+    {envpython} -m black --line-length=79 --check --diff setup.py gridsync tests
+    {envpython} -m isort --line-length=79 --check --diff setup.py gridsync tests
     {envpython} {toxinidir}/scripts/mypy-wrapper.py gridsync
-    flake8 setup.py gridsync tests
-    pylint --reports=no gridsync
+    {envpython} -m flake8 setup.py gridsync tests
+    {envpython} -m pylint --reports=no gridsync
 
 [testenv:pyinstaller-tahoe]
 skip_install = True
-install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/pyinstaller.txt
     -r{toxinidir}/requirements/tahoe-lafs.txt
-setenv =
-    PYTHONHASHSEED=1
 commands =
-    pip list
+    {envpython} -m pip list
     {envpython} -m pip check
-    pyinstaller -y pyinstaller.spec
+    {envpython} -m PyInstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-magic-folder]
 skip_install = True
-install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/pyinstaller.txt
     -r{toxinidir}/requirements/magic-folder.txt
-setenv =
-    PYTHONHASHSEED=1
 commands =
-    pip list
+    {envpython} -m pip list
     {envpython} -m pip check
-    pyinstaller -y pyinstaller.spec
+    {envpython} -m PyInstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-gridsync]
-install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/pyinstaller.txt
     -r{toxinidir}/requirements/gridsync.txt
     -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
-setenv =
-    PYTHONHASHSEED=1
 commands =
-    pip list
+    {envpython} -m pip list
     {envpython} -m pip check
-    pyinstaller -y pyinstaller.spec
+    {envpython} -m PyInstaller -y pyinstaller.spec
 
 [testenv:pyinstaller]
-install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
     -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
     -r{toxinidir}/requirements/pyinstaller.txt
     -r{toxinidir}/requirements/tahoe-lafs.txt
     -r{toxinidir}/requirements/magic-folder.txt
-setenv =
-    PYTHONHASHSEED=1
 commands =
-    pip list
+    {envpython} -m pip list
     {envpython} -m pip check
-    pyinstaller -y pyinstaller.spec
+    {envpython} -m PyInstaller -y pyinstaller.spec
 
 
 [testenv:integration]
-install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
     -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
     -r{toxinidir}/requirements/test.txt
 commands =
-    python -m pytest tests/integration
+    {envpython} -m pytest tests/integration
 
 
 [testenv:update-hashes]

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
     {envpython} -m pytest {posargs}
 passenv = *
 
+
 [testenv:lint]
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -33,35 +34,6 @@ commands =
     {envpython} -m flake8 setup.py gridsync tests
     {envpython} -m pylint --reports=no gridsync
 
-[testenv:pyinstaller-tahoe]
-skip_install = True
-deps =
-    -r{toxinidir}/requirements/pyinstaller.txt
-    -r{toxinidir}/requirements/tahoe-lafs.txt
-commands =
-    {envpython} -m pip list
-    {envpython} -m pip check
-    {envpython} -m PyInstaller -y pyinstaller.spec
-
-[testenv:pyinstaller-magic-folder]
-skip_install = True
-deps =
-    -r{toxinidir}/requirements/pyinstaller.txt
-    -r{toxinidir}/requirements/magic-folder.txt
-commands =
-    {envpython} -m pip list
-    {envpython} -m pip check
-    {envpython} -m PyInstaller -y pyinstaller.spec
-
-[testenv:pyinstaller-gridsync]
-deps =
-    -r{toxinidir}/requirements/pyinstaller.txt
-    -r{toxinidir}/requirements/gridsync.txt
-    -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
-commands =
-    {envpython} -m pip list
-    {envpython} -m pip check
-    {envpython} -m PyInstaller -y pyinstaller.spec
 
 [testenv:pyinstaller]
 deps =
@@ -75,6 +47,27 @@ commands =
     {envpython} -m pip check
     {envpython} -m PyInstaller -y pyinstaller.spec
 
+[testenv:pyinstaller-tahoe]
+skip_install = True
+deps =
+    -r{toxinidir}/requirements/pyinstaller.txt
+    -r{toxinidir}/requirements/tahoe-lafs.txt
+commands = {[testenv:pyinstaller]commands}
+
+[testenv:pyinstaller-magic-folder]
+skip_install = True
+deps =
+    -r{toxinidir}/requirements/pyinstaller.txt
+    -r{toxinidir}/requirements/magic-folder.txt
+commands = {[testenv:pyinstaller]commands}
+
+[testenv:pyinstaller-gridsync]
+deps =
+    -r{toxinidir}/requirements/pyinstaller.txt
+    -r{toxinidir}/requirements/gridsync.txt
+    -r{toxinidir}/requirements/{env:QT_API:pyqt5}.txt
+commands = {[testenv:pyinstaller]commands}
+
 
 [testenv:integration]
 deps =
@@ -87,7 +80,7 @@ commands =
 
 [testenv:update-hashes]
 skip_install = True
-install_command = python -m pip install {opts} {packages}
+install_command = {envpython} -m pip install {opts} {packages}
 deps =
     pip-tools
     hashin
@@ -110,7 +103,7 @@ commands =
 
 [testenv:update-github-repo]
 skip_install = True
-install_command = python -m pip install {opts} {packages}
+install_command = {envpython} -m pip install {opts} {packages}
 deps =
     httpx
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ ignore_basepython_conflict = True
 
 [testenv]
 usedevelop = True
-basepython = python3.10
+basepython = {env:TOX_BASEPYTHON:python3.10}
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 setenv =
     PYTHONHASHSEED=1

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv = *
 
 [testenv:lint]
 usedevelop = True
-basepython = python3.9
+basepython = python3.10
 install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -94,7 +94,7 @@ commands =
 
 [testenv:integration]
 usedevelop = True
-basepython = python3.9
+basepython = python3.10
 install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -105,7 +105,7 @@ commands =
 
 
 [testenv:update-hashes]
-basepython = python3.9
+basepython = python3.10
 skip_install = True
 install_command = python -m pip install {opts} {packages}
 deps =
@@ -129,7 +129,7 @@ commands =
     pip-compile -q --allow-unsafe --generate-hashes --upgrade --output-file=requirements/pyside6.txt requirements/pyside6.in
 
 [testenv:update-github-repo]
-basepython = python3.9
+basepython = python3.10
 skip_install = True
 install_command = python -m pip install {opts} {packages}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist = py{39,310},lint
 skip_missing_interpreters = True
+ignore_basepython_conflict = True
 
 [testenv]
 usedevelop = True
+basepython = python3.10
 install_command = python -m pip install --no-deps {opts} {packages}
 setenv =
     pyqt5: QT_API=pyqt5
@@ -19,8 +21,6 @@ commands =
 passenv = *
 
 [testenv:lint]
-usedevelop = True
-basepython = python3.10
 install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -34,8 +34,6 @@ commands =
     pylint --reports=no gridsync
 
 [testenv:pyinstaller-tahoe]
-usedevelop = True
-basepython = python3.10
 skip_install = True
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
@@ -49,8 +47,6 @@ commands =
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-magic-folder]
-usedevelop = True
-basepython = python3.10
 skip_install = True
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
@@ -64,8 +60,6 @@ commands =
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller-gridsync]
-usedevelop = True
-basepython = python3.10
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/pyinstaller.txt
@@ -79,8 +73,6 @@ commands =
     pyinstaller -y pyinstaller.spec
 
 [testenv:pyinstaller]
-usedevelop = True
-basepython = python3.10
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -97,8 +89,6 @@ commands =
 
 
 [testenv:integration]
-usedevelop = True
-basepython = python3.10
 install_command = python -m pip install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt
@@ -109,7 +99,6 @@ commands =
 
 
 [testenv:update-hashes]
-basepython = python3.10
 skip_install = True
 install_command = python -m pip install {opts} {packages}
 deps =
@@ -133,7 +122,6 @@ commands =
     pip-compile -q --allow-unsafe --generate-hashes --upgrade --output-file=requirements/pyside6.txt requirements/pyside6.in
 
 [testenv:update-github-repo]
-basepython = python3.10
 skip_install = True
 install_command = python -m pip install {opts} {packages}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
 
 [testenv:pyinstaller-tahoe]
 usedevelop = True
+basepython = python3.10
 skip_install = True
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
@@ -49,6 +50,7 @@ commands =
 
 [testenv:pyinstaller-magic-folder]
 usedevelop = True
+basepython = python3.10
 skip_install = True
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
@@ -63,6 +65,7 @@ commands =
 
 [testenv:pyinstaller-gridsync]
 usedevelop = True
+basepython = python3.10
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/pyinstaller.txt
@@ -77,6 +80,7 @@ commands =
 
 [testenv:pyinstaller]
 usedevelop = True
+basepython = python3.10
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 deps =
     -r{toxinidir}/requirements/gridsync.txt


### PR DESCRIPTION
This PR adds/enables support for Python version 3.10 and updates various CI/testing/build configuration files accordingly.

In addition, this PR refactors the project `tox.ini` file to (optionally) read and set the `basepython` configuration value from a `TOX_BASEPYTHON` environment variable, making it easier to test/build the application with different interpreters and/or on systems that don't have python3.10 installed (for example, to build the PyInstaller bundle with Python 3.9, one can invoke `TOX_BASEPYTHON=python3.9 tox -e pyinstaller`)