### PR TITLE
479.importlib bug workaround

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -5,13 +5,6 @@
 
 set PY_PYTHON=3.10
 
-:: To prevent some on-disk state from the (non-integration) tests from
-:: carrying over to the integration tests, possibly (but not certainly)
-:: avoiding the pytest/importlib._bootstrap "INTERNALERROR" described
-:: in https://github.com/gridsync/gridsync/issues/479
-set PYTHONDONTWRITEBYTECODE=1
-
-
 if "%1"=="clean" call :clean
 if "%1"=="test" call :test
 if "%1"=="test-integration" call :test-integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,14 @@ disable = [
     "unbalanced-tuple-unpacking",
     "wrong-import-position",
 ]
+
+
+[tool.pytest.ini_options]
+# Configure pytest to ignore ResourceWarning as a work-around for
+# https://github.com/gridsync/gridsync/issues/479 /
+# https://github.com/python/cpython/issues/91351
+#
+# https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+filterwarnings = [
+    "ignore::ResourceWarning",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,18 @@ usedevelop = True
 basepython = {env:TOX_BASEPYTHON:python3.10}
 install_command = {envpython} scripts/reproducible-pip.py install --no-deps {opts} {packages}
 setenv =
+    # The time saved by having bytecode around instead of having to recompile
+    # the source code is probably negligible.  Even if it isn't, avoiding the
+    # extra complexity involved in having the bytecode around (is it for the
+    # right Python version?  How does it interact with the pytest-generated
+    # bytecode?  is it up-to-date with respect to the source files?  etc) is a
+    # far greater cost.  So, don't have bytecode.
+    PYTHONDONTWRITEBYTECODE=1
+
+    # Remove a source of non-determinism from the builds by making sure
+    # strings hash to the same value from one run to the next.
     PYTHONHASHSEED=1
+
     pyqt5: QT_API=pyqt5
     pyqt6: QT_API=pyqt6
     pyside2: QT_API=pyside2


### PR DESCRIPTION
This is an attempt to further mitigate #479.  It probably cannot be said that this _fixes_ that issue because any other `__del__`, weakref callback, or signal handler could still introduce an import at a bad time.

Still, maybe it is worth having until CPython does something about the underlying issue.  The change does mean ResourceWarning reporting by pytest will be lost.  I don't think that's a big deal because I don't think anyone is paying attention to that information right now anyway (if we wanted GridSync to be ResourceWarning-free then I expect we would add a CI job that configures a warnings filter like "error::ResourceWarning" and this should also avoid the CPython bug).

Also included here is a change to PYTHONDONTWRITEBYTECODE so that it is set consistently for all platforms when using tox instead of only being set for Windows.  It was set for Windows because it managed to mitigate the CPython bug but it did so in a more fragile way than this warnings reconfiguration (I think) but it is a pretty reasonable thing to set anyway since pyc files mostly add complexity.


