### PR TITLE
Update `Vagrantfile`, provisioning scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,6 @@ jobs:
         SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
     - name: Test
       run: |
-        cat ~/.bash_profile
         source ~/.bash_profile
         make test
     - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:
@@ -135,8 +135,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
         restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
         SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
     - name: Test
       run: |
+        cat ~/.bash_profile
         source ~/.bash_profile
         make test
     - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
     - name: Test
       run: |
         ls -al ~
+        cat ~/.bash_profile
         source ~/.bashrc
         cat ~/.bashrc
         make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,11 +78,11 @@ jobs:
         SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
     - name: Test
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make test
     - name: Build
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make all
     - name: Verify
       run: |
@@ -92,11 +92,11 @@ jobs:
         xvfb-run -a dist/Gridsync.AppImage --version
     - name: Test determinism
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make test-determinism
     - name: Build (in container)
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make clean in-container
         sudo chown -R runner ~
     - name: Verify (on host)
@@ -104,7 +104,7 @@ jobs:
         xvfb-run -a dist/Gridsync.AppImage --version
     - name: Test integration
       run: |
-        source ~/.bash_profile
+        source ~/.bashrc
         make test-integration
     - name: sha256sum
       run: python3 scripts/sha256sum.py dist/*.*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,14 +78,11 @@ jobs:
         SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
     - name: Test
       run: |
-        ls -al ~
-        cat ~/.bash_profile
-        source ~/.bashrc
-        cat ~/.bashrc
+        source ~/.bash_profile
         make test
     - name: Build
       run: |
-        source ~/.bashrc
+        source ~/.bash_profile
         make all
     - name: Verify
       run: |
@@ -95,11 +92,11 @@ jobs:
         xvfb-run -a dist/Gridsync.AppImage --version
     - name: Test determinism
       run: |
-        source ~/.bashrc
+        source ~/.bash_profile
         make test-determinism
     - name: Build (in container)
       run: |
-        source ~/.bashrc
+        source ~/.bash_profile
         make clean in-container
         sudo chown -R runner ~
     - name: Verify (on host)
@@ -107,7 +104,7 @@ jobs:
         xvfb-run -a dist/Gridsync.AppImage --version
     - name: Test integration
       run: |
-        source ~/.bashrc
+        source ~/.bash_profile
         make test-integration
     - name: sha256sum
       run: python3 scripts/sha256sum.py dist/*.*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
     - name: Test
       run: |
         source ~/.bashrc
+        cat ~/.bashrc
         make test
     - name: Build
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:
@@ -135,8 +135,8 @@ jobs:
         path: |
           ~/.cargo
           ~/.pyenv
-        key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
+        key: pyenv-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
+        restore-keys: pyenv-${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
         SKIP_DOCKER_INSTALL=1 scripts/provision_devtools.sh
     - name: Test
       run: |
+        ls -al ~
         source ~/.bashrc
         cat ~/.bashrc
         make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           ~/.cargo
           ~/.pyenv
         key: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-${{ hashFiles('scripts/provision_*') }}
-        restore-keys: pyenv-cache${{ matrix.os }}-${{ matrix.qt }}-
+        restore-keys: pyenv-cache-${{ matrix.os }}-${{ matrix.qt }}-
     - name: Restore pip cache
       uses: actions/cache@v2
       with:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ ENV["VAGRANT_EXPERIMENTAL"] = "typed_triggers"
 
 def update_macos
   return <<-EOF
-    softwareupdate --verbose --install --all
+    softwareupdate --verbose --install --all --restart
   EOF
 end
 

--- a/scripts/provision_buildbot-worker.sh
+++ b/scripts/provision_buildbot-worker.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+. ~/.$(basename "$SHELL"rc)
 buildbot-worker stop ~/buildbot
 rm -rf ~/buildbot
 python3 -m pip install buildbot-worker

--- a/scripts/provision_buildbot-worker.sh
+++ b/scripts/provision_buildbot-worker.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 . ~/.$(basename "$SHELL"rc)
 buildbot-worker stop ~/buildbot
 rm -rf ~/buildbot

--- a/scripts/provision_buildbot-worker.sh
+++ b/scripts/provision_buildbot-worker.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 . ~/.$(basename "$SHELL"rc)
-buildbot-worker stop ~/buildbot
-rm -rf ~/buildbot
+buildbot-worker stop ~/buildbot || true
+rm -rf ~/buildbot || true
 python3 -m pip install buildbot-worker
 buildbot-worker create-worker ~/buildbot "$BUILDBOT_HOST" "$BUILDBOT_NAME" "$BUILDBOT_PASS"
 unset BUILDBOT_HOST

--- a/scripts/provision_buildbot-worker.sh
+++ b/scripts/provision_buildbot-worker.sh
@@ -3,7 +3,7 @@ set -e
 . ~/.$(basename "$SHELL"rc)
 buildbot-worker stop ~/buildbot || true
 rm -rf ~/buildbot || true
-python3 -m pip install buildbot-worker
+python3 -m pip install --upgrade buildbot-worker
 buildbot-worker create-worker ~/buildbot "$BUILDBOT_HOST" "$BUILDBOT_NAME" "$BUILDBOT_PASS"
 unset BUILDBOT_HOST
 unset BUILDBOT_NAME

--- a/scripts/provision_devtools.bat
+++ b/scripts/provision_devtools.bat
@@ -1,6 +1,6 @@
 choco install -y --no-progress --require-checksums git
 choco install -y --no-progress --require-checksums -m python3 --version 3.9.13
-choco install -y --no-progress --require-checksums -m python3 --version 3.10.4
+choco install -y --no-progress --require-checksums -m python3 --version 3.10.6
 choco install -y --no-progress --require-checksums visualcpp-build-tools
 choco install -y --no-progress --require-checksums innosetup
 refreshenv

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -16,9 +16,7 @@ else
     if [ -f "/usr/bin/apt-get" ]; then
         sudo apt-get -y update
         sudo apt-get -y install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libgl1 libgl1-mesa-dev x11-utils libdbus-1-3 libxcb-xfixes0 uidmap libfuse2
-        if [ -v GITHUB_ACTIONS ]; then
-            SHELLRC=~/.bash_profile
-        fi
+        SHELLRC=~/.bash_profile
     elif [ -f "/usr/bin/yum" ]; then
         PKGS="which make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb file"
         yum -y install $PKGS || sudo yum -y install $PKGS

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -35,7 +35,7 @@ else
     fi
 fi
 
-git clone --branch v2.3.1 https://github.com/pyenv/pyenv.git ~/.pyenv || git --git-dir=$HOME/.pyenv/.git pull --force --ff origin v2.3.1
+git clone --branch v2.3.3 https://github.com/pyenv/pyenv.git ~/.pyenv || git --git-dir=$HOME/.pyenv/.git pull --force --ff origin v2.3.3
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$SHELLRC"
 echo 'export PATH="$PYENV_ROOT/bin:$HOME/bin:$PATH"' >> "$SHELLRC"
 echo 'eval "$(pyenv init --path)"' >> "$SHELLRC"
@@ -47,9 +47,9 @@ if [ "$(awk -F= '$1=="PRETTY_NAME" { print $2 ;}' /etc/os-release)" = '"CentOS L
     export CPPFLAGS="-I/usr/include/openssl11"
     export LDFLAGS="-L/usr/lib64/openssl11"
 fi
-pyenv install --skip-existing 3.10.4
+pyenv install --skip-existing 3.10.6
 pyenv rehash
-pyenv global 3.9.13 3.10.4
+pyenv global 3.9.13 3.10.6
 pyenv versions
 
 python3 -m pip install --upgrade setuptools pip tox diffoscope

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -19,7 +19,6 @@ else
     elif [ -f "/usr/bin/yum" ]; then
         PKGS="which make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb file"
         yum -y install $PKGS || sudo yum -y install $PKGS
-        SHELLRC=~/.bashrc
     else
         echo "Error: Unknown environment"
         exit 1

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+SHELLRC=~/.$(basename "$SHELL"rc)
+
 if [ "$(uname)" = "Darwin" ]; then
     export HOMEBREW_NO_ANALYTICS=1
     if [ ! -f "/usr/local/bin/brew" ]; then
@@ -10,12 +12,10 @@ if [ "$(uname)" = "Darwin" ]; then
     brew install openssl readline sqlite3 xz zlib diffoscope
     export MACOSX_DEPLOYMENT_TARGET="10.13"
     export PYTHON_CONFIGURE_OPTS="--enable-framework"
-    SHELLRC=~/.$(basename "$SHELL"rc)
 else
     if [ -f "/usr/bin/apt-get" ]; then
         sudo apt-get -y update
         sudo apt-get -y install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libgl1 libgl1-mesa-dev x11-utils libdbus-1-3 libxcb-xfixes0 uidmap libfuse2
-        SHELLRC=~/.bash_profile
     elif [ -f "/usr/bin/yum" ]; then
         PKGS="which make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb file"
         yum -y install $PKGS || sudo yum -y install $PKGS

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -16,9 +16,9 @@ else
     if [ -f "/usr/bin/apt-get" ]; then
         sudo apt-get -y update
         sudo apt-get -y install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libgl1 libgl1-mesa-dev x11-utils libdbus-1-3 libxcb-xfixes0 uidmap libfuse2
-	if [ -v GITHUB_ACTIONS ]; then
+        if [ -v GITHUB_ACTIONS ]; then
             SHELLRC=~/.bash_profile
-	fi
+        fi
     elif [ -f "/usr/bin/yum" ]; then
         PKGS="which make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb file"
         yum -y install $PKGS || sudo yum -y install $PKGS

--- a/scripts/provision_devtools.sh
+++ b/scripts/provision_devtools.sh
@@ -16,6 +16,9 @@ else
     if [ -f "/usr/bin/apt-get" ]; then
         sudo apt-get -y update
         sudo apt-get -y install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libgl1 libgl1-mesa-dev x11-utils libdbus-1-3 libxcb-xfixes0 uidmap libfuse2
+	if [ -v GITHUB_ACTIONS ]; then
+            SHELLRC=~/.bash_profile
+	fi
     elif [ -f "/usr/bin/yum" ]; then
         PKGS="which make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz git xorg-x11-server-Xvfb file"
         yum -y install $PKGS || sudo yum -y install $PKGS


### PR DESCRIPTION
Just some fairly minor updates to the project `Vagrantfile` and associated scripts to a) facilitate provisioning buildbot-workers on newer, zsh-using versions of macOS and b) bump the python interpreter version (from 3.10.4 to 3.10.6).