### PR TITLE
Convert gridsync/tahoe.py to `async def`

### DIFF
--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -155,7 +155,7 @@ class Core:
     @inlineCallbacks
     def _start_gateway(gateway: Tahoe) -> TwistedDeferred[None]:
         try:
-            yield gateway.start()
+            yield Deferred.fromCoroutine(gateway.start())
         except Exception as e:  # pylint: disable=broad-except
             msg.critical(
                 f"Error starting Tahoe-LAFS gateway for {gateway.name}",

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -58,7 +58,7 @@ qtreactor.install()  # type: ignore
 
 # pylint: disable=wrong-import-order
 from twisted.internet import reactor
-from twisted.internet.defer import DeferredList, inlineCallbacks
+from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
 from twisted.python.log import PythonLoggingObserver, startLogging
 
 from gridsync import (
@@ -138,7 +138,7 @@ class Core:
     @inlineCallbacks
     def get_tahoe_version(self) -> TwistedDeferred[None]:
         tahoe = Tahoe()
-        version = yield tahoe.command(["--version"])
+        version = yield Deferred.fromCoroutine(tahoe.command(["--version"]))
         if version:
             self.tahoe_version = version.split("\n")[0]
             if self.tahoe_version.startswith("tahoe-lafs: "):

--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -253,7 +253,12 @@ class Core:
 
     @inlineCallbacks
     def stop_gateways(self) -> TwistedDeferred[None]:
-        yield DeferredList([gateway.stop() for gateway in self.gateways])
+        yield DeferredList(
+            [
+                Deferred.fromCoroutine(gateway.stop())
+                for gateway in self.gateways
+            ]
+        )
 
     def start(self) -> None:
         try:

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -44,7 +44,7 @@ from qtpy.QtWidgets import (
     QStyleOptionViewItem,
     QTreeView,
 )
-from twisted.internet.defer import DeferredList, inlineCallbacks
+from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
 from twisted.python.failure import Failure
 
 from gridsync import APP_NAME, features, resource
@@ -153,7 +153,7 @@ class View(QTreeView):
     def _create_rootcap(self) -> TwistedDeferred[None]:
         # There's probably a better place/module for this...
         try:
-            yield self.gateway.create_rootcap()
+            yield Deferred.fromCoroutine(self.gateway.create_rootcap())
         except Exception as exc:  # pylint: disable=broad-except
             error(
                 self,

--- a/gridsync/magic_folder.py
+++ b/gridsync/magic_folder.py
@@ -861,7 +861,9 @@ class MagicFolder:
             )
         data = backups.get(folder_name, {})
         upload_dircap = data.get("upload_dircap")
-        personal_dmd = yield self.gateway.diminish(upload_dircap)
+        personal_dmd = yield Deferred.fromCoroutine(
+            self.gateway.diminish(upload_dircap)
+        )
         yield self.add_folder(local_path, randstr(8), name=folder_name)  # XXX
         author = f"Restored-{datetime.now().isoformat()}"
         yield self.add_participant(folder_name, author, personal_dmd)

--- a/gridsync/monitor.py
+++ b/gridsync/monitor.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import attr
 from qtpy.QtCore import QObject, Signal
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.error import ConnectError
 from twisted.internet.task import LoopingCall
 
@@ -37,7 +37,7 @@ class GridChecker(QObject):
 
     @inlineCallbacks
     def do_check(self) -> TwistedDeferred[None]:
-        results = yield self.gateway.get_grid_status()
+        results = yield Deferred.fromCoroutine(self.gateway.get_grid_status())
         if results:
             num_connected, num_known, available_space = results
         else:

--- a/gridsync/news.py
+++ b/gridsync/news.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from atomicwrites import atomic_write
 from qtpy.QtCore import QObject, Signal
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.task import deferLater
 
 from gridsync import settings
@@ -50,7 +50,9 @@ class NewscapChecker(QObject):
         downloads = sorted(downloads)
         for dest, filecap in downloads:
             try:
-                yield self.gateway.download(filecap, dest)
+                yield Deferred.fromCoroutine(
+                    self.gateway.download(filecap, dest)
+                )
             except Exception as e:  # pylint: disable=broad-except
                 logging.warning("Error downloading '%s': %s", dest, str(e))
         newest_message_filepath = downloads[-1][0]

--- a/gridsync/news.py
+++ b/gridsync/news.py
@@ -62,7 +62,9 @@ class NewscapChecker(QObject):
 
     @inlineCallbacks
     def _check_v1(self) -> TwistedDeferred[None]:
-        content = yield self.gateway.get_json(self.gateway.newscap + "/v1")
+        content = yield Deferred.fromCoroutine(
+            self.gateway.get_json(self.gateway.newscap + "/v1")
+        )
         if not content:
             return
 
@@ -98,7 +100,9 @@ class NewscapChecker(QObject):
         if not self.gateway.newscap:
             return
         yield self.gateway.await_ready()
-        content = yield self.gateway.get_json(self.gateway.newscap)
+        content = yield Deferred.fromCoroutine(
+            self.gateway.get_json(self.gateway.newscap)
+        )
         if not content:
             return
         try:

--- a/gridsync/setup.py
+++ b/gridsync/setup.py
@@ -14,6 +14,7 @@ from atomicwrites import atomic_write
 from qtpy.QtCore import QObject, Qt, Signal
 from qtpy.QtWidgets import QInputDialog, QLineEdit, QMessageBox, QWidget
 from twisted.internet import reactor
+from twisted.internet.defer import Deferred
 
 from gridsync import APP_NAME, config_dir, resource
 from gridsync.config import Config
@@ -313,7 +314,7 @@ class SetupRunner(QObject):
 
         nodedir = os.path.join(config_dir, nickname)
         self.gateway = Tahoe(nodedir)
-        await self.gateway.create_client(settings)
+        await Deferred.fromCoroutine(self.gateway.create_client(settings))
 
         self.gateway.save_settings(settings)
 

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -590,10 +590,13 @@ class Tahoe:
             f"Error {resp.code} creating Tahoe-LAFS directory: {content}"
         )
 
-    @inlineCallbacks
-    def diminish(self, cap: str) -> TwistedDeferred[str]:
-        output = yield self.get_json(cap)
-        return output[1]["ro_uri"]
+    async def diminish(self, cap: str) -> str:
+        output = await self.get_json(cap)
+        if isinstance(output, list):
+            return output[1]["ro_uri"]
+        raise ValueError(
+            "Unexpected response attempting to diminish capability"
+        )
 
     @inlineCallbacks
     def create_rootcap(self) -> TwistedDeferred[str]:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -574,18 +574,15 @@ class Tahoe:
     def await_ready(self) -> Deferred[bool]:
         return self._ready_poller.wait_for_completion()
 
-    @inlineCallbacks
-    def mkdir(
-        self, parentcap: str = None, childname: str = None
-    ) -> TwistedDeferred[str]:
-        yield self.await_ready()
+    async def mkdir(self, parentcap: str = None, childname: str = None) -> str:
+        await self.await_ready()
         url = self.nodeurl + "uri"
         params = {"t": "mkdir"}
         if parentcap and childname:
             url += "/" + parentcap
             params["name"] = childname
-        resp = yield treq.post(url, params=params)
-        content = yield treq.content(resp)
+        resp = await treq.post(url, params=params)
+        content = await treq.content(resp)
         content = content.decode("utf-8").strip()
         if resp.code == 200:
             return content

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -381,11 +381,10 @@ class Tahoe:
         if storage_servers and isinstance(storage_servers, dict):
             self.add_storage_servers(storage_servers)
 
-    @inlineCallbacks
-    def create_client(self, settings: dict) -> TwistedDeferred[None]:
+    async def create_client(self, settings: dict) -> None:
         settings["no-storage"] = True
         settings["listen"] = "none"
-        yield Deferred.fromCoroutine(self.create_node(settings))
+        await self.create_node(settings)
 
     def is_storage_node(self) -> bool:
         if self.storage_furl:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -120,9 +120,8 @@ class Tahoe:
 
         # TODO: Replace with "readiness" API?
         # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2844
-        @inlineCallbacks
-        def poll() -> TwistedDeferred[bool]:
-            ready = yield self.is_ready()
+        async def poll() -> bool:
+            ready = await self.is_ready()
             if ready:
                 log.debug('Connected to "%s"', self.name)
             else:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -659,14 +659,13 @@ class Tahoe:
             dircap_hash,
         )
 
