### PR TITLE
Add Nix-based development shell and related CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,16 +11,9 @@ jobs:
     steps:
     - name: "Install Basic Dependencies"
       run: |
-        # The nixos/nix image does not include ssh.  Install it so the
-        # `checkout` step will succeed.  We also want cachix for
-        # Nix-friendly caching.  We only use these tools for setting up
-        # the build environment so the exact version of nixos/nixpkgs we
-        # use doesn't matter a whole lot.  The inputs for the real build
-        # are pinned elsewhere.
-        nix-env \
-          --file https://github.com/nixos/nixpkgs/archive/nixos-21.11.tar.gz \
-          --install \
-          -A openssh bash
+        # The GitHub Actions "checkout" action wants to read this file.  Make
+        # sure it exists.
+        touch /etc/os-release
 
         # We also want to use flakes but they're still experimental so
         # turn them on.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: "ubuntu-latest"
     container:
       image: "nixos/nix:2.9.1"
+      options: "--sysctl kernel.unprivileged_userns_clone=1"
 
     steps:
     - name: "Install Basic Dependencies"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,206 +36,206 @@ jobs:
       run: |
         nix run .#tox -- -e integration
 
-  # Linux:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-  #       qt: [pyqt5, pyqt6]
-  #       exclude:
-  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
-  #         # https://doc.qt.io/qt-6/supported-platforms.html
-  #         - os: ubuntu-18.04
-  #           qt: pyqt6
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt-get install -y podman
-  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test
-  #   - name: Build
-  #     run: |
-  #       source ~/.bash_profile
-  #       make all
-  #   - name: Verify
-  #     run: |
-  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-  #       xvfb-run -a dist/Gridsync/gridsync --version
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-determinism
-  #   - name: Build (in container)
-  #     run: |
-  #       source ~/.bash_profile
-  #       make clean in-container
-  #       sudo chown -R runner ~
-  #   - name: Verify (on host)
-  #     run: |
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-integration
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.AppImage
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  # macOS:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-11, macos-12]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo rm -rf /Applications/Python*
-  #       scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bashrc
-  #       make test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       source ~/.bashrc
-  #       make pyinstaller
-  #       make zip
-  #   - name: Verify
-  #     run: |
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-determinism
-  #   - name: Make dmg
-  #     run: |
-  #       source ~/.bashrc
-  #       make dmg
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.dmg
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  # Windows:
-  #   strategy:
-  #     matrix:
-  #       os: [windows-2019, windows-2022]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #     PY_PYTHON: 3.10
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: c:\users\runneradmin\appdata\local\pip\cache
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
-  #   - name: Test
-  #     run: .\make.bat test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       .\make.bat pyinstaller
-  #       .\make.bat zip
-  #   - name: Verify
-  #     run: |
-  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
-  #       .\dist\Gridsync\Gridsync.exe --version
-  #   - name: Test integration
-  #     run: |
-  #       .\make.bat test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       .\make.bat test-determinism
-  #   - name: Upload zipfiles
-  #     uses: actions/upload-artifact@v2
-  #     if: failure()
-  #     with:
-  #       name: zipfiles.zip
-  #       path: .\dist\*.zip
-  #   - name: Make installer
-  #     run: |
-  #       .\make.bat installer
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py .\dist\*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: .\dist\Gridsync-setup.exe
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  Linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        qt: [pyqt5, pyqt6]
+        exclude:
+          # Qt 6 is unsupported on Ubuntu 18.04. See:
+          # https://doc.qt.io/qt-6/supported-platforms.html
+          - os: ubuntu-18.04
+            qt: pyqt6
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y podman
+        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bash_profile
+        make test
+    - name: Build
+      run: |
+        source ~/.bash_profile
+        make all
+    - name: Verify
+      run: |
+        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+        xvfb-run -a dist/Gridsync/gridsync --version
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        make test-determinism
+    - name: Build (in container)
+      run: |
+        source ~/.bash_profile
+        make clean in-container
+        sudo chown -R runner ~
+    - name: Verify (on host)
+      run: |
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test integration
+      run: |
+        source ~/.bash_profile
+        make test-integration
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.AppImage
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  macOS:
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo rm -rf /Applications/Python*
+        scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bashrc
+        make test
+    - name: Make pyinstaller
+      run: |
+        source ~/.bashrc
+        make pyinstaller
+        make zip
+    - name: Verify
+      run: |
+        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+        dist/Gridsync.app/Contents/MacOS/Gridsync --version
+    - name: Test integration
+      run: |
+        source ~/.bashrc
+        make test-integration
+    - name: Test determinism
+      run: |
+        source ~/.bashrc
+        make test-determinism
+    - name: Make dmg
+      run: |
+        source ~/.bashrc
+        make dmg
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.dmg
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  Windows:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+      PY_PYTHON: 3.10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: c:\users\runneradmin\appdata\local\pip\cache
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: py -m pip install --upgrade setuptools pip tox diffoscope
+    - name: Test
+      run: .\make.bat test
+    - name: Make pyinstaller
+      run: |
+        .\make.bat pyinstaller
+        .\make.bat zip
+    - name: Verify
+      run: |
+        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+        .\dist\Gridsync\Gridsync-magic-folder.exe --version
+        .\dist\Gridsync\Gridsync.exe --version
+    - name: Test integration
+      run: |
+        .\make.bat test-integration
+    - name: Test determinism
+      run: |
+        .\make.bat test-determinism
+    - name: Upload zipfiles
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: zipfiles.zip
+        path: .\dist\*.zip
+    - name: Make installer
+      run: |
+        .\make.bat installer
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py .\dist\*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: .\dist\Gridsync-setup.exe
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf
 
     - name: "Checkout"
-      uses: "actions/checkout@v2"
+      uses: "actions/checkout@v1"
       with:
         fetch-depth: 0
         # Checkout head of the branch of the PR, or the exact revision

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,20 +5,11 @@ on: [push, pull_request]
 jobs:
   NixOS:
     runs-on: "ubuntu-latest"
-    container:
-      image: "nixos/nix:2.9.1"
-
     steps:
-    - name: "Install Basic Dependencies"
+    - name: "Setup Execution Environment"
       run: |
-        # The GitHub Actions "checkout" action wants to read this file.  Make
-        # sure it exists.
-        touch /etc/os-release
-
-        # We also want to use flakes but they're still experimental so
-        # turn them on.
-        mkdir -p ~/.config/nix
-        echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf
+        # Also to allow `nix develop` to unshare in the Nix container, we need userns_clone:
+        sysctl -w kernel.unprivileged_userns_clone=1
 
     - name: "Checkout"
       uses: "actions/checkout@v1"
@@ -28,21 +19,21 @@ jobs:
         # specified for non-PR builds.
         ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
-    - name: "Check"
-      run: |
-        nix flake check
+    # - name: "Check"
+    #   run: |
+    #     nix flake check
 
-    - name: "Unit Test"
-      run: |
-        nix develop --command tox -e py39
+    # - name: "Unit Test"
+    #   run: |
+    #     nix develop --command tox -e py39
 
-    - name: "Integration Test"
-      run: |
-        nix develop --command tox -e integration
+    # - name: "Integration Test"
+    #   run: |
+    #     nix develop --command tox -e integration
 
-    - name: "Lint"
-      run: |
-        nix develop --command tox -e lint
+    # - name: "Lint"
+    #   run: |
+    #     nix develop --command tox -e lint
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,12 @@ jobs:
         # specified for non-PR builds.
         ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
+    - name: "Cache Docker Images"
+      uses: "addnab/docker-run-action@v3"
+      with:
+        image: "nixos/nix:2.9.1"
+        run: ""
+
     - name: "Check"
       uses: "addnab/docker-run-action@v3"
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,54 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  NixOS:
+    runs-on: "ubuntu-latest"
+    container:
+      image: "nixos/nix:2.9.1"
+
+    steps:
+    - name: "Install Basic Dependencies"
+      run: |
+        # The nixos/nix image does not include ssh.  Install it so the
+        # `checkout` step will succeed.  We also want cachix for
+        # Nix-friendly caching.  We only use these tools for setting up
+        # the build environment so the exact version of nixos/nixpkgs we
+        # use doesn't matter a whole lot.  The inputs for the real build
+        # are pinned elsewhere.
+        nix-env \
+          --file https://github.com/nixos/nixpkgs/archive/nixos-21.11.tar.gz \
+          --install \
+          -A openssh
+
+        # We also want to use flakes but they're still experimental so
+        # turn them on.
+        mkdir -p ~/.config/nix
+        echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf
+
+    - name: "Checkout"
+      uses: "actions/checkout@v2"
+      with:
+        fetch-depth: 0
+      # Checkout head of the branch of the PR, or the exact revision
+      # specified for non-PR builds.
+      ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+
+    - name: "Check"
+      run: |
+        nix flake check
+
+    - name: "Unit Test"
+      run: |
+        nix develop --command tox -e py39
+
+    - name: "Integration Test"
+      run: |
+        nix develop --command tox -e integration
+
+    - name: "Lint"
+      run: |
+        nix develop --command tox -e lint
+
   Linux:
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: "Setup Execution Environment"
       run: |
         # Also to allow `nix develop` to unshare in the Nix container, we need userns_clone:
-        sysctl -w kernel.unprivileged_userns_clone=1
+        sudo sysctl -w kernel.unprivileged_userns_clone=1
 
     - name: "Checkout"
       uses: "actions/checkout@v1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,206 +36,206 @@ jobs:
       run: |
         nix develop --command tox -e integration
 
-  # Linux:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-  #       qt: [pyqt5, pyqt6]
-  #       exclude:
-  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
-  #         # https://doc.qt.io/qt-6/supported-platforms.html
-  #         - os: ubuntu-18.04
-  #           qt: pyqt6
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt-get install -y podman
-  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test
-  #   - name: Build
-  #     run: |
-  #       source ~/.bash_profile
-  #       make all
-  #   - name: Verify
-  #     run: |
-  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-  #       xvfb-run -a dist/Gridsync/gridsync --version
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-determinism
-  #   - name: Build (in container)
-  #     run: |
-  #       source ~/.bash_profile
-  #       make clean in-container
-  #       sudo chown -R runner ~
-  #   - name: Verify (on host)
-  #     run: |
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-integration
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.AppImage
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  # macOS:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-11, macos-12]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo rm -rf /Applications/Python*
-  #       scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bashrc
-  #       make test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       source ~/.bashrc
-  #       make pyinstaller
-  #       make zip
-  #   - name: Verify
-  #     run: |
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-determinism
-  #   - name: Make dmg
-  #     run: |
-  #       source ~/.bashrc
-  #       make dmg
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.dmg
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  # Windows:
-  #   strategy:
-  #     matrix:
-  #       os: [windows-2019, windows-2022]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #     PY_PYTHON: 3.10
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: c:\users\runneradmin\appdata\local\pip\cache
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
-  #   - name: Test
-  #     run: .\make.bat test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       .\make.bat pyinstaller
-  #       .\make.bat zip
-  #   - name: Verify
-  #     run: |
-  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
-  #       .\dist\Gridsync\Gridsync.exe --version
-  #   - name: Test integration
-  #     run: |
-  #       .\make.bat test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       .\make.bat test-determinism
-  #   - name: Upload zipfiles
-  #     uses: actions/upload-artifact@v2
-  #     if: failure()
-  #     with:
-  #       name: zipfiles.zip
-  #       path: .\dist\*.zip
-  #   - name: Make installer
-  #     run: |
-  #       .\make.bat installer
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py .\dist\*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: .\dist\Gridsync-setup.exe
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  Linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        qt: [pyqt5, pyqt6]
+        exclude:
+          # Qt 6 is unsupported on Ubuntu 18.04. See:
+          # https://doc.qt.io/qt-6/supported-platforms.html
+          - os: ubuntu-18.04
+            qt: pyqt6
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y podman
+        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bash_profile
+        make test
+    - name: Build
+      run: |
+        source ~/.bash_profile
+        make all
+    - name: Verify
+      run: |
+        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+        xvfb-run -a dist/Gridsync/gridsync --version
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        make test-determinism
+    - name: Build (in container)
+      run: |
+        source ~/.bash_profile
+        make clean in-container
+        sudo chown -R runner ~
+    - name: Verify (on host)
+      run: |
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test integration
+      run: |
+        source ~/.bash_profile
+        make test-integration
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.AppImage
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  macOS:
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo rm -rf /Applications/Python*
+        scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bashrc
+        make test
+    - name: Make pyinstaller
+      run: |
+        source ~/.bashrc
+        make pyinstaller
+        make zip
+    - name: Verify
+      run: |
+        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+        dist/Gridsync.app/Contents/MacOS/Gridsync --version
+    - name: Test integration
+      run: |
+        source ~/.bashrc
+        make test-integration
+    - name: Test determinism
+      run: |
+        source ~/.bashrc
+        make test-determinism
+    - name: Make dmg
+      run: |
+        source ~/.bashrc
+        make dmg
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.dmg
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  Windows:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+      PY_PYTHON: 3.10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: c:\users\runneradmin\appdata\local\pip\cache
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: py -m pip install --upgrade setuptools pip tox diffoscope
+    - name: Test
+      run: .\make.bat test
+    - name: Make pyinstaller
+      run: |
+        .\make.bat pyinstaller
+        .\make.bat zip
+    - name: Verify
+      run: |
+        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+        .\dist\Gridsync\Gridsync-magic-folder.exe --version
+        .\dist\Gridsync\Gridsync.exe --version
+    - name: Test integration
+      run: |
+        .\make.bat test-integration
+    - name: Test determinism
+      run: |
+        .\make.bat test-determinism
+    - name: Upload zipfiles
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: zipfiles.zip
+        path: .\dist\*.zip
+    - name: Make installer
+      run: |
+        .\make.bat installer
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py .\dist\*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: .\dist\Gridsync-setup.exe
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   NixOS:
     runs-on: "ubuntu-latest"
     container:
-      image: "nixos/nix:2.9.1"
+      image: "nixos/nix:2.10.3"
       # Run the container privileged because `nix develop` wants to use
       # unshare (I'm not sure why, maybe because we use buildFHSUserEnv).
       options: "--privileged"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 jobs:
   NixOS:
     runs-on: "ubuntu-latest"
-    env:
-      NIX: "nix --option experimental-features 'nix-command flakes'"
-
     steps:
     - name: "Setup Execution Environment"
       run: |
@@ -44,7 +41,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          $NIX flake check
+          nix --option experimental-features 'nix-command flakes' flake check
 
     - name: "Unit Test"
       uses: "addnab/docker-run-action@v3"
@@ -53,7 +50,8 @@ jobs:
         options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
-          $NIX develop --command tox -e py39
+          nix --option experimental-features 'nix-command flakes' develop \
+            --command tox -e py39
 
     - name: "Integration Test"
       uses: "addnab/docker-run-action@v3"
@@ -62,7 +60,8 @@ jobs:
         options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
-          $NIX develop --command tox -e integration
+          nix --option experimental-features 'nix-command flakes' develop \
+            --command tox -e integration
 
     - name: "Lint"
       uses: "addnab/docker-run-action@v3"
@@ -71,7 +70,8 @@ jobs:
         options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
-          $NIX develop --command tox -e lint
+          nix --option experimental-features 'nix-command flakes' develop \
+            --command tox -e lint
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,206 +41,206 @@ jobs:
           nix --option experimental-features 'nix-command flakes' develop \
             --command tox -e py39,integration,lint
 
-  # Linux:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-  #       qt: [pyqt5, pyqt6]
-  #       exclude:
-  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
-  #         # https://doc.qt.io/qt-6/supported-platforms.html
-  #         - os: ubuntu-18.04
-  #           qt: pyqt6
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt-get install -y podman
-  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test
-  #   - name: Build
-  #     run: |
-  #       source ~/.bash_profile
-  #       make all
-  #   - name: Verify
-  #     run: |
-  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-  #       xvfb-run -a dist/Gridsync/gridsync --version
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-determinism
-  #   - name: Build (in container)
-  #     run: |
-  #       source ~/.bash_profile
-  #       make clean in-container
-  #       sudo chown -R runner ~
-  #   - name: Verify (on host)
-  #     run: |
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-integration
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.AppImage
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  # macOS:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-10.15, macos-11, macos-12]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo rm -rf /Applications/Python*
-  #       scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bashrc
-  #       make test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       source ~/.bashrc
-  #       make pyinstaller
-  #       make zip
-  #   - name: Verify
-  #     run: |
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-determinism
-  #   - name: Make dmg
-  #     run: |
-  #       source ~/.bashrc
-  #       make dmg
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.dmg
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  # Windows:
-  #   strategy:
-  #     matrix:
-  #       os: [windows-2019, windows-2022]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #     PY_PYTHON: 3.10
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: c:\users\runneradmin\appdata\local\pip\cache
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
-  #   - name: Test
-  #     run: .\make.bat test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       .\make.bat pyinstaller
-  #       .\make.bat zip
-  #   - name: Verify
-  #     run: |
-  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
-  #       .\dist\Gridsync\Gridsync.exe --version
-  #   - name: Test integration
-  #     run: |
-  #       .\make.bat test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       .\make.bat test-determinism
-  #   - name: Upload zipfiles
-  #     uses: actions/upload-artifact@v2
-  #     if: failure()
-  #     with:
-  #       name: zipfiles.zip
-  #       path: .\dist\*.zip
-  #   - name: Make installer
-  #     run: |
-  #       .\make.bat installer
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py .\dist\*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: .\dist\Gridsync-setup.exe
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  Linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        qt: [pyqt5, pyqt6]
+        exclude:
+          # Qt 6 is unsupported on Ubuntu 18.04. See:
+          # https://doc.qt.io/qt-6/supported-platforms.html
+          - os: ubuntu-18.04
+            qt: pyqt6
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y podman
+        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bash_profile
+        make test
+    - name: Build
+      run: |
+        source ~/.bash_profile
+        make all
+    - name: Verify
+      run: |
+        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+        xvfb-run -a dist/Gridsync/gridsync --version
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        make test-determinism
+    - name: Build (in container)
+      run: |
+        source ~/.bash_profile
+        make clean in-container
+        sudo chown -R runner ~
+    - name: Verify (on host)
+      run: |
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test integration
+      run: |
+        source ~/.bash_profile
+        make test-integration
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.AppImage
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  macOS:
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11, macos-12]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo rm -rf /Applications/Python*
+        scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bashrc
+        make test
+    - name: Make pyinstaller
+      run: |
+        source ~/.bashrc
+        make pyinstaller
+        make zip
+    - name: Verify
+      run: |
+        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+        dist/Gridsync.app/Contents/MacOS/Gridsync --version
+    - name: Test integration
+      run: |
+        source ~/.bashrc
+        make test-integration
+    - name: Test determinism
+      run: |
+        source ~/.bashrc
+        make test-determinism
+    - name: Make dmg
+      run: |
+        source ~/.bashrc
+        make dmg
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.dmg
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  Windows:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+      PY_PYTHON: 3.10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: c:\users\runneradmin\appdata\local\pip\cache
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: py -m pip install --upgrade setuptools pip tox diffoscope
+    - name: Test
+      run: .\make.bat test
+    - name: Make pyinstaller
+      run: |
+        .\make.bat pyinstaller
+        .\make.bat zip
+    - name: Verify
+      run: |
+        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+        .\dist\Gridsync\Gridsync-magic-folder.exe --version
+        .\dist\Gridsync\Gridsync.exe --version
+    - name: Test integration
+      run: |
+        .\make.bat test-integration
+    - name: Test determinism
+      run: |
+        .\make.bat test-determinism
+    - name: Upload zipfiles
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: zipfiles.zip
+        path: .\dist\*.zip
+    - name: Make installer
+      run: |
+        .\make.bat installer
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py .\dist\*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: .\dist\Gridsync-setup.exe
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,206 +36,206 @@ jobs:
       run: |
         nix develop --command tox -e integration
 
