### PR TITLE
Fix `QRect` TypeError introduced by PyQt5 5.15.7

### DIFF
--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -73,7 +73,7 @@ class BadgedPixmap(QPixmap):
 
         if text:
             font = painter.font()
-            font.setPixelSize(badge_max - pen_width)
+            font.setPixelSize(int(badge_max - pen_width))
             painter.setFont(font)
             painter.setPen(Qt.white)
             painter.drawText(rect, Qt.AlignCenter, str(text))

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -7,7 +7,7 @@ from gridsync import resource
 
 
 class Pixmap(QPixmap):
-    def __init__(self, resource_filename, size=None):
+    def __init__(self, resource_filename: str, size: int = None) -> None:
         super().__init__(resource(resource_filename))
         if size:
             self.swap(
@@ -18,7 +18,9 @@ class Pixmap(QPixmap):
 
 
 class CompositePixmap(QPixmap):
-    def __init__(self, pixmap, overlay=None, grayout=False):
+    def __init__(
+        self, pixmap: QPixmap, overlay: str = None, grayout: bool = False
+    ) -> None:
         super().__init__()
         base_pixmap = QPixmap(pixmap)
         if grayout:
@@ -43,7 +45,13 @@ class BadgedPixmap(QPixmap):
     BottomLeft = (0, 1)
     BottomRight = (1, 1)
 
-    def __init__(self, pixmap, text="", size=0.5, corner=BottomRight):
+    def __init__(
+        self,
+        pixmap: QPixmap,
+        text: str = "",
+        size: float = 0.5,
+        corner: tuple[int, int] = BottomRight,
+    ) -> None:
         super().__init__()
 
         base_pixmap = QPixmap(pixmap)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -43,7 +43,7 @@ class BadgedPixmap(QPixmap):
     BottomLeft = (0, 1)
     BottomRight = (1, 1)
 
-    def __init__(self, pixmap, text, size=0.5, corner=BottomRight):
+    def __init__(self, pixmap, text="", size=0.5, corner=BottomRight):
         super().__init__()
 
         base_pixmap = QPixmap(pixmap)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -59,10 +59,10 @@ class BadgedPixmap(QPixmap):
         badge_max = base_max * size
         pen_width = badge_max * 0.05
         rect = QRect(
-            base_max * max(corner[0] - size, 0) + pen_width,
-            base_max * max(corner[1] - size, 0) + pen_width,
-            badge_max - pen_width,
-            badge_max - pen_width,
+            int(base_max * max(corner[0] - size, 0) + pen_width),
+            int(base_max * max(corner[1] - size, 0) + pen_width),
+            int(badge_max - pen_width),
+            int(badge_max - pen_width),
         )
 
         painter = QPainter(base_pixmap)

--- a/gridsync/gui/pixmap.py
+++ b/gridsync/gui/pixmap.py
@@ -7,7 +7,7 @@ from gridsync import resource
 
 
 class Pixmap(QPixmap):
-    def __init__(self, resource_filename: str, size: int = None) -> None:
+    def __init__(self, resource_filename: str, size: int = 0) -> None:
         super().__init__(resource(resource_filename))
         if size:
             self.swap(

--- a/gridsync/gui/systray.py
+++ b/gridsync/gui/systray.py
@@ -54,7 +54,7 @@ class SystemTrayIcon(QSystemTrayIcon):
             pixmap = self.animation.currentPixmap()
             if self.gui.unread_messages:
                 pixmap = BadgedPixmap(
-                    pixmap, len(self.gui.unread_messages), 0.6
+                    pixmap, str(len(self.gui.unread_messages)), 0.6
                 )
             self.setIcon(QIcon(pixmap))
         else:
@@ -63,7 +63,9 @@ class SystemTrayIcon(QSystemTrayIcon):
                 self.setIcon(
                     QIcon(
                         BadgedPixmap(
-                            self.app_pixmap, len(self.gui.unread_messages), 0.6
+                            self.app_pixmap,
+                            str(len(self.gui.unread_messages)),
+                            0.6,
                         )
                     )
                 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,6 @@ disallow_untyped_defs = False
 [mypy-gridsync.gui.main_window]
 disallow_untyped_defs = False
 
-[mypy-gridsync.gui.pixmap]
-disallow_untyped_defs = False
-
 [mypy-gridsync.gui.preferences]
 disallow_untyped_defs = False
 

--- a/tests/gui/test_pixmap.py
+++ b/tests/gui/test_pixmap.py
@@ -7,5 +7,5 @@ from gridsync.gui.pixmap import BadgedPixmap
 
 
 def test_badged_pixmap(gui):
-    bp = BadgedPixmap(resource("gridsync.png"))
+    bp = BadgedPixmap(resource("gridsync.png"), "test")
     assert bp is not None

--- a/tests/gui/test_pixmap.py
+++ b/tests/gui/test_pixmap.py
@@ -6,6 +6,6 @@ from gridsync import resource
 from gridsync.gui.pixmap import BadgedPixmap
 
 
-def test_badged_pixmap():
-    bp = BadgedPixmap(resource("gridsync.png"), "test")
+def test_badged_pixmap(gui):
+    bp = BadgedPixmap(resource("gridsync.png"))
     assert bp is not None

--- a/tests/gui/test_pixmap.py
+++ b/tests/gui/test_pixmap.py
@@ -1,11 +1,25 @@
 """
 Tests for ``gridsync.gui.pixmap``.
 """
+from qtpy.QtGui import QPixmap
 
 from gridsync import resource
-from gridsync.gui.pixmap import BadgedPixmap
+from gridsync.gui.pixmap import BadgedPixmap, CompositePixmap, Pixmap
+
+
+def test_pixmap():
+    p = Pixmap(resource("gridsync.png"), 16)
+    size = p.size()
+    assert (size.width(), size.height()) == (16, 16)
+
+
+def test_composite_pixmap(gui):
+    original = QPixmap(resource("gridsync.png"))
+    composite = CompositePixmap(original, "gridsync.png", grayout=True)
+    assert composite != original
 
 
 def test_badged_pixmap(gui):
-    bp = BadgedPixmap(resource("gridsync.png"), "test")
-    assert bp is not None
+    original = QPixmap(resource("gridsync.png"))
+    badged = BadgedPixmap(original, "test")
+    assert badged != original

--- a/tests/gui/test_pixmap.py
+++ b/tests/gui/test_pixmap.py
@@ -1,0 +1,11 @@
+"""
+Tests for ``gridsync.gui.pixmap``.
+"""
+
+from gridsync import resource
+from gridsync.gui.pixmap import BadgedPixmap
+
+
+def test_badged_pixmap():
+    bp = BadgedPixmap(resource("gridsync.png"), "test")
+    assert bp is not None


### PR DESCRIPTION
Fixes #496.

Also adds type annotations and some basic tests for the rest of the "pixmap" module.