-    @inlineCallbacks
-    def unlink(
+    async def unlink(
         self, dircap: str, childname: str, missing_ok: bool = False
-    ) -> TwistedDeferred[None]:
+    ) -> None:
         dircap_hash = trunchash(dircap)
         log.debug('Unlinking "%s" from %s...', childname, dircap_hash)
-        yield self.await_ready()
-        resp = yield treq.post(
+        await self.await_ready()
+        resp = await treq.post(
             "{}uri/{}/?t=unlink&name={}".format(
                 self.nodeurl, dircap, childname
             )
@@ -674,7 +673,7 @@ class Tahoe:
         if resp.code == 404 and missing_ok:
             pass
         elif resp.code != 200:
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             raise TahoeWebError(content.decode("utf-8"))
         log.debug('Done unlinking "%s" from %s', childname, dircap_hash)
 

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -634,10 +634,7 @@ class Tahoe:
             content = await treq.content(resp)
             raise TahoeWebError(content.decode("utf-8"))
 
-    @inlineCallbacks
-    def link(
-        self, dircap: str, childname: str, childcap: str
-    ) -> TwistedDeferred[None]:
+    async def link(self, dircap: str, childname: str, childcap: str) -> None:
         dircap_hash = trunchash(dircap)
         childcap_hash = trunchash(childcap)
         log.debug(
@@ -646,14 +643,14 @@ class Tahoe:
             childcap_hash,
             dircap_hash,
         )
-        yield self.await_ready()
-        resp = yield treq.post(
+        await self.await_ready()
+        resp = await treq.post(
             "{}uri/{}/?t=uri&name={}&uri={}".format(
                 self.nodeurl, dircap, childname, childcap
             )
         )
         if resp.code != 200:
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             raise TahoeWebError(content.decode("utf-8"))
         log.debug(
             'Done linking "%s" (%s) into %s',

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -622,17 +622,16 @@ class Tahoe:
         content = await treq.content(resp)
         raise TahoeWebError(content.decode("utf-8"))
 
-    @inlineCallbacks
-    def download(self, cap: str, local_path: str) -> TwistedDeferred[None]:
+    async def download(self, cap: str, local_path: str) -> None:
         log.debug("Downloading %s...", local_path)
-        yield self.await_ready()
-        resp = yield treq.get("{}uri/{}".format(self.nodeurl, cap))
+        await self.await_ready()
+        resp = await treq.get("{}uri/{}".format(self.nodeurl, cap))
         if resp.code == 200:
             with atomic_write(local_path, mode="wb", overwrite=True) as f:
-                yield treq.collect(resp, f.write)
+                await treq.collect(resp, f.write)
             log.debug("Successfully downloaded %s", local_path)
         else:
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             raise TahoeWebError(content.decode("utf-8"))
 
     @inlineCallbacks

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -677,19 +677,16 @@ class Tahoe:
             raise TahoeWebError(content.decode("utf-8"))
         log.debug('Done unlinking "%s" from %s', childname, dircap_hash)
 
-    @inlineCallbacks
-    def get_json(
-        self, cap: str
-    ) -> TwistedDeferred[Optional[Union[dict, list]]]:
+    async def get_json(self, cap: str) -> Optional[Union[dict, list]]:
         if not cap or not self.nodeurl:
             return None
         uri = "{}uri/{}/?t=json".format(self.nodeurl, cap)
         try:
-            resp = yield treq.get(uri)
+            resp = await treq.get(uri)
         except ConnectError:
             return None
         if resp.code == 200:
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             return json.loads(content.decode("utf-8"))
         return None
 
@@ -701,7 +698,7 @@ class Tahoe:
         exclude_filenodes: bool = False,
     ) -> TwistedDeferred[Optional[dict[str, dict]]]:
         yield self.await_ready()
-        json_output = yield self.get_json(cap)
+        json_output = yield Deferred.fromCoroutine(self.get_json(cap))
         if json_output is None:
             return None
         results = {}

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -598,12 +598,8 @@ class Tahoe:
             "Unexpected response attempting to diminish capability"
         )
 
-    @inlineCallbacks
-    def create_rootcap(self) -> TwistedDeferred[str]:
-        rootcap = yield Deferred.fromCoroutine(
-            self.rootcap_manager.create_rootcap()
-        )
-        return rootcap
+    async def create_rootcap(self) -> str:
+        return await self.rootcap_manager.create_rootcap()
 
     @inlineCallbacks
     def upload(

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -354,8 +354,7 @@ class Tahoe:
             raise TahoeCommandError(f"{type(e).__name__}: {str(e)}") from e
         return output
 
-    @inlineCallbacks
-    def create_node(self, settings: dict) -> TwistedDeferred[None]:
+    async def create_node(self, settings: dict) -> None:
         if os.path.exists(self.nodedir):
             raise FileExistsError(
                 "Nodedir already exists: {}".format(self.nodedir)
@@ -377,7 +376,7 @@ class Tahoe:
                 args.extend([f"--shares-{key}", str(value)])
             elif key in ("hide-ip", "no-storage"):
                 args.append(f"--{key}")
-        yield Deferred.fromCoroutine(self.command(args))
+        await self.command(args)
         storage_servers = settings.get("storage")
         if storage_servers and isinstance(storage_servers, dict):
             self.add_storage_servers(storage_servers)
@@ -386,7 +385,7 @@ class Tahoe:
     def create_client(self, settings: dict) -> TwistedDeferred[None]:
         settings["no-storage"] = True
         settings["listen"] = "none"
-        yield self.create_node(settings)
+        yield Deferred.fromCoroutine(self.create_node(settings))
 
     def is_storage_node(self) -> bool:
         if self.storage_furl:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -690,15 +690,14 @@ class Tahoe:
             return json.loads(content.decode("utf-8"))
         return None
 
-    @inlineCallbacks
-    def ls(
+    async def ls(
         self,
         cap: str,
         exclude_dirnodes: bool = False,
         exclude_filenodes: bool = False,
-    ) -> TwistedDeferred[Optional[dict[str, dict]]]:
-        yield self.await_ready()
-        json_output = yield Deferred.fromCoroutine(self.get_json(cap))
+    ) -> Optional[dict[str, dict]]:
+        await self.await_ready()
+        json_output = await self.get_json(cap)
         if json_output is None:
             return None
         results = {}

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -446,7 +446,8 @@ class Tahoe:
 
         self.state = Tahoe.STARTED
 
-        self.scan_storage_plugins()
+        # XXX Should something wait on this?
+        Deferred.fromCoroutine(self.scan_storage_plugins())
 
         if not self.is_storage_node():
             self.magic_folder.start()
@@ -717,12 +718,11 @@ class Tahoe:
     def get_rootcap(self) -> str:
         return self.rootcap_manager.get_rootcap()
 
-    @inlineCallbacks
-    def scan_storage_plugins(self) -> TwistedDeferred[None]:
+    async def scan_storage_plugins(self) -> None:
         plugins = []
         log.debug("Scanning for known storage plugins...")
         try:
-            version = yield self.zkapauthorizer.get_version()
+            version = await self.zkapauthorizer.get_version()
         except TahoeWebError:
             version = ""
         if version:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -601,10 +601,9 @@ class Tahoe:
     async def create_rootcap(self) -> str:
         return await self.rootcap_manager.create_rootcap()
 
-    @inlineCallbacks
-    def upload(
+    async def upload(
         self, local_path: str, dircap: str = "", mutable: bool = False
-    ) -> TwistedDeferred[str]:
+    ) -> str:
         if dircap:
             filename = Path(local_path).name
             url = f"{self.nodeurl}uri/{dircap}/{filename}"
@@ -613,14 +612,14 @@ class Tahoe:
         if mutable:
             url = f"{url}?format=MDMF"
         log.debug("Uploading %s...", local_path)
-        yield self.await_ready()
+        await self.await_ready()
         with open(local_path, "rb") as f:
-            resp = yield treq.put(url, f)
+            resp = await treq.put(url, f)
         if resp.code in (200, 201):
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             log.debug("Successfully uploaded %s", local_path)
             return content.decode("utf-8")
-        content = yield treq.content(resp)
+        content = await treq.content(resp)
         raise TahoeWebError(content.decode("utf-8"))
 
     @inlineCallbacks

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -521,18 +521,17 @@ class Tahoe:
         """
         self.nodeurl = nodeurl
 
-    @inlineCallbacks
-    def get_grid_status(
+    async def get_grid_status(
         self,
-    ) -> TwistedDeferred[Optional[tuple[int, int, int]]]:
+    ) -> Optional[tuple[int, int, int]]:
         if not self.nodeurl:
             return None
         try:
-            resp = yield treq.get(self.nodeurl + "?t=json")
+            resp = await treq.get(self.nodeurl + "?t=json")
         except ConnectError:
             return None
         if resp.code == 200:
-            content = yield treq.content(resp)
+            content = await treq.content(resp)
             content = json.loads(content.decode("utf-8"))
             servers_connected = 0
             servers_known = 0

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -563,13 +563,10 @@ class Tahoe:
                 return int(match.group(1))
         return None
 
-    @inlineCallbacks
-    def is_ready(self) -> TwistedDeferred[bool]:
+    async def is_ready(self) -> bool:
         if not self.shares_happy:
             return False
-        connected_servers = yield Deferred.fromCoroutine(
-            self.get_connected_servers()
-        )
+        connected_servers = await self.get_connected_servers()
         return bool(
             connected_servers and connected_servers >= self.shares_happy
         )

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -469,8 +469,7 @@ class Tahoe:
         # using the same pid contained in that pidfile. Also, Windows.
         Path(self.nodedir, "twistd.pid").unlink(missing_ok=True)
 
-    @inlineCallbacks
-    def start(self) -> TwistedDeferred[None]:
+    async def start(self) -> None:
         log.debug('Starting "%s" tahoe client...', self.name)
         self.state = Tahoe.STARTING
         self.monitor.start()
@@ -493,7 +492,7 @@ class Tahoe:
         if not self.executable:
             self.executable = which("tahoe")
         try:
-            results = yield self.supervisor.start(
+            results = await self.supervisor.start(
                 [self.executable, "-d", self.nodedir, "run"],
                 started_trigger="client running",
                 stdout_line_collector=self.line_received,

--- a/gridsync/zkapauthorizer.py
+++ b/gridsync/zkapauthorizer.py
@@ -282,7 +282,7 @@ class ZKAPAuthorizer:
             )
         except ValueError:
             return False
-        ls_output = yield self.gateway.ls(recovery_cap)
+        ls_output = yield Deferred.fromCoroutine(self.gateway.ls(recovery_cap))
         if ls_output and "snapshot" in ls_output:
             return True
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,8 +97,16 @@ def _tahoe(tmpdir_factory, reactor):
     client.api_token = api_token
     with open(os.path.join(private_dir, "api_auth_token"), "w") as f:
         f.write(api_token)
-    client.magic_folder = Mock()  # XXX
+    client.magic_folder = DummyMagicFolder() # XXX
     return client
+
+
+class DummyMagicFolder:
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def _tahoe(tmpdir_factory, reactor):
     client.api_token = api_token
     with open(os.path.join(private_dir, "api_auth_token"), "w") as f:
         f.write(api_token)
-    client.magic_folder = DummyMagicFolder() # XXX
+    client.magic_folder = DummyMagicFolder()  # XXX
     return client
 
 

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -235,7 +235,7 @@ def test_add_participant(magic_folder, tmp_path):
     yield magic_folder.add_folder(path, author)
 
     author_name = randstr()
-    dircap = yield magic_folder.gateway.mkdir()
+    dircap = yield Deferred.fromCoroutine(magic_folder.gateway.mkdir())
     personal_dmd = yield magic_folder.gateway.diminish(dircap)
     yield magic_folder.add_participant(folder_name, author_name, personal_dmd)
     participants = yield magic_folder.get_participants(folder_name)

--- a/tests/integration/test_magic_folder_integration.py
+++ b/tests/integration/test_magic_folder_integration.py
@@ -236,7 +236,9 @@ def test_add_participant(magic_folder, tmp_path):
 
     author_name = randstr()
     dircap = yield Deferred.fromCoroutine(magic_folder.gateway.mkdir())
-    personal_dmd = yield magic_folder.gateway.diminish(dircap)
+    personal_dmd = yield Deferred.fromCoroutine(
+        magic_folder.gateway.diminish(dircap)
+    )
     yield magic_folder.add_participant(folder_name, author_name, personal_dmd)
     participants = yield magic_folder.get_participants(folder_name)
     assert author_name in participants
@@ -515,8 +517,10 @@ def test_bob_receive_folder(alice_magic_folder, bob_magic_folder, tmp_path):
     yield bob_magic_folder.add_folder(bob_path, "Bob", poll_interval=1)
 
     alice_folders = yield alice_magic_folder.get_folders()
-    alice_personal_dmd = yield alice_magic_folder.gateway.diminish(
-        alice_folders["ToBob"]["upload_dircap"]
+    alice_personal_dmd = yield Deferred.fromCoroutine(
+        alice_magic_folder.gateway.diminish(
+            alice_folders["ToBob"]["upload_dircap"]
+        )
     )
     yield bob_magic_folder.add_participant(
         folder_name, "Alice", alice_personal_dmd

--- a/tests/integration/test_rootcap_integration.py
+++ b/tests/integration/test_rootcap_integration.py
@@ -31,7 +31,8 @@ def test_create_rootcap_doesnt_override_existing_rootcap(rootcap_manager):
 
 @inlineCallbacks
 def test_add_backup(tahoe_client, rootcap_manager):
-    dircap = yield tahoe_client.mkdir()
+    1 / 0
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield Deferred.fromCoroutine(
         rootcap_manager.add_backup("TestBackups-1", "backup-1", dircap)
     )
@@ -43,7 +44,7 @@ def test_add_backup(tahoe_client, rootcap_manager):
 
 @inlineCallbacks
 def test_remove_backup(tahoe_client, rootcap_manager):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield Deferred.fromCoroutine(
         rootcap_manager.add_backup("TestBackups-2", "backup-2", dircap)
     )
@@ -58,7 +59,7 @@ def test_remove_backup(tahoe_client, rootcap_manager):
 
 @inlineCallbacks
 def test_remove_backup_is_idempotent(tahoe_client, rootcap_manager):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield Deferred.fromCoroutine(
         rootcap_manager.add_backup("TestBackups-3", "backup-3", dircap)
     )

--- a/tests/integration/test_tahoe_integration.py
+++ b/tests/integration/test_tahoe_integration.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 from pytest_twisted import inlineCallbacks
+from twisted.internet.defer import Deferred
 
 from gridsync import APP_NAME
 
@@ -32,7 +33,9 @@ def test_tahoe_start_creates_pidfile(tahoe_client):
 @inlineCallbacks
 def test_tahoe_client_connected_servers(tahoe_client):
     yield tahoe_client.await_ready()
-    connected_servers = yield tahoe_client.get_connected_servers()
+    connected_servers = yield Deferred.fromCoroutine(
+        tahoe_client.get_connected_servers()
+    )
     assert connected_servers == 1
 
 

--- a/tests/integration/test_tahoe_integration.py
+++ b/tests/integration/test_tahoe_integration.py
@@ -48,7 +48,7 @@ def test_tahoe_client_mkdir(tahoe_client):
 @inlineCallbacks
 def test_diminish(tahoe_client):
     dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
-    diminished = yield tahoe_client.diminish(dircap)
+    diminished = yield Deferred.fromCoroutine(tahoe_client.diminish(dircap))
     assert diminished.startswith("URI:DIR2-RO:")
 
 

--- a/tests/integration/test_tahoe_integration.py
+++ b/tests/integration/test_tahoe_integration.py
@@ -41,13 +41,13 @@ def test_tahoe_client_connected_servers(tahoe_client):
 
 @inlineCallbacks
 def test_tahoe_client_mkdir(tahoe_client):
-    cap = yield tahoe_client.mkdir()
+    cap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     assert cap.startswith("URI:DIR2:")
 
 
 @inlineCallbacks
 def test_diminish(tahoe_client):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     diminished = yield tahoe_client.diminish(dircap)
     assert diminished.startswith("URI:DIR2-RO:")
 
@@ -67,7 +67,7 @@ def test_upload_convergence_secret_determines_cap(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_upload_to_dircap(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"1" * 64)
     local_path = p.resolve()
@@ -86,7 +86,7 @@ def test_upload_mutable(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_upload_to_dircap_mutable(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"1" * 64)
     local_path = p.resolve()
@@ -96,7 +96,7 @@ def test_upload_to_dircap_mutable(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_upload_to_dircap_mutable_uses_same_cap(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"1" * 64)
     local_path = p.resolve()
@@ -111,12 +111,12 @@ def test_upload_to_dircap_mutable_uses_same_cap(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_ls(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"2" * 64)
     local_path = p.resolve()
     yield tahoe_client.upload(local_path, dircap)
-    subdircap = yield tahoe_client.mkdir()
+    subdircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield tahoe_client.link(dircap, "subdir", subdircap)
     output = yield tahoe_client.ls(dircap)
     assert ("TestFile.txt" in output) and ("subdir" in output)
@@ -124,12 +124,12 @@ def test_ls(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_ls_exclude_dirnodes(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"2" * 64)
     local_path = p.resolve()
     yield tahoe_client.upload(local_path, dircap)
-    subdircap = yield tahoe_client.mkdir()
+    subdircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield tahoe_client.link(dircap, "subdir", subdircap)
     output = yield tahoe_client.ls(dircap, exclude_dirnodes=True)
     assert ("TestFile.txt" in output) and ("subdir" not in output)
@@ -137,12 +137,12 @@ def test_ls_exclude_dirnodes(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_ls_exclude_filenodes(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"2" * 64)
     local_path = p.resolve()
     yield tahoe_client.upload(local_path, dircap)
-    subdircap = yield tahoe_client.mkdir()
+    subdircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     yield tahoe_client.link(dircap, "subdir", subdircap)
     output = yield tahoe_client.ls(dircap, exclude_filenodes=True)
     assert ("TestFile.txt" not in output) and ("subdir" in output)
@@ -150,7 +150,7 @@ def test_ls_exclude_filenodes(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_ls_includes_most_authoritative_cap(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     p = tmp_path / "TestFile.txt"
     p.write_bytes(b"2" * 64)
     local_path = p.resolve()
@@ -161,6 +161,6 @@ def test_ls_includes_most_authoritative_cap(tahoe_client, tmp_path):
 
 @inlineCallbacks
 def test_ls_nonexistent_path(tahoe_client, tmp_path):
-    dircap = yield tahoe_client.mkdir()
+    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
     output = yield tahoe_client.ls(dircap + "/Path/Does/Not/Exist")
     assert output is None

--- a/tests/integration/test_tahoe_integration.py
+++ b/tests/integration/test_tahoe_integration.py
@@ -161,8 +161,8 @@ async def test_ls_includes_most_authoritative_cap(tahoe_client, tmp_path):
     assert output.get("TestFile.txt").get("cap").startswith("URI:CHK:")
 
 
-@inlineCallbacks
-def test_ls_nonexistent_path(tahoe_client, tmp_path):
-    dircap = yield Deferred.fromCoroutine(tahoe_client.mkdir())
-    output = yield tahoe_client.ls(dircap + "/Path/Does/Not/Exist")
+@ensureDeferred
+async def test_ls_nonexistent_path(tahoe_client, tmp_path):
+    dircap = await tahoe_client.mkdir()
+    output = await tahoe_client.ls(dircap + "/Path/Does/Not/Exist")
     assert output is None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -6,7 +6,6 @@ from typing import Awaitable, Callable, TypeVar
 from unittest.mock import MagicMock, Mock, call
 
 from pytest_twisted import inlineCallbacks
-from twisted.internet.defer import succeed
 
 from gridsync.monitor import GridChecker, Monitor, ZKAPChecker, _parse_vouchers
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,17 +2,28 @@
 
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Awaitable, Callable, TypeVar
 from unittest.mock import MagicMock, Mock, call
 
 from pytest_twisted import inlineCallbacks
+from twisted.internet.defer import succeed
 
 from gridsync.monitor import GridChecker, Monitor, ZKAPChecker, _parse_vouchers
+
+T = TypeVar("T")
+
+
+def fake_grid_status(status: T) -> Callable[[], Awaitable[T]]:
+    async def get_grid_status() -> T:
+        return status
+
+    return get_grid_status
 
 
 @inlineCallbacks
 def test_grid_checker_emit_space_updated(qtbot):
     gc = GridChecker(MagicMock(shares_happy=7))
-    gc.gateway.get_grid_status = MagicMock(return_value=(8, 10, 1234))
+    gc.gateway.get_grid_status = fake_grid_status((8, 10, 1234))
     with qtbot.wait_signal(gc.space_updated) as blocker:
         yield gc.do_check()
     assert blocker.args == [1234]
@@ -21,7 +32,7 @@ def test_grid_checker_emit_space_updated(qtbot):
 @inlineCallbacks
 def test_grid_checker_emit_nodes_updated_(qtbot):
     gc = GridChecker(MagicMock(shares_happy=7))
-    gc.gateway.get_grid_status = MagicMock(return_value=(8, 10, 1234))
+    gc.gateway.get_grid_status = fake_grid_status((8, 10, 1234))
     with qtbot.wait_signal(gc.nodes_updated) as blocker:
         yield gc.do_check()
     assert blocker.args == [8, 10]
@@ -30,7 +41,7 @@ def test_grid_checker_emit_nodes_updated_(qtbot):
 @inlineCallbacks
 def test_grid_checker_emit_connected(qtbot):
     gc = GridChecker(MagicMock(shares_happy=7))
-    gc.gateway.get_grid_status = MagicMock(return_value=(8, 10, 1234))
+    gc.gateway.get_grid_status = fake_grid_status((8, 10, 1234))
     with qtbot.wait_signal(gc.connected):
         yield gc.do_check()
 
@@ -38,7 +49,7 @@ def test_grid_checker_emit_connected(qtbot):
 @inlineCallbacks
 def test_grid_checker_emit_disconnected(qtbot):
     gc = GridChecker(MagicMock(shares_happy=7))
-    gc.gateway.get_grid_status = MagicMock(return_value=(5, 10, 1234))
+    gc.gateway.get_grid_status = fake_grid_status((5, 10, 1234))
     gc.is_connected = True
     with qtbot.wait_signal(gc.disconnected):
         yield gc.do_check()
@@ -47,7 +58,7 @@ def test_grid_checker_emit_disconnected(qtbot):
 @inlineCallbacks
 def test_grid_checker_not_connected(qtbot):
     gc = GridChecker(MagicMock(shares_happy=0))
-    gc.gateway.get_grid_status = MagicMock(return_value=None)
+    gc.gateway.get_grid_status = fake_grid_status(None)
     yield gc.do_check()
     assert gc.num_connected == 0
 

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import Mock
 
 import pytest
+from pytest_twisted import ensureDeferred
 
 from gridsync.news import NewscapChecker
 from gridsync.tahoe import TahoeWebError
@@ -41,16 +42,30 @@ def test_newscap_checker_init_delay_max_not_less_than_min(tahoe, monkeypatch):
     assert (nc.check_delay_min, nc.check_delay_max) == (78, 78)
 
 
-def test_newscap_checker__download_messages(newscap_checker, monkeypatch):
-    fake_download = Mock()
+@ensureDeferred
+async def test_newscap_checker__download_messages(
+    newscap_checker, monkeypatch
+):
+    call_count = 0
+
+    async def fake_download(
+        self,
+        cap: str,
+        local_path: str,
+    ) -> None:
+        nonlocal call_count
+        call_count += 1
+
     monkeypatch.setattr("gridsync.tahoe.Tahoe.download", fake_download)
     downloads = [("dest01", "filecap01"), ("dest02", "filecap02")]
-    newscap_checker._download_messages(downloads)
-    assert fake_download.call_count == 2
+    await newscap_checker._download_messages(downloads)
+    assert call_count == 2
 
 
 def test_newscap_checker__download_messages_warn(newscap_checker, monkeypatch):
-    fake_download = Mock(side_effect=TahoeWebError)
+    async def fake_download(self, cap: str, local_path: str) -> None:
+        raise TahoeWebError()
+
     monkeypatch.setattr("gridsync.tahoe.Tahoe.download", fake_download)
     fake_logging_warning = Mock()
     monkeypatch.setattr("logging.warning", fake_logging_warning)
@@ -62,7 +77,9 @@ def test_newscap_checker__download_messages_warn(newscap_checker, monkeypatch):
 def test_newscap_checker__download_emit_message_received_signal_newest_file(
     newscap_checker, monkeypatch, qtbot
 ):
-    fake_download = Mock()
+    async def fake_download(self, cap: str, local_path: str) -> None:
+        pass
+
     monkeypatch.setattr("gridsync.tahoe.Tahoe.download", fake_download)
     newscap_messages_dir = os.path.join(
         newscap_checker.gateway.nodedir, "private", "newscap_messages"

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -558,7 +558,7 @@ def test_get_connected_servers(tahoe, monkeypatch):
 
 @inlineCallbacks
 def test_is_ready_false_not_shares_happy(tahoe, monkeypatch):
-    output = yield tahoe.is_ready()
+    output = yield Deferred.fromCoroutine(tahoe.is_ready())
     assert output is False
 
 
@@ -579,7 +579,7 @@ def test_is_ready_false_not_connected_servers(tahoe, monkeypatch):
         "gridsync.tahoe.Tahoe.get_connected_servers",
         fake_awaitable_method(None),
     )
-    output = yield tahoe.is_ready()
+    output = yield Deferred.fromCoroutine(tahoe.is_ready())
     assert output is False
 
 
@@ -590,7 +590,7 @@ def test_is_ready_true(tahoe, monkeypatch):
         "gridsync.tahoe.Tahoe.get_connected_servers",
         fake_awaitable_method(10),
     )
-    output = yield tahoe.is_ready()
+    output = yield Deferred.fromCoroutine(tahoe.is_ready())
     assert output is True
 
 
@@ -601,17 +601,15 @@ def test_is_ready_false_connected_less_than_happy(tahoe, monkeypatch):
         "gridsync.tahoe.Tahoe.get_connected_servers",
         fake_awaitable_method(3),
     )
-    output = yield tahoe.is_ready()
+    output = yield Deferred.fromCoroutine(tahoe.is_ready())
     assert output is False
-
-
-async def fake_is_ready(self) -> bool:
-    return True
 
 
 @inlineCallbacks
 def test_await_ready(tahoe, monkeypatch):
-    monkeypatch.setattr("gridsync.tahoe.Tahoe.is_ready", fake_is_ready)
+    monkeypatch.setattr(
+        "gridsync.tahoe.Tahoe.is_ready", fake_awaitable_method(True)
+    )
     yield tahoe.await_ready()
     assert True
 

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -753,25 +753,25 @@ async def test_tahoe_download_fail_code_500(tahoe, monkeypatch):
         await tahoe.download("test_cap", os.path.join(tahoe.nodedir, "nofile"))
 
 
-@inlineCallbacks
-def test_tahoe_link(tahoe, monkeypatch):
+@ensureDeferred
+async def test_tahoe_link(tahoe, monkeypatch):
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.await_ready", lambda _: succeed(None)
     )
     monkeypatch.setattr("treq.post", fake_post)
-    yield tahoe.link("test_dircap", "test_childname", "test_childcap")
+    await tahoe.link("test_dircap", "test_childname", "test_childcap")
     assert True
 
 
-@inlineCallbacks
-def test_tahoe_link_fail_code_500(tahoe, monkeypatch):
+@ensureDeferred
+async def test_tahoe_link_fail_code_500(tahoe, monkeypatch):
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.await_ready", lambda _: succeed(None)
     )
     monkeypatch.setattr("treq.post", fake_post_code_500)
     monkeypatch.setattr("treq.content", lambda _: succeed(b"test content"))
     with pytest.raises(TahoeWebError):
-        yield tahoe.link("test_dircap", "test_childname", "test_childcap")
+        await tahoe.link("test_dircap", "test_childname", "test_childcap")
 
 
 @inlineCallbacks

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -567,9 +567,13 @@ def test_is_ready_false_connected_less_than_happy(tahoe, monkeypatch):
     assert output is False
 
 
+async def fake_is_ready(self) -> bool:
+    return True
+
+
 @inlineCallbacks
 def test_await_ready(tahoe, monkeypatch):
-    monkeypatch.setattr("gridsync.tahoe.Tahoe.is_ready", lambda _: True)
+    monkeypatch.setattr("gridsync.tahoe.Tahoe.is_ready", fake_is_ready)
     yield tahoe.await_ready()
     assert True
 
@@ -590,7 +594,7 @@ def test_concurrent_await_ready(tahoe, monkeypatch):
         is_ready = False
         poll_count = 0
 
-        def check_ready(self):
+        async def check_ready(self) -> bool:
             nonlocal poll_count
             poll_count += 1
             return is_ready

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -774,12 +774,12 @@ def test_tahoe_start_use_tor_false(monkeypatch, tmpdir_factory):
     monkeypatch.setattr("shutil.which", lambda _: "_tahoe")
     monkeypatch.setattr(
         "gridsync.supervisor.Supervisor.start",
-        lambda *args, **kwargs: (9999, "tahoe"),
+        lambda *args, **kwargs: succeed((9999, "tahoe")),
     )
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.scan_storage_plugins", lambda _: None
     )
-    yield client.start()
+    yield Deferred.fromCoroutine(client.start())
     assert not client.use_tor
 
 
@@ -787,7 +787,7 @@ def test_tahoe_start_use_tor_false(monkeypatch, tmpdir_factory):
 def test_tahoe_starts_streamedlogs(monkeypatch, tahoe_factory):
     monkeypatch.setattr(
         "gridsync.supervisor.Supervisor.start",
-        lambda *args, **kwargs: (9999, "tahoe"),
+        lambda *args, **kwargs: succeed((9999, "tahoe")),
     )
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.scan_storage_plugins", lambda _: None
@@ -798,7 +798,7 @@ def test_tahoe_starts_streamedlogs(monkeypatch, tahoe_factory):
     tahoe.config_set("client", "shares.needed", "3")
     tahoe.config_set("client", "shares.happy", "7")
     tahoe.config_set("client", "shares.total", "10")
-    yield tahoe.start()
+    yield Deferred.fromCoroutine(tahoe.start())
     tahoe._on_started()  # XXX
     assert tahoe.streamedlogs.running
     (host, port, _, _, _) = reactor.tcpClients.pop(0)
@@ -809,7 +809,7 @@ def test_tahoe_starts_streamedlogs(monkeypatch, tahoe_factory):
 def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
     monkeypatch.setattr(
         "gridsync.supervisor.Supervisor.start",
-        lambda *args, **kwargs: (9999, "tahoe"),
+        lambda *args, **kwargs: succeed((9999, "tahoe")),
     )
     monkeypatch.setattr("gridsync.supervisor.Supervisor.stop", Mock())
     monkeypatch.setattr(
@@ -820,7 +820,7 @@ def test_tahoe_stops_streamedlogs(monkeypatch, tahoe_factory):
     tahoe.config_set("client", "shares.needed", "3")
     tahoe.config_set("client", "shares.happy", "7")
     tahoe.config_set("client", "shares.total", "10")
-    yield tahoe.start()
+    yield Deferred.fromCoroutine(tahoe.start())
     Path(tahoe.pidfile).write_text(str("4194306"), encoding="utf-8")
     yield tahoe.stop()
     assert not tahoe.streamedlogs.running
@@ -843,10 +843,10 @@ def test_tahoe_start_use_tor_true(monkeypatch, tmpdir_factory):
     monkeypatch.setattr("shutil.which", lambda _: "_tahoe")
     monkeypatch.setattr(
         "gridsync.supervisor.Supervisor.start",
-        lambda *args, **kwargs: (9999, "tahoe"),
+        lambda *args, **kwargs: succeed((9999, "tahoe")),
     )
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.scan_storage_plugins", lambda _: None
     )
-    yield client.start()
+    yield Deferred.fromCoroutine(client.start())
     assert client.use_tor

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -28,7 +28,7 @@ from gridsync.zkapauthorizer import PLUGIN_NAME as ZKAPAUTHZ_PLUGIN_NAME
 def fake_get(*args, **kwargs):
     response = MagicMock()
     response.code = 200
-    return response
+    return succeed(response)
 
 
 def fake_get_code_500(*args, **kwargs):
@@ -539,8 +539,10 @@ def test_get_grid_status(tahoe, monkeypatch):
         ]
     }"""
     monkeypatch.setattr("treq.get", fake_get)
-    monkeypatch.setattr("treq.content", lambda _: json_content)
-    num_connected, num_known, available_space = yield tahoe.get_grid_status()
+    monkeypatch.setattr("treq.content", lambda _: succeed(json_content))
+    num_connected, num_known, available_space = yield Deferred.fromCoroutine(
+        tahoe.get_grid_status()
+    )
     assert (num_connected, num_known, available_space) == (2, 3, 3072)
 
 

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -774,25 +774,25 @@ async def test_tahoe_link_fail_code_500(tahoe, monkeypatch):
         await tahoe.link("test_dircap", "test_childname", "test_childcap")
 
 
-@inlineCallbacks
-def test_tahoe_unlink(tahoe, monkeypatch):
+@ensureDeferred
+async def test_tahoe_unlink(tahoe, monkeypatch):
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.await_ready", lambda _: succeed(None)
     )
     monkeypatch.setattr("treq.post", fake_post)
-    yield tahoe.unlink("test_dircap", "test_childname")
+    await tahoe.unlink("test_dircap", "test_childname")
     assert True
 
 
-@inlineCallbacks
-def test_tahoe_unlink_fail_code_500(tahoe, monkeypatch):
+@ensureDeferred
+async def test_tahoe_unlink_fail_code_500(tahoe, monkeypatch):
     monkeypatch.setattr(
         "gridsync.tahoe.Tahoe.await_ready", lambda _: succeed(None)
     )
     monkeypatch.setattr("treq.post", fake_post_code_500)
     monkeypatch.setattr("treq.content", lambda _: succeed(b"test content"))
     with pytest.raises(TahoeWebError):
-        yield tahoe.unlink("test_dircap", "test_childname")
+        await tahoe.unlink("test_dircap", "test_childname")
 
 
 @inlineCallbacks

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -11,7 +11,7 @@ except ImportError:
 import pytest
 import yaml
 from pytest_twisted import inlineCallbacks
-from twisted.internet.defer import succeed
+from twisted.internet.defer import Deferred, succeed
 from twisted.internet.testing import MemoryReactorClock
 
 from gridsync.crypto import randstr
@@ -405,7 +405,7 @@ def test_add_storage_servers_writes_zkapauthorizer_allowed_public_keys(tmpdir):
 @inlineCallbacks
 def test_tahoe_create_client_nodedir_exists_error(tahoe):
     with pytest.raises(FileExistsError):
-        yield tahoe.create_client({})
+        yield Deferred.fromCoroutine(tahoe.create_client({}))
 
 
 def command_spy():
@@ -436,7 +436,9 @@ def test_tahoe_create_client_args(tahoe, monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda x: False)
     spy, intel = command_spy()
     monkeypatch.setattr("gridsync.tahoe.Tahoe.command", spy)
-    yield tahoe.create_client({"nickname": "test_nickname"})
+    yield Deferred.fromCoroutine(
+        tahoe.create_client({"nickname": "test_nickname"})
+    )
     assert has_args(intel[0], ("--nickname", "test_nickname"))
 
 
@@ -445,7 +447,7 @@ def test_tahoe_create_client_args_compat(tahoe, monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda x: False)
     spy, intel = command_spy()
     monkeypatch.setattr("gridsync.tahoe.Tahoe.command", spy)
-    yield tahoe.create_client({"happy": "7"})
+    yield Deferred.fromCoroutine(tahoe.create_client({"happy": "7"}))
     assert has_args(intel[0], ("--shares-happy", "7"))
 
 
@@ -455,7 +457,7 @@ def test_tahoe_create_client_args_hide_ip(tahoe, monkeypatch):
     spy, intel = command_spy()
     monkeypatch.setattr("gridsync.tahoe.Tahoe.command", spy)
     settings = {"hide-ip": True}
-    yield tahoe.create_client(settings)
+    yield Deferred.fromCoroutine(tahoe.create_client(settings))
     assert has_args(intel[0], ("--hide-ip",))
 
 
@@ -472,7 +474,7 @@ def test_tahoe_create_client_add_storage_servers(tmpdir, monkeypatch):
         "node-1": {"anonymous-storage-FURL": "pb://test", "nickname": "One"}
     }
     settings = {"nickname": "TestGrid", "storage": storage_servers}
-    yield client.create_client(settings)
+    yield Deferred.fromCoroutine(client.create_client(settings))
     assert client.get_storage_servers() == storage_servers
 
 


### PR DESCRIPTION
Fixes #523 

Please note `test_tahoe_stop_locked`.  I'm not sure if this kind of global reactor interaction is correct with pytest_twisted, and even if so if it is the preferred style in GridSync's tests.  However, I'm also not sure what else to do there.

The commits are almost all self-contained changesets that address one function from `tahoe.py` completely throughout the codebase, in case that helps with review.