### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -273,7 +273,7 @@ Vagrant.configure("2") do |config|
     # Shared directories are not supported by Big Sur guests
     # See https://app.vagrantup.com/amarcireau/boxes/macos
     b.vm.synced_folder ".", "/Users/vagrant/vagrant", disabled: true
-    b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
+    b.vm.provision "update", type: "shell", privileged: false, inline: update_macos
     b.vm.provision "install-monterey", type: "shell", privileged: false, inline: install_macos_monterey
     b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
     b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,14 @@ def update_macos
 end
 
 
+def install_macos_monterey
+  return <<-EOF
+    softwareupdate --verbose --fetch-full-installer --full-installer-version 12.5
+    echo vagrant | /Applications/Install\ macOS\ Monterey.app/Contents/Resources/startosinstall --agreetolicense --forcequitapps --user vagrant --stdinpass
+  EOF
+end
+
+
 def gnome_desktop
   return <<-EOF
     yum -y update
@@ -224,6 +232,7 @@ Vagrant.configure("2") do |config|
     # See https://app.vagrantup.com/amarcireau/boxes/macos
     b.vm.synced_folder ".", "/Users/vagrant/vagrant", disabled: true
     b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
+    b.vm.provision "install-monterey", type: "shell", privileged: false, run: "never", inline: install_macos_monterey
     b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
     b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test
     b.vm.provision "build", type: "shell", privileged: false, run: "never", inline: make

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ end
 def install_macos_monterey
   return <<-EOF
     softwareupdate --verbose --fetch-full-installer --full-installer-version 12.5
-    echo vagrant | /Applications/Install\ macOS\ Monterey.app/Contents/Resources/startosinstall --agreetolicense --forcequitapps --user vagrant --stdinpass
+    echo vagrant | /Applications/Install\\ macOS\\ Monterey.app/Contents/Resources/startosinstall --agreetolicense --forcequitapps --user vagrant --stdinpass
   EOF
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -239,6 +239,48 @@ Vagrant.configure("2") do |config|
     b.vm.provision "buildbot-worker", type: "shell", privileged: false, run: "never", env: {"BUILDBOT_HOST": "#{ENV['BUILDBOT_HOST']}", "BUILDBOT_NAME": "#{ENV['BUILDBOT_NAME']}", "BUILDBOT_PASS": "#{ENV['BUILDBOT_PASS']}"}, path: "scripts/provision_buildbot-worker.sh"
   end
 
+  config.vm.define "macos-12" do |b|
+    b.vm.box = "amarcireau/macos"
+    b.vm.hostname = "macos-12"
+    b.vm.box_version = "11.3.1"
+    b.vm.provider "virtualbox" do |vb|
+      vb.memory = "4096"
+      # Guest additions are not supported by Big Sur guests
+      # See https://app.vagrantup.com/amarcireau/boxes/macos
+      vb.check_guest_additions = false
+      vb.customize ["modifyvm", :id, "--usbehci", "off"]
+      vb.customize ["modifyvm", :id, "--usbxhci", "off"]
+      vb.customize ["setextradata", :id, "VBoxInternal/Devices/efi/0/Config/DmiSystemProduct", "MacBookPro11,3"]
+      vb.customize ["setextradata", :id, "VBoxInternal/Devices/efi/0/Config/DmiSystemVersion", "1.0"]
+      vb.customize ["setextradata", :id, "VBoxInternal/Devices/efi/0/Config/DmiBoardProduct", "Iloveapple"]
+      vb.customize ["setextradata", :id, "VBoxInternal/Devices/smc/0/Config/DeviceKey", "ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"]
+    end
+    # "The NVRAM file packaged with this Vagrant box must be copied manually after importing it into Virtualbox."
+    # See https://app.vagrantup.com/amarcireau/boxes/macos
+    config.trigger.after :"VagrantPlugins::ProviderVirtualBox::Action::Import", type: :action do |t|
+        t.ruby do |env, machine|
+            FileUtils.cp(
+                machine.box.directory.join("include").join("macOS.nvram").to_s,
+                machine.provider.driver.execute_command(["showvminfo", machine.id, "--machinereadable"]).
+                    split(/\n/).
+                    map {|line| line.partition(/=/)}.
+                    select {|partition| partition.first == "BIOS NVRAM File"}.
+                    last.
+                    last[1..-2]
+            )
+        end
+    end
+    # Shared directories are not supported by Big Sur guests
+    # See https://app.vagrantup.com/amarcireau/boxes/macos
+    b.vm.synced_folder ".", "/Users/vagrant/vagrant", disabled: true
+    b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
+    b.vm.provision "install-monterey", type: "shell", privileged: false, inline: install_macos_monterey
+    b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
+    b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test
+    b.vm.provision "build", type: "shell", privileged: false, run: "never", inline: make
+    b.vm.provision "buildbot-worker", type: "shell", privileged: false, run: "never", env: {"BUILDBOT_HOST": "#{ENV['BUILDBOT_HOST']}", "BUILDBOT_NAME": "#{ENV['BUILDBOT_NAME']}", "BUILDBOT_PASS": "#{ENV['BUILDBOT_PASS']}"}, path: "scripts/provision_buildbot-worker.sh"
+  end
+
   config.vm.define "windows-10" do |b|
     b.vm.box = "gusztavvargadr/windows-10"
     b.vm.hostname = "windows-10"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,13 @@
 # Needed for copying NVRAM file for macos-11 as per https://app.vagrantup.com/amarcireau/boxes/macos
 ENV["VAGRANT_EXPERIMENTAL"] = "typed_triggers"
 
+def update_macos
+  return <<-EOF
+    softwareupdate --verbose --install --all
+  EOF
+end
+
+
 def gnome_desktop
   return <<-EOF
     yum -y update
@@ -155,6 +162,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["setextradata", :id, "VBoxInternal/Devices/smc/0/Config/DeviceKey", "ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"]
     end
     b.vm.synced_folder ".", "/Users/vagrant/vagrant", type: "rsync", rsync__chown: false
+    b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
     b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
     b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test
     b.vm.provision "build", type: "shell", privileged: false, run: "never", inline: make
@@ -174,6 +182,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["setextradata", :id, "VBoxInternal/Devices/smc/0/Config/DeviceKey", "ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"]
     end
     b.vm.synced_folder ".", "/Users/vagrant/vagrant", type: "rsync"
+    b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
     b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
     b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test
     b.vm.provision "build", type: "shell", privileged: false, run: "never", inline: make
@@ -214,6 +223,7 @@ Vagrant.configure("2") do |config|
     # Shared directories are not supported by Big Sur guests
     # See https://app.vagrantup.com/amarcireau/boxes/macos
     b.vm.synced_folder ".", "/Users/vagrant/vagrant", disabled: true
+    b.vm.provision "update", type: "shell", privileged: false, run: "never", inline: update_macos
     b.vm.provision "devtools", type: "shell", privileged: false, run: "never", path: "scripts/provision_devtools.sh"
     b.vm.provision "test", type: "shell", privileged: false, run: "never", inline: test
     b.vm.provision "build", type: "shell", privileged: false, run: "never", inline: make


### PR DESCRIPTION
This PR updates the project `Vagrantfile`, adding a "macos-11" environment and a "macos-12" environment (which upgrades from a macos-11 environment in-place). Additional provisioners were also added for updating macOS (via `softwareupdate') and installing macOS Monterey (in-place).