-  # Linux:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-  #       qt: [pyqt5, pyqt6]
-  #       exclude:
-  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
-  #         # https://doc.qt.io/qt-6/supported-platforms.html
-  #         - os: ubuntu-18.04
-  #           qt: pyqt6
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt-get install -y podman
-  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test
-  #   - name: Build
-  #     run: |
-  #       source ~/.bash_profile
-  #       make all
-  #   - name: Verify
-  #     run: |
-  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-  #       xvfb-run -a dist/Gridsync/gridsync --version
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-determinism
-  #   - name: Build (in container)
-  #     run: |
-  #       source ~/.bash_profile
-  #       make clean in-container
-  #       sudo chown -R runner ~
-  #   - name: Verify (on host)
-  #     run: |
-  #       xvfb-run -a dist/Gridsync.AppImage --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bash_profile
-  #       make test-integration
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.AppImage
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  # macOS:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-10.15, macos-11, macos-12]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pyenv cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cargo
-  #         ~/.pyenv
-  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: |
-  #         ~/.cache/pip
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo rm -rf /Applications/Python*
-  #       scripts/provision_devtools.sh
-  #   - name: Test
-  #     run: |
-  #       source ~/.bashrc
-  #       make test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       source ~/.bashrc
-  #       make pyinstaller
-  #       make zip
-  #   - name: Verify
-  #     run: |
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
-  #   - name: Test integration
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       source ~/.bashrc
-  #       make test-determinism
-  #   - name: Make dmg
-  #     run: |
-  #       source ~/.bashrc
-  #       make dmg
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py dist/*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: dist/Gridsync.dmg
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  # Windows:
-  #   strategy:
-  #     matrix:
-  #       os: [windows-2019, windows-2022]
-  #       qt: [pyqt5, pyqt6]
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     QT_API: ${{ matrix.qt }}
-  #     PY_PYTHON: 3.10
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #       # Checkout head of the branch of the PR, or the exact revision
-  #       # specified for non-PR builds.
-  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-  #   - name: Restore pip cache
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: c:\users\runneradmin\appdata\local\pip\cache
-  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-  #   - name: Install dependencies
-  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
-  #   - name: Test
-  #     run: .\make.bat test
-  #   - name: Make pyinstaller
-  #     run: |
-  #       .\make.bat pyinstaller
-  #       .\make.bat zip
-  #   - name: Verify
-  #     run: |
-  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
-  #       .\dist\Gridsync\Gridsync.exe --version
-  #   - name: Test integration
-  #     run: |
-  #       .\make.bat test-integration
-  #   - name: Test determinism
-  #     run: |
-  #       .\make.bat test-determinism
-  #   - name: Upload zipfiles
-  #     uses: actions/upload-artifact@v2
-  #     if: failure()
-  #     with:
-  #       name: zipfiles.zip
-  #       path: .\dist\*.zip
-  #   - name: Make installer
-  #     run: |
-  #       .\make.bat installer
-  #   - name: sha256sum
-  #     run: python3 scripts/sha256sum.py .\dist\*.*
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       path: .\dist\Gridsync-setup.exe
-  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  Linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        qt: [pyqt5, pyqt6]
+        exclude:
+          # Qt 6 is unsupported on Ubuntu 18.04. See:
+          # https://doc.qt.io/qt-6/supported-platforms.html
+          - os: ubuntu-18.04
+            qt: pyqt6
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y podman
+        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bash_profile
+        make test
+    - name: Build
+      run: |
+        source ~/.bash_profile
+        make all
+    - name: Verify
+      run: |
+        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+        xvfb-run -a dist/Gridsync/gridsync --version
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test determinism
+      run: |
+        source ~/.bash_profile
+        make test-determinism
+    - name: Build (in container)
+      run: |
+        source ~/.bash_profile
+        make clean in-container
+        sudo chown -R runner ~
+    - name: Verify (on host)
+      run: |
+        xvfb-run -a dist/Gridsync.AppImage --version
+    - name: Test integration
+      run: |
+        source ~/.bash_profile
+        make test-integration
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.AppImage
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  macOS:
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11, macos-12]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pyenv cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.pyenv
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: |
+        sudo rm -rf /Applications/Python*
+        scripts/provision_devtools.sh
+    - name: Test
+      run: |
+        source ~/.bashrc
+        make test
+    - name: Make pyinstaller
+      run: |
+        source ~/.bashrc
+        make pyinstaller
+        make zip
+    - name: Verify
+      run: |
+        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+        dist/Gridsync.app/Contents/MacOS/Gridsync --version
+    - name: Test integration
+      run: |
+        source ~/.bashrc
+        make test-integration
+    - name: Test determinism
+      run: |
+        source ~/.bashrc
+        make test-determinism
+    - name: Make dmg
+      run: |
+        source ~/.bashrc
+        make dmg
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py dist/*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/Gridsync.dmg
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  Windows:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+        qt: [pyqt5, pyqt6]
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_API: ${{ matrix.qt }}
+      PY_PYTHON: 3.10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: c:\users\runneradmin\appdata\local\pip\cache
+        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+    - name: Install dependencies
+      run: py -m pip install --upgrade setuptools pip tox diffoscope
+    - name: Test
+      run: .\make.bat test
+    - name: Make pyinstaller
+      run: |
+        .\make.bat pyinstaller
+        .\make.bat zip
+    - name: Verify
+      run: |
+        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+        .\dist\Gridsync\Gridsync-magic-folder.exe --version
+        .\dist\Gridsync\Gridsync.exe --version
+    - name: Test integration
+      run: |
+        .\make.bat test-integration
+    - name: Test determinism
+      run: |
+        .\make.bat test-determinism
+    - name: Upload zipfiles
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: zipfiles.zip
+        path: .\dist\*.zip
+    - name: Make installer
+      run: |
+        .\make.bat installer
+    - name: sha256sum
+      run: python3 scripts/sha256sum.py .\dist\*.*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: .\dist\Gridsync-setup.exe
+        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ jobs:
         nix flake check
     - name: "Lint"
       run: |
-        nix develop '.#lint'
+        nix run .#tox -- -e lint
     - name: "Unit Tests"
       run: |
-        nix develop '.#py39'
+        nix run .#tox -- -e py39
     - name: "Integration Tests"
       run: |
-        nix develop '.#integration'
+        nix run .#tox -- -e integration
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,17 +34,35 @@ jobs:
           cd /project
           nix --option experimental-features "nix-command flakes" flake check
 
-    # - name: "Unit Test"
-    #   run: |
-    #     nix develop --command tox -e py39
+    - name: "Unit Test"
+      uses: "addnab/docker-run-action@v3"
+      with:
+        image: "nixos/nix:2.9.1"
+        options: "-v ${{ github.workspace }}:/project"
+        run: |
+          cd /project
+          nix --option experimental-features "nix-command flakes" develop \
+            --command tox -e py39
 
-    # - name: "Integration Test"
-    #   run: |
-    #     nix develop --command tox -e integration
+    - name: "Integration Test"
+      uses: "addnab/docker-run-action@v3"
+      with:
+        image: "nixos/nix:2.9.1"
+        options: "-v ${{ github.workspace }}:/project"
+        run: |
+          cd /project
+          nix --option experimental-features "nix-command flakes" develop \
+            --command tox -e integration
 
-    # - name: "Lint"
-    #   run: |
-    #     nix develop --command tox -e lint
+    - name: "Lint"
+      uses: "addnab/docker-run-action@v3"
+      with:
+        image: "nixos/nix:2.9.1"
+        options: "-v ${{ github.workspace }}:/project"
+        run: |
+          cd /project
+          nix --option experimental-features "nix-command flakes" develop \
+            --command tox -e lint
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,14 @@ on: [push, pull_request]
 jobs:
   NixOS:
     runs-on: "ubuntu-latest"
+    env:
+      NIX: "nix --option experimental-features 'nix-command flakes'"
+
     steps:
     - name: "Setup Execution Environment"
       run: |
-        # Also to allow `nix develop` to unshare in the Nix container, we need userns_clone:
+        # Also to allow `nix develop` to unshare in the Nix container, we need
+        # userns_clone.
         sudo sysctl -w kernel.unprivileged_userns_clone=1
 
     - name: "Checkout"
@@ -19,6 +23,13 @@ jobs:
         # specified for non-PR builds.
         ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
+    # Since we have to fiddle with sysctl on the host, we can't make the whole
+    # job a container job.  So we use this action to run each of the following
+    # steps in the right container.  Start with a step that does no
+    # application-level work.  The point is just to build the
+    # `docker-run-action` image and have it ready for the following steps.
+    # This keeps all of the Docker build output isolated in this step instead
+    # of smashing it into the first "real" step below.
     - name: "Cache Docker Images"
       uses: "addnab/docker-run-action@v3"
       with:
@@ -32,7 +43,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          nix --option experimental-features "nix-command flakes" flake check
+          $NIX flake check
 
     - name: "Unit Test"
       uses: "addnab/docker-run-action@v3"
@@ -41,8 +52,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          nix --option experimental-features "nix-command flakes" develop \
-            --command tox -e py39
+          $NIX develop --command tox -e py39
 
     - name: "Integration Test"
       uses: "addnab/docker-run-action@v3"
@@ -51,8 +61,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          nix --option experimental-features "nix-command flakes" develop \
-            --command tox -e integration
+          $NIX develop --command tox -e integration
 
     - name: "Lint"
       uses: "addnab/docker-run-action@v3"
@@ -61,8 +70,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          nix --option experimental-features "nix-command flakes" develop \
-            --command tox -e lint
+          $NIX develop --command tox -e lint
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         options: "-v ${{ github.workspace }}:/project"
         run: |
           cd /project
-          nix flake check
+          nix --option experimental-features "nix-command flakes" flake check
 
     # - name: "Unit Test"
     #   run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ jobs:
     runs-on: "ubuntu-latest"
     container:
       image: "nixos/nix:2.9.1"
-      options: "--sysctl kernel.unprivileged_userns_clone=1"
 
     steps:
     - name: "Install Basic Dependencies"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,9 @@ jobs:
       # unshare (I'm not sure why, maybe because we use buildFHSUserEnv).
       options: "--privileged"
       env:
-        NIX: "nix --option experimental-features 'nix-command flakes'"
+        # Let us use features marked "experimental".  For example, most/all of
+        # the `nix <subcommand>` forms.  And also flakes.
+        NIX_CONFIG: "experimental-features = nix-command flakes"
     steps:
     - name: "Checkout"
       uses: "actions/checkout@v1"
@@ -23,16 +25,16 @@ jobs:
 
     - name: "Check"
       run: |
-        $NIX flake check
+        nix flake check
     - name: "Lint"
       run: |
-        $NIX develop --command tox -e lint
+        nix develop --command tox -e lint
     - name: "Unit Tests"
       run: |
-        $NIX develop --command tox -e py39
+        nix develop --command tox -e py39
     - name: "Integration Tests"
       run: |
-        $NIX develop --command tox -e integration
+        nix develop --command tox -e integration
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project"
+        options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
           $NIX develop --command tox -e py39
@@ -59,7 +59,7 @@ jobs:
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project"
+        options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
           $NIX develop --command tox -e integration
@@ -68,7 +68,7 @@ jobs:
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project"
+        options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
           $NIX develop --command tox -e lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ on: [push, pull_request]
 jobs:
   NixOS:
     runs-on: "ubuntu-latest"
+    container:
+      image: "nixos/nix:2.9.1"
+      # Run the container privileged because `nix develop` wants to use
+      # unshare (I'm not sure why, maybe because we use buildFHSUserEnv).
+      options: "--privileged"
+      env:
+        NIX: "nix --option experimental-features 'nix-command flakes'"
     steps:
     - name: "Checkout"
       uses: "actions/checkout@v1"
@@ -14,233 +21,219 @@ jobs:
         # specified for non-PR builds.
         ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
-    # Since we have to fiddle with sysctl on the host, we can't make the whole
-    # job a container job.  So we use this action to run each of the following
-    # steps in the right container.  Start with a step that does no
-    # application-level work.  The point is just to build the
-    # `docker-run-action` image and have it ready for the following steps.
-    # This keeps all of the Docker build output isolated in this step instead
-    # of smashing it into the first "real" step below.
-    - name: "Cache Docker Images"
-      uses: "addnab/docker-run-action@v3"
-      with:
-        image: "nixos/nix:2.9.1"
-        run: ""
+    - name: "Check"
+      run: |
+        $NIX flake check
+    - name: "Lint"
+      run: |
+        $NIX develop --command tox -e lint
+    - name: "Unit Tests"
+      run: |
+        $NIX develop --command tox -e py39
+    - name: "Integration Tests"
+      run: |
+        $NIX develop --command tox -e integration
 
-    - name: "Check Flake and Run Tests"
-      uses: "addnab/docker-run-action@v3"
-      with:
-        image: "nixos/nix:2.9.1"
-        # Put the source checkout where the container can see it.  Also, run
-        # the container privileged because `nix develop` wants to use unshare
-        # (I'm not sure why, maybe because we use buildFHSUserEnv).
-        options: "-v ${{ github.workspace }}:/project --privileged"
-        run: |
-          cd /project
-          nix --option experimental-features 'nix-command flakes' flake check
-          nix --option experimental-features 'nix-command flakes' develop \
-            --command tox -e py39,integration,lint
-
-  Linux:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        qt: [pyqt5, pyqt6]
-        exclude:
-          # Qt 6 is unsupported on Ubuntu 18.04. See:
-          # https://doc.qt.io/qt-6/supported-platforms.html
-          - os: ubuntu-18.04
-            qt: pyqt6
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y podman
-        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bash_profile
-        make test
-    - name: Build
-      run: |
-        source ~/.bash_profile
-        make all
-    - name: Verify
-      run: |
-        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-        xvfb-run -a dist/Gridsync/gridsync --version
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        make test-determinism
-    - name: Build (in container)
-      run: |
-        source ~/.bash_profile
-        make clean in-container
-        sudo chown -R runner ~
-    - name: Verify (on host)
-      run: |
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test integration
-      run: |
-        source ~/.bash_profile
-        make test-integration
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.AppImage
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  macOS:
-    strategy:
-      matrix:
-        os: [macos-10.15, macos-11, macos-12]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo rm -rf /Applications/Python*
-        scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bashrc
-        make test
-    - name: Make pyinstaller
-      run: |
-        source ~/.bashrc
-        make pyinstaller
-        make zip
-    - name: Verify
-      run: |
-        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-        dist/Gridsync.app/Contents/MacOS/Gridsync --version
-    - name: Test integration
-      run: |
-        source ~/.bashrc
-        make test-integration
-    - name: Test determinism
-      run: |
-        source ~/.bashrc
-        make test-determinism
-    - name: Make dmg
-      run: |
-        source ~/.bashrc
-        make dmg
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.dmg
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  Windows:
-    strategy:
-      matrix:
-        os: [windows-2019, windows-2022]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-      PY_PYTHON: 3.10
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: c:\users\runneradmin\appdata\local\pip\cache
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: py -m pip install --upgrade setuptools pip tox diffoscope
-    - name: Test
-      run: .\make.bat test
-    - name: Make pyinstaller
-      run: |
-        .\make.bat pyinstaller
-        .\make.bat zip
-    - name: Verify
-      run: |
-        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-        .\dist\Gridsync\Gridsync-magic-folder.exe --version
-        .\dist\Gridsync\Gridsync.exe --version
-    - name: Test integration
-      run: |
-        .\make.bat test-integration
-    - name: Test determinism
-      run: |
-        .\make.bat test-determinism
-    - name: Upload zipfiles
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: zipfiles.zip
-        path: .\dist\*.zip
-    - name: Make installer
-      run: |
-        .\make.bat installer
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py .\dist\*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: .\dist\Gridsync-setup.exe
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  # Linux:
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+  #       qt: [pyqt5, pyqt6]
+  #       exclude:
+  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
+  #         # https://doc.qt.io/qt-6/supported-platforms.html
+  #         - os: ubuntu-18.04
+  #           qt: pyqt6
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo apt-get install -y podman
+  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test
+  #   - name: Build
+  #     run: |
+  #       source ~/.bash_profile
+  #       make all
+  #   - name: Verify
+  #     run: |
+  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+  #       xvfb-run -a dist/Gridsync/gridsync --version
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-determinism
+  #   - name: Build (in container)
+  #     run: |
+  #       source ~/.bash_profile
+  #       make clean in-container
+  #       sudo chown -R runner ~
+  #   - name: Verify (on host)
+  #     run: |
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-integration
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.AppImage
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  # macOS:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-10.15, macos-11, macos-12]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo rm -rf /Applications/Python*
+  #       scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bashrc
+  #       make test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       source ~/.bashrc
+  #       make pyinstaller
+  #       make zip
+  #   - name: Verify
+  #     run: |
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-determinism
+  #   - name: Make dmg
+  #     run: |
+  #       source ~/.bashrc
+  #       make dmg
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.dmg
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  # Windows:
+  #   strategy:
+  #     matrix:
+  #       os: [windows-2019, windows-2022]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #     PY_PYTHON: 3.10
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: c:\users\runneradmin\appdata\local\pip\cache
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
+  #   - name: Test
+  #     run: .\make.bat test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       .\make.bat pyinstaller
+  #       .\make.bat zip
+  #   - name: Verify
+  #     run: |
+  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
+  #       .\dist\Gridsync\Gridsync.exe --version
+  #   - name: Test integration
+  #     run: |
+  #       .\make.bat test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       .\make.bat test-determinism
+  #   - name: Upload zipfiles
+  #     uses: actions/upload-artifact@v2
+  #     if: failure()
+  #     with:
+  #       name: zipfiles.zip
+  #       path: .\dist\*.zip
+  #   - name: Make installer
+  #     run: |
+  #       .\make.bat installer
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py .\dist\*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: .\dist\Gridsync-setup.exe
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ jobs:
         nix flake check
     - name: "Lint"
       run: |
-        nix develop --command tox -e lint
+        nix develop .#lint
     - name: "Unit Tests"
       run: |
-        nix develop --command tox -e py39
+        nix develop .#py39
     - name: "Integration Tests"
       run: |
-        nix develop --command tox -e integration
+        nix develop .#integration
 
   Linux:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,206 +36,206 @@ jobs:
       run: |
         nix develop '.#integration'
 
-  Linux:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        qt: [pyqt5, pyqt6]
-        exclude:
-          # Qt 6 is unsupported on Ubuntu 18.04. See:
-          # https://doc.qt.io/qt-6/supported-platforms.html
-          - os: ubuntu-18.04
-            qt: pyqt6
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y podman
-        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bash_profile
-        make test
-    - name: Build
-      run: |
-        source ~/.bash_profile
-        make all
-    - name: Verify
-      run: |
-        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-        xvfb-run -a dist/Gridsync/gridsync --version
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        make test-determinism
-    - name: Build (in container)
-      run: |
-        source ~/.bash_profile
-        make clean in-container
-        sudo chown -R runner ~
-    - name: Verify (on host)
-      run: |
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test integration
-      run: |
-        source ~/.bash_profile
-        make test-integration
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.AppImage
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  macOS:
-    strategy:
-      matrix:
-        os: [macos-11, macos-12]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo rm -rf /Applications/Python*
-        scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bashrc
-        make test
-    - name: Make pyinstaller
-      run: |
-        source ~/.bashrc
-        make pyinstaller
-        make zip
-    - name: Verify
-      run: |
-        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-        dist/Gridsync.app/Contents/MacOS/Gridsync --version
-    - name: Test integration
-      run: |
-        source ~/.bashrc
-        make test-integration
-    - name: Test determinism
-      run: |
-        source ~/.bashrc
-        make test-determinism
-    - name: Make dmg
-      run: |
-        source ~/.bashrc
-        make dmg
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.dmg
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  Windows:
-    strategy:
-      matrix:
-        os: [windows-2019, windows-2022]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-      PY_PYTHON: 3.10
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: c:\users\runneradmin\appdata\local\pip\cache
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: py -m pip install --upgrade setuptools pip tox diffoscope
-    - name: Test
-      run: .\make.bat test
-    - name: Make pyinstaller
-      run: |
-        .\make.bat pyinstaller
-        .\make.bat zip
-    - name: Verify
-      run: |
-        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-        .\dist\Gridsync\Gridsync-magic-folder.exe --version
-        .\dist\Gridsync\Gridsync.exe --version
-    - name: Test integration
-      run: |
-        .\make.bat test-integration
-    - name: Test determinism
-      run: |
-        .\make.bat test-determinism
-    - name: Upload zipfiles
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: zipfiles.zip
-        path: .\dist\*.zip
-    - name: Make installer
-      run: |
-        .\make.bat installer
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py .\dist\*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: .\dist\Gridsync-setup.exe
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  # Linux:
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+  #       qt: [pyqt5, pyqt6]
+  #       exclude:
+  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
+  #         # https://doc.qt.io/qt-6/supported-platforms.html
+  #         - os: ubuntu-18.04
+  #           qt: pyqt6
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo apt-get install -y podman
+  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test
+  #   - name: Build
+  #     run: |
+  #       source ~/.bash_profile
+  #       make all
+  #   - name: Verify
+  #     run: |
+  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+  #       xvfb-run -a dist/Gridsync/gridsync --version
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-determinism
+  #   - name: Build (in container)
+  #     run: |
+  #       source ~/.bash_profile
+  #       make clean in-container
+  #       sudo chown -R runner ~
+  #   - name: Verify (on host)
+  #     run: |
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-integration
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.AppImage
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  # macOS:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-11, macos-12]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo rm -rf /Applications/Python*
+  #       scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bashrc
+  #       make test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       source ~/.bashrc
+  #       make pyinstaller
+  #       make zip
+  #   - name: Verify
+  #     run: |
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-determinism
+  #   - name: Make dmg
+  #     run: |
+  #       source ~/.bashrc
+  #       make dmg
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.dmg
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  # Windows:
+  #   strategy:
+  #     matrix:
+  #       os: [windows-2019, windows-2022]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #     PY_PYTHON: 3.10
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: c:\users\runneradmin\appdata\local\pip\cache
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
+  #   - name: Test
+  #     run: .\make.bat test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       .\make.bat pyinstaller
+  #       .\make.bat zip
+  #   - name: Verify
+  #     run: |
+  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
+  #       .\dist\Gridsync\Gridsync.exe --version
+  #   - name: Test integration
+  #     run: |
+  #       .\make.bat test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       .\make.bat test-determinism
+  #   - name: Upload zipfiles
+  #     uses: actions/upload-artifact@v2
+  #     if: failure()
+  #     with:
+  #       name: zipfiles.zip
+  #       path: .\dist\*.zip
+  #   - name: Make installer
+  #     run: |
+  #       .\make.bat installer
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py .\dist\*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: .\dist\Gridsync-setup.exe
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,13 +6,6 @@ jobs:
   NixOS:
     runs-on: "ubuntu-latest"
     steps:
-    - name: "Setup Execution Environment"
-      run: |
-        # Also to allow `nix develop` to unshare in the Nix container, we need
-        # userns_clone.
-        sudo sysctl -w kernel.unprivileged_userns_clone=1
-        sudo sysctl -a | grep unprivileged
-
     - name: "Checkout"
       uses: "actions/checkout@v1"
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         image: "nixos/nix:2.9.1"
         run: ""
 
-    - name: "Check"
+    - name: "Check Flake and Run Tests"
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,206 +36,206 @@ jobs:
       run: |
         nix develop --command tox -e integration
 
-  Linux:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        qt: [pyqt5, pyqt6]
-        exclude:
-          # Qt 6 is unsupported on Ubuntu 18.04. See:
-          # https://doc.qt.io/qt-6/supported-platforms.html
-          - os: ubuntu-18.04
-            qt: pyqt6
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y podman
-        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bash_profile
-        make test
-    - name: Build
-      run: |
-        source ~/.bash_profile
-        make all
-    - name: Verify
-      run: |
-        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-        xvfb-run -a dist/Gridsync/gridsync --version
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        make test-determinism
-    - name: Build (in container)
-      run: |
-        source ~/.bash_profile
-        make clean in-container
-        sudo chown -R runner ~
-    - name: Verify (on host)
-      run: |
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test integration
-      run: |
-        source ~/.bash_profile
-        make test-integration
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.AppImage
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  macOS:
-    strategy:
-      matrix:
-        os: [macos-11, macos-12]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo rm -rf /Applications/Python*
-        scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bashrc
-        make test
-    - name: Make pyinstaller
-      run: |
-        source ~/.bashrc
-        make pyinstaller
-        make zip
-    - name: Verify
-      run: |
-        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-        dist/Gridsync.app/Contents/MacOS/Gridsync --version
-    - name: Test integration
-      run: |
-        source ~/.bashrc
-        make test-integration
-    - name: Test determinism
-      run: |
-        source ~/.bashrc
-        make test-determinism
-    - name: Make dmg
-      run: |
-        source ~/.bashrc
-        make dmg
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.dmg
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  Windows:
-    strategy:
-      matrix:
-        os: [windows-2019, windows-2022]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-      PY_PYTHON: 3.10
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: c:\users\runneradmin\appdata\local\pip\cache
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: py -m pip install --upgrade setuptools pip tox diffoscope
-    - name: Test
-      run: .\make.bat test
-    - name: Make pyinstaller
-      run: |
-        .\make.bat pyinstaller
-        .\make.bat zip
-    - name: Verify
-      run: |
-        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-        .\dist\Gridsync\Gridsync-magic-folder.exe --version
-        .\dist\Gridsync\Gridsync.exe --version
-    - name: Test integration
-      run: |
-        .\make.bat test-integration
-    - name: Test determinism
-      run: |
-        .\make.bat test-determinism
-    - name: Upload zipfiles
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: zipfiles.zip
-        path: .\dist\*.zip
-    - name: Make installer
-      run: |
-        .\make.bat installer
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py .\dist\*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: .\dist\Gridsync-setup.exe
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  # Linux:
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+  #       qt: [pyqt5, pyqt6]
+  #       exclude:
+  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
+  #         # https://doc.qt.io/qt-6/supported-platforms.html
+  #         - os: ubuntu-18.04
+  #           qt: pyqt6
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo apt-get install -y podman
+  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test
+  #   - name: Build
+  #     run: |
+  #       source ~/.bash_profile
+  #       make all
+  #   - name: Verify
+  #     run: |
+  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+  #       xvfb-run -a dist/Gridsync/gridsync --version
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-determinism
+  #   - name: Build (in container)
+  #     run: |
+  #       source ~/.bash_profile
+  #       make clean in-container
+  #       sudo chown -R runner ~
+  #   - name: Verify (on host)
+  #     run: |
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-integration
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.AppImage
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  # macOS:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-11, macos-12]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo rm -rf /Applications/Python*
+  #       scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bashrc
+  #       make test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       source ~/.bashrc
+  #       make pyinstaller
+  #       make zip
+  #   - name: Verify
+  #     run: |
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-determinism
+  #   - name: Make dmg
+  #     run: |
+  #       source ~/.bashrc
+  #       make dmg
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.dmg
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  # Windows:
+  #   strategy:
+  #     matrix:
+  #       os: [windows-2019, windows-2022]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #     PY_PYTHON: 3.10
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: c:\users\runneradmin\appdata\local\pip\cache
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
+  #   - name: Test
+  #     run: .\make.bat test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       .\make.bat pyinstaller
+  #       .\make.bat zip
+  #   - name: Verify
+  #     run: |
+  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
+  #       .\dist\Gridsync\Gridsync.exe --version
+  #   - name: Test integration
+  #     run: |
+  #       .\make.bat test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       .\make.bat test-determinism
+  #   - name: Upload zipfiles
+  #     uses: actions/upload-artifact@v2
+  #     if: failure()
+  #     with:
+  #       name: zipfiles.zip
+  #       path: .\dist\*.zip
+  #   - name: Make installer
+  #     run: |
+  #       .\make.bat installer
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py .\dist\*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: .\dist\Gridsync-setup.exe
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,14 @@ jobs:
         # specified for non-PR builds.
         ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
-    # - name: "Check"
-    #   run: |
-    #     nix flake check
+    - name: "Check"
+      uses: "addnab/docker-run-action@v3"
+      with:
+        image: "nixos/nix:2.9.1"
+        options: "-v ${{ github.workspace }}:/project"
+        run: |
+          cd /project
+          nix flake check
 
     # - name: "Unit Test"
     #   run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
         # Also to allow `nix develop` to unshare in the Nix container, we need
         # userns_clone.
         sudo sysctl -w kernel.unprivileged_userns_clone=1
+        sudo sysctl -a | grep unprivileged
 
     - name: "Checkout"
       uses: "actions/checkout@v1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ jobs:
         nix flake check
     - name: "Lint"
       run: |
-        nix develop .#lint
+        nix develop '.#lint'
     - name: "Unit Tests"
       run: |
-        nix develop .#py39
+        nix develop '.#py39'
     - name: "Integration Tests"
       run: |
-        nix develop .#integration
+        nix develop '.#integration'
 
   Linux:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         nix-env \
           --file https://github.com/nixos/nixpkgs/archive/nixos-21.11.tar.gz \
           --install \
-          -A openssh
+          -A openssh bash
 
         # We also want to use flakes but they're still experimental so
         # turn them on.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,9 @@ jobs:
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"
+        # Put the source checkout where the container can see it.  Also, run
+        # the container privileged because `nix develop` wants to use unshare
+        # (I'm not sure why, maybe because we use buildFHSUserEnv).
         options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,206 +44,206 @@ jobs:
       run: |
         nix develop --command tox -e lint
 
-  Linux:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        qt: [pyqt5, pyqt6]
-        exclude:
-          # Qt 6 is unsupported on Ubuntu 18.04. See:
-          # https://doc.qt.io/qt-6/supported-platforms.html
-          - os: ubuntu-18.04
-            qt: pyqt6
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y podman
-        SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bash_profile
-        make test
-    - name: Build
-      run: |
-        source ~/.bash_profile
-        make all
-    - name: Verify
-      run: |
-        xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
-        xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
-        xvfb-run -a dist/Gridsync/gridsync --version
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test determinism
-      run: |
-        source ~/.bash_profile
-        make test-determinism
-    - name: Build (in container)
-      run: |
-        source ~/.bash_profile
-        make clean in-container
-        sudo chown -R runner ~
-    - name: Verify (on host)
-      run: |
-        xvfb-run -a dist/Gridsync.AppImage --version
-    - name: Test integration
-      run: |
-        source ~/.bash_profile
-        make test-integration
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.AppImage
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
-  macOS:
-    strategy:
-      matrix:
-        os: [macos-10.15, macos-11, macos-12]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pyenv cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo
-          ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: |
-        sudo rm -rf /Applications/Python*
-        scripts/provision_devtools.sh
-    - name: Test
-      run: |
-        source ~/.bashrc
-        make test
-    - name: Make pyinstaller
-      run: |
-        source ~/.bashrc
-        make pyinstaller
-        make zip
-    - name: Verify
-      run: |
-        dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
-        dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
-        dist/Gridsync.app/Contents/MacOS/Gridsync --version
-    - name: Test integration
-      run: |
-        source ~/.bashrc
-        make test-integration
-    - name: Test determinism
-      run: |
-        source ~/.bashrc
-        make test-determinism
-    - name: Make dmg
-      run: |
-        source ~/.bashrc
-        make dmg
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py dist/*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/Gridsync.dmg
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
-  Windows:
-    strategy:
-      matrix:
-        os: [windows-2019, windows-2022]
-        qt: [pyqt5, pyqt6]
-    runs-on: ${{ matrix.os }}
-    env:
-      QT_API: ${{ matrix.qt }}
-      PY_PYTHON: 3.10
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        # Checkout head of the branch of the PR, or the exact revision
-        # specified for non-PR builds.
-        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
-    - name: Restore pip cache
-      uses: actions/cache@v2
-      with:
-        path: c:\users\runneradmin\appdata\local\pip\cache
-        key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
-    - name: Install dependencies
-      run: py -m pip install --upgrade setuptools pip tox diffoscope
-    - name: Test
-      run: .\make.bat test
-    - name: Make pyinstaller
-      run: |
-        .\make.bat pyinstaller
-        .\make.bat zip
-    - name: Verify
-      run: |
-        .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
-        .\dist\Gridsync\Gridsync-magic-folder.exe --version
-        .\dist\Gridsync\Gridsync.exe --version
-    - name: Test integration
-      run: |
-        .\make.bat test-integration
-    - name: Test determinism
-      run: |
-        .\make.bat test-determinism
-    - name: Upload zipfiles
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: zipfiles.zip
-        path: .\dist\*.zip
-    - name: Make installer
-      run: |
-        .\make.bat installer
-    - name: sha256sum
-      run: python3 scripts/sha256sum.py .\dist\*.*
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        path: .\dist\Gridsync-setup.exe
-        name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe
+  # Linux:
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+  #       qt: [pyqt5, pyqt6]
+  #       exclude:
+  #         # Qt 6 is unsupported on Ubuntu 18.04. See:
+  #         # https://doc.qt.io/qt-6/supported-platforms.html
+  #         - os: ubuntu-18.04
+  #           qt: pyqt6
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo apt-get install -y podman
+  #       SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test
+  #   - name: Build
+  #     run: |
+  #       source ~/.bash_profile
+  #       make all
+  #   - name: Verify
+  #     run: |
+  #       xvfb-run -a dist/Gridsync/Gridsync-tahoe --version-and-path
+  #       xvfb-run -a dist/Gridsync/Gridsync-magic-folder --version
+  #       xvfb-run -a dist/Gridsync/gridsync --version
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-determinism
+  #   - name: Build (in container)
+  #     run: |
+  #       source ~/.bash_profile
+  #       make clean in-container
+  #       sudo chown -R runner ~
+  #   - name: Verify (on host)
+  #     run: |
+  #       xvfb-run -a dist/Gridsync.AppImage --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bash_profile
+  #       make test-integration
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.AppImage
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.AppImage
+  # macOS:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-10.15, macos-11, macos-12]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pyenv cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cargo
+  #         ~/.pyenv
+  #       key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+  #       restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: |
+  #         ~/.cache/pip
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo rm -rf /Applications/Python*
+  #       scripts/provision_devtools.sh
+  #   - name: Test
+  #     run: |
+  #       source ~/.bashrc
+  #       make test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       source ~/.bashrc
+  #       make pyinstaller
+  #       make zip
+  #   - name: Verify
+  #     run: |
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-tahoe --version-and-path
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync-magic-folder --version
+  #       dist/Gridsync.app/Contents/MacOS/Gridsync --version
+  #   - name: Test integration
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       source ~/.bashrc
+  #       make test-determinism
+  #   - name: Make dmg
+  #     run: |
+  #       source ~/.bashrc
+  #       make dmg
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py dist/*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: dist/Gridsync.dmg
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}.dmg
+  # Windows:
+  #   strategy:
+  #     matrix:
+  #       os: [windows-2019, windows-2022]
+  #       qt: [pyqt5, pyqt6]
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     QT_API: ${{ matrix.qt }}
+  #     PY_PYTHON: 3.10
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #       # Checkout head of the branch of the PR, or the exact revision
+  #       # specified for non-PR builds.
+  #       ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+  #   - name: Restore pip cache
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: c:\users\runneradmin\appdata\local\pip\cache
+  #       key: pip-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('requirements/*.txt') }}
+  #       restore-keys: pip-${{ matrix.os }}-${{ matrix.qt }}-
+  #   - name: Install dependencies
+  #     run: py -m pip install --upgrade setuptools pip tox diffoscope
+  #   - name: Test
+  #     run: .\make.bat test
+  #   - name: Make pyinstaller
+  #     run: |
+  #       .\make.bat pyinstaller
+  #       .\make.bat zip
+  #   - name: Verify
+  #     run: |
+  #       .\dist\Gridsync\Gridsync-tahoe.exe --version-and-path
+  #       .\dist\Gridsync\Gridsync-magic-folder.exe --version
+  #       .\dist\Gridsync\Gridsync.exe --version
+  #   - name: Test integration
+  #     run: |
+  #       .\make.bat test-integration
+  #   - name: Test determinism
+  #     run: |
+  #       .\make.bat test-determinism
+  #   - name: Upload zipfiles
+  #     uses: actions/upload-artifact@v2
+  #     if: failure()
+  #     with:
+  #       name: zipfiles.zip
+  #       path: .\dist\*.zip
+  #   - name: Make installer
+  #     run: |
+  #       .\make.bat installer
+  #   - name: sha256sum
+  #     run: python3 scripts/sha256sum.py .\dist\*.*
+  #   - name: Upload artifacts
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       path: .\dist\Gridsync-setup.exe
+  #       name: Gridsync-${{ matrix.os }}-${{ matrix.qt }}-setup.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,36 +35,8 @@ jobs:
         run: |
           cd /project
           nix --option experimental-features 'nix-command flakes' flake check
-
-    - name: "Unit Test"
-      uses: "addnab/docker-run-action@v3"
-      with:
-        image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project --privileged"
-        run: |
-          cd /project
           nix --option experimental-features 'nix-command flakes' develop \
-            --command tox -e py39
-
-    - name: "Integration Test"
-      uses: "addnab/docker-run-action@v3"
-      with:
-        image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project --privileged"
-        run: |
-          cd /project
-          nix --option experimental-features 'nix-command flakes' develop \
-            --command tox -e integration
-
-    - name: "Lint"
-      uses: "addnab/docker-run-action@v3"
-      with:
-        image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project --privileged"
-        run: |
-          cd /project
-          nix --option experimental-features 'nix-command flakes' develop \
-            --command tox -e lint
+            --command tox -e py39,integration,lint
 
   # Linux:
   #   strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: "addnab/docker-run-action@v3"
       with:
         image: "nixos/nix:2.9.1"
-        options: "-v ${{ github.workspace }}:/project"
+        options: "-v ${{ github.workspace }}:/project --privileged"
         run: |
           cd /project
           nix --option experimental-features 'nix-command flakes' flake check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,9 @@ jobs:
       uses: "actions/checkout@v2"
       with:
         fetch-depth: 0
-      # Checkout head of the branch of the PR, or the exact revision
-      # specified for non-PR builds.
-      ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+        # Checkout head of the branch of the PR, or the exact revision
+        # specified for non-PR builds.
+        ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
     - name: "Check"
       run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,6 +17,7 @@ It is also possible to pass ``pull/<pr-number>/head`` to test against a specific
 
 magic-folder
 ............
+
 We depend on a pinned commit of magic-folder.
 To update to the latest commit, run
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,3 +27,28 @@ To update to the latest commit, run
 
 This will update the pinned commit.
 It is also possible to pass ``pull/<pr-number>/head`` to test against a specific PR.
+
+nix
+...
+
+We maintain a `Nix flake <https://nixos.wiki/wiki/Flakes>`_ that provides a partial *development* environment for GridSync.
+
+You can expect to be able to run most tox environments from within the environment provided by
+
+.. code:: shell
+
+   nix develop
+
+Some development dependencies
+(mostly Python and the native library dependencies of Qt)
+are taken from a pinned version of nixpkgs.
+To update the version of nixpkgs used run
+
+.. code:: shell
+
+   nix flake lock --update-input nixpkgs
+
+And then commit the changes to ``flake.nix`` and ``flake.lock``.
+Each other input (see ``nix flake metadata``) can be updated similarly.
+
+One constraint to be aware of is that ``mach-nix`` generally will not run if the pinned ``pypi-deps-db`` input is older than the pinned ``nixpkgs`` input.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,87 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pypi-deps-db": [
+          "pypi-deps-db"
+        ]
+      },
+      "locked": {
+        "lastModified": 1659091740,
+        "narHash": "sha256-aNtnezQfUX1QS/bFno2H5661qIY/Rn7BmHnspuuyI+4=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "f15ea8677df951cb4fe608945fd98725dcd033b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658705145,
+        "narHash": "sha256-H/nZuqNsXsT3A3dPV4zjrjo3rhgugyd0Pg0zoOhX3/4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6cce09ce7f12e039318168ccfb0344426e17eec8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6cce09ce7f12e039318168ccfb0344426e17eec8",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659429585,
+        "narHash": "sha256-89EBdr30V3XF1Ik9PqJ0MWcD4OEezPmkAr4Nr18oess=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "f61b6cc4a8b345ea07526c6a3929a8cbc0cc87a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -43,28 +43,28 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658705145,
-        "narHash": "sha256-H/nZuqNsXsT3A3dPV4zjrjo3rhgugyd0Pg0zoOhX3/4=",
+        "lastModified": 1659445012,
+        "narHash": "sha256-n8/7npmp3hLbPSTRHPW8EPO8qh9vJ10RgkRM3Ve4vfc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cce09ce7f12e039318168ccfb0344426e17eec8",
+        "rev": "a9f66ae640146ac16b6e33d2359e9171b27b0993",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
-        "rev": "6cce09ce7f12e039318168ccfb0344426e17eec8",
         "type": "github"
       }
     },
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1659429585,
-        "narHash": "sha256-89EBdr30V3XF1Ik9PqJ0MWcD4OEezPmkAr4Nr18oess=",
+        "lastModified": 1659516582,
+        "narHash": "sha256-kXJnZW2nCVyvr+Xqr6cD+E4+3Hmh5YGMcqfjD7PUVcY=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "f61b6cc4a8b345ea07526c6a3929a8cbc0cc87a8",
+        "rev": "cef4187f3bc116740836ee3a194eaaa8c3457bb6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,11 +44,35 @@
       };
     in rec {
       devShell = (pkgs.buildFHSUserEnv {
-        name = "gridsync-env";
-        profile = ''
+        name = "gridsync";
+        profile = (
+          # Usually bytecode is just a nuisance - getting stale, taking more
+          # time to read/write than it saves, or creating extra noise in the
+          # checkout with generated files.
+          ''
           export PYTHONDONTWRITEBYTECODE=1
+          ''
+
+          # If there are any Qt plugins installed on the host system then we
+          # must not let information about them leak into the dev environment.
+          # The PyQt/Qt libraries we use for GridSync are almost certainly not
+          # compatible with whatever is on the system and if the two get too
+          # close to each other, Qt tends to SIGABRT itself.
+          #
+          # Clear this plugin path environment variable so any host plugin
+          # libraries aren't discovered.
+          + ''
           unset QT_PLUGIN_PATH
-        '';
+          ''
+
+          # Sometimes the information Qt dumps when this variable is set is
+          # useful for debugging Qt-related problems (especially problems
+          # finding or loading certain Qt plugins).  It's pretty noisy so it's
+          # not on by default.
+          + ''
+          # export QT_DEBUG_PLUGINS=1
+          ''
+        );
         targetPkgs = pkgs: (with pkgs;
           [
             # GridSync depends on PyQt5.  The PyQt5 wheel bundles Qt5 itself

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,7 @@
 {
   description = "GridSync, Tahoe-LAFS/magic-folder GUI";
   inputs.nixpkgs = {
-    # Pin a revision that is older than the pypi-deps-db at the time this is
-    # written.  mach-nix does not like it when pypi-deps-db is older than
-    # nixpkgs.  This is only necessary because, by accident, HEAD of nixpkgs
-    # happened to be newer than HEAD of pypi-deps-db during development of
-    # this flake.
-    url = "github:NixOS/nixpkgs?rev=6cce09ce7f12e039318168ccfb0344426e17eec8";
+    url = "github:NixOS/nixpkgs?ref=nixos-22.05";
   };
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,15 @@
   };
   outputs = { self, nixpkgs, flake-utils, mach-nix, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: let
+
+      python = "python39";
+
       pkgs = nixpkgs.legacyPackages.${system};
 
-      tox-env = pkgs.python39.withPackages (ps: [ ps.tox ] );
+      tox-env = pkgs.${python}.withPackages (ps: [ ps.tox ] );
 
       tahoe-env = mach-nix.lib.${system}.mkPython {
-        python = "python39";
+        inherit python;
         requirements = ''
           tahoe-lafs
           zero-knowledge-access-pass-authorizer
@@ -34,7 +37,7 @@
       };
 
       magic-folder-env = mach-nix.lib.${system}.mkPython {
-        python = "python39";
+        inherit python;
         requirements = ''
           magic-folder
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,12 @@
   outputs = { self, nixpkgs, flake-utils, mach-nix, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: let
 
-      python = "python39";
+      # The version of Python we'll use to set up the environment.
+      pythonVersion = "python3.9";
+
+      # Many Nix-related tools don't want the `.` in the Python derivation
+      # identifier.  Generate a string in the right format for them.
+      python = builtins.replaceStrings ["."] [""] pythonVersion;
 
       pkgs = nixpkgs.legacyPackages.${system};
 
@@ -63,6 +68,14 @@
           # libraries aren't discovered.
           + ''
           unset QT_PLUGIN_PATH
+          ''
+
+          # tox has its own ideas about what the default Python should be,
+          # without regard to what version of Python is actually available on
+          # the system.  Convince it to agree with the environment we've set
+          # up.
+          + ''
+          export TOX_BASEPYTHON=${pythonVersion}
           ''
 
           # Sometimes the information Qt dumps when this variable is set is

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,9 @@
           # export QT_DEBUG_PLUGINS=1
           ''
         );
+
+        # Install some libraries in the environment (only versions for the
+        # target architecture).
         targetPkgs = pkgs: (with pkgs;
           [
             # GridSync depends on PyQt5.  The PyQt5 wheel bundles Qt5 itself

--- a/flake.nix
+++ b/flake.nix
@@ -129,12 +129,17 @@
         default = (makeDevShell "bash").env;
       };
 
-      apps.tox = {
-        type = "app";
-        # Run the env-entering script from the FHS user environment.
-        # Arguments from the command line will be passed along.
-        # pkgs/build-support/build-fhs-userenv/default.nix for gory details.
-        program = "${makeDevShell "tox"}/bin/dev-env";
-      };
+      apps.tox =
+        let
+          xvfb-tox = pkgs.writeScript "xvfb-tox" ''
+            ${pkgs.xvfb-run}/bin/xvfb-run --auto-servernum tox "$@"
+          '';
+        in {
+          type = "app";
+          # Run the env-entering script from the FHS user environment.
+          # Arguments from the command line will be passed along.
+          # pkgs/build-support/build-fhs-userenv/default.nix for gory details.
+          program = "${makeDevShell xvfb-tox}/bin/dev-env";
+        };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         '';
       };
     in rec {
-      devShell = (pkgs.buildFHSUserEnv {
+      devShells.default = (pkgs.buildFHSUserEnv {
         name = "gridsync";
         profile = (
           # Usually bytecode is just a nuisance - getting stale, taking more

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
       # dependencies and some Python tools.  This is suitable for running tox
       # in.  `runScript` is the command to run in the FHS env's chroot.
       makeDevShell = runScript: pkgs.buildFHSUserEnv {
-        name = "gridsync";
+        name = "dev-env";
         profile = (
           # Usually bytecode is just a nuisance - getting stale, taking more
           # time to read/write than it saves, or creating extra noise in the
@@ -123,17 +123,18 @@
         inherit runScript;
       };
 
-    in rec {
+    in {
       devShells = {
         # The default is to run an interactive shell.
         default = (makeDevShell "bash").env;
+      };
 
-        # These environments mostly help CI by running certain CI-relevant
-        # jobs directly.  It would be nice if we did not have to have one
-        # entry per tox env here but I'm not sure how to accomplish that.
-        lint = (makeDevShell "tox -e lint").env;
-        py39 = (makeDevShell "tox -e py39").env;
-        integration = (makeDevShell "tox -e integration").env;
+      apps.tox = {
+        type = "app";
+        # Run the env-entering script from the FHS user environment.
+        # Arguments from the command line will be passed along.
+        # pkgs/build-support/build-fhs-userenv/default.nix for gory details.
+        program = "${makeDevShell "tox"}/bin/dev-env";
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -35,17 +35,16 @@
 
       tahoe-env = mach-nix.lib.${system}.mkPython {
         inherit python;
-        requirements = ''
-          tahoe-lafs
-          zero-knowledge-access-pass-authorizer
-        '';
+        # mach-nix can't parse the .txt files so we can't easily match the
+        # exact dependency versions the pip-based toolchain will use.  We can
+        # get close, though.
+        requirements = builtins.readFile ./requirements/tahoe-lafs.in;
       };
 
       magic-folder-env = mach-nix.lib.${system}.mkPython {
         inherit python;
-        requirements = ''
-          magic-folder
-        '';
+        # See comment on tahoe-env definition.
+        requirements = builtins.readFile ./requirements/magic-folder.in;
       };
 
       # Build an FHS user environment that contains Qt native library

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "GridSync, Tahoe-LAFS/magic-folder GUI";
+  inputs.nixpkgs = {
+    url = "github:NixOS/nixpkgs?rev=6cce09ce7f12e039318168ccfb0344426e17eec8";
+  };
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+  };
+  inputs.pypi-deps-db = {
+    flake = false;
+    url = "github:DavHau/pypi-deps-db";
+  };
+  inputs.mach-nix = {
+    flake = true;
+    url = "github:DavHau/mach-nix";
+    inputs = {
+      nixpkgs.follows = "nixpkgs";
+      flake-utils.follows = "flake-utils";
+      pypi-deps-db.follows = "pypi-deps-db";
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, mach-nix, ... }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      tox-env = pkgs.python39.withPackages (ps: [ ps.tox ] );
+
+      tahoe-env = mach-nix.lib.${system}.mkPython {
+        python = "python39";
+        requirements = ''
+          tahoe-lafs
+          zero-knowledge-access-pass-authorizer
+        '';
+      };
+
+      magic-folder-env = mach-nix.lib.${system}.mkPython {
+        python = "python39";
+        requirements = ''
+          magic-folder
+        '';
+      };
+    in rec {
+      devShell = (pkgs.buildFHSUserEnv {
+        name = "gridsync-env";
+        profile = ''
+          export PYTHONDONTWRITEBYTECODE=1
+          unset QT_PLUGIN_PATH
+        '';
+        targetPkgs = pkgs: (with pkgs;
+          [
+            # GridSync depends on PyQt5.  The PyQt5 wheel bundles Qt5 itself
+            # but not the dependencies of those libraries.  Supply them.
+            libstdcxx5
+            zlib
+            glib
+            libGL
+            fontconfig
+            freetype
+            libxkbcommon
+            xorg.libxcb
+            xorg.libXext
+            xorg.libX11
+            xorg.xcbutil
+            xorg.xcbutilwm
+            xorg.xcbutilimage
+            xorg.xcbutilkeysyms
+            xorg.xcbutilrenderutil
+            dbus.lib
+
+            # Put tox into the environment for "easy" testing
+            tox-env
+
+            # GridSync also depends on `tahoe` and `magic-folder` CLI tools.
+            tahoe-env
+            magic-folder-env
+          ]);
+        runScript = "bash";
+      }).env;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "GridSync, Tahoe-LAFS/magic-folder GUI";
   inputs.nixpkgs = {
+    # Pin a revision that is older than the pypi-deps-db at the time this is
+    # written.  mach-nix does not like it when pypi-deps-db is older than
+    # nixpkgs.  This is only necessary because, by accident, HEAD of nixpkgs
+    # happened to be newer than HEAD of pypi-deps-db during development of
+    # this flake.
     url = "github:NixOS/nixpkgs?rev=6cce09ce7f12e039318168ccfb0344426e17eec8";
   };
   inputs.flake-utils = {


### PR DESCRIPTION
This makes `nix develop` work with a recent-enough version of Nix (with flakes enabled).  The resulting environment contains enough stuff for `tox -e py39,integration,lint` to succeed.

Also included is a new GitHub Actions job to do these things on CI, mostly to ensure they keep working (and so remain useful for development work on GridSync on NixOS or with Nix tools on other OS).
