### PR TITLE
Update Magic-Folder to version 22.8.0

### DIFF
--- a/requirements/gridsync-base.txt
+++ b/requirements/gridsync-base.txt
@@ -18,8 +18,8 @@ attrs==22.1.0 \
     #   service-identity
     #   treq
     #   twisted
-autobahn[twisted]==22.6.1 \
-    --hash=sha256:fb63e946d5c2dd0df680851e84e65624a494ce87c999f2a4944e4f2d81bf4498
+autobahn[twisted]==22.7.1 \
+    --hash=sha256:8b462ea2e6aad6b4dc0ed45fb800b6cbfeb0325e7fe6983907f122f2be4a1fe9
     # via
     #   -r requirements/gridsync.in
     #   magic-wormhole
@@ -434,9 +434,9 @@ zxcvbn==4.4.28 \
     # via -r requirements/gridsync.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==63.3.0 \
-    --hash=sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408 \
-    --hash=sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0
+setuptools==63.4.1 \
+    --hash=sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca \
+    --hash=sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6
     # via
     #   autobahn
     #   zope-interface

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -41,9 +41,9 @@ dill==0.3.5.1 \
     --hash=sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302 \
     --hash=sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86
     # via pylint
-flake8==5.0.2 \
-    --hash=sha256:9cc32bc0c5d16eacc014c7ec6f0e9565fd81df66c2092c3c9df06e3c1ac95e5d \
-    --hash=sha256:a7926e0b6d23c0991245b60279e774d2596dfecd9b158525d1f8c050a61eae5a
+flake8==5.0.4 \
+    --hash=sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db \
+    --hash=sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248
     # via -r requirements/lint.in
 isort==5.10.1 \
     --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
@@ -143,9 +143,9 @@ platformdirs==2.5.2 \
     # via
     #   black
     #   pylint
-pycodestyle==2.9.0 \
-    --hash=sha256:289cdc0969d589d90752582bef6dff57c5fbc6949ee8b013ad6d6449a8ae9437 \
-    --hash=sha256:beaba44501f89d785be791c9462553f06958a221d166c64e1f107320f839acc2
+pycodestyle==2.9.1 \
+    --hash=sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785 \
+    --hash=sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b
     # via flake8
 pyflakes==2.5.0 \
     --hash=sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2 \
@@ -320,9 +320,9 @@ zope-schema==6.2.0 \
     # via mypy-zope
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==63.3.0 \
-    --hash=sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408 \
-    --hash=sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0
+setuptools==63.4.1 \
+    --hash=sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca \
+    --hash=sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6
     # via
     #   astroid
     #   zope-interface

--- a/requirements/magic-folder-base.txt
+++ b/requirements/magic-folder-base.txt
@@ -23,8 +23,8 @@ attrs==22.1.0 \
     #   tahoe-lafs
     #   treq
     #   twisted
-autobahn[twisted]==22.6.1 \
-    --hash=sha256:fb63e946d5c2dd0df680851e84e65624a494ce87c999f2a4944e4f2d81bf4498
+autobahn[twisted]==22.7.1 \
+    --hash=sha256:8b462ea2e6aad6b4dc0ed45fb800b6cbfeb0325e7fe6983907f122f2be4a1fe9
     # via
     #   -r requirements/magic-folder.in
     #   magic-folder
@@ -262,9 +262,9 @@ klein==21.8.0 \
     # via
     #   magic-folder
     #   tahoe-lafs
-magic-folder==22.5.0 \
-    --hash=sha256:82e6df3c58cfd6247b3391b3e60894c32e8166f1df171a24409b7bd09b168f93 \
-    --hash=sha256:b3588a288864bc9ff6d24ec3c57ccf1f95f87fa0a169fdd323d00f12097cc524
+magic-folder==22.8.0 \
+    --hash=sha256:8605df7bd1d084fdf7dd5129e45874542e5699072dc62cee1f39199024f029f5 \
+    --hash=sha256:d5aa0f30d091762dc6388f7a13255eb2e87fdec993b650830cd609c47b961595
     # via -r requirements/magic-folder.in
 magic-wormhole==0.12.0 \
     --hash=sha256:1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160 \
@@ -652,9 +652,9 @@ zope-interface==5.4.0 \
     #   txtorcon
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==63.3.0 \
-    --hash=sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408 \
-    --hash=sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0
+setuptools==63.4.1 \
+    --hash=sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca \
+    --hash=sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6
     # via
     #   autobahn
     #   tahoe-lafs

--- a/requirements/pyinstaller-base.txt
+++ b/requirements/pyinstaller-base.txt
@@ -27,7 +27,7 @@ pyinstaller-hooks-contrib==2022.8 \
     # via pyinstaller
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==63.3.0 \
-    --hash=sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408 \
-    --hash=sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0
+setuptools==63.4.1 \
+    --hash=sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca \
+    --hash=sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6
     # via pyinstaller

--- a/requirements/tahoe-lafs-base.txt
+++ b/requirements/tahoe-lafs-base.txt
@@ -26,8 +26,8 @@ attrs==22.1.0 \
     #   treq
     #   twisted
     #   zero-knowledge-access-pass-authorizer
-autobahn[twisted]==22.6.1 \
-    --hash=sha256:fb63e946d5c2dd0df680851e84e65624a494ce87c999f2a4944e4f2d81bf4498
+autobahn[twisted]==22.7.1 \
+    --hash=sha256:8b462ea2e6aad6b4dc0ed45fb800b6cbfeb0325e7fe6983907f122f2be4a1fe9
     # via
     #   magic-wormhole
     #   tahoe-lafs
@@ -643,9 +643,9 @@ zope-interface==5.4.0 \
     #   zero-knowledge-access-pass-authorizer
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==63.3.0 \
-    --hash=sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408 \
-    --hash=sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0
+setuptools==63.4.1 \
+    --hash=sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca \
+    --hash=sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6
     # via
     #   autobahn
     #   tahoe-lafs


### PR DESCRIPTION
Magic-Folder 22.8.0 has just been released, fixing [an issue that caused downloads to fail for files with shared content](https://github.com/LeastAuthority/magic-folder/issues/662). This PR updates Gridsync's Magic-Folder dependency to 22.8.0 (along with other minor dependency updates).