### PR TITLE
Fix race condition between test and supervisor restart

### DIFF
--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -77,10 +77,10 @@ def test_supervisor_restarts_process_when_killed(tmp_path):
     pidfile = tmp_path / "python.pid"
     supervisor = Supervisor(pidfile=pidfile, restart_delay=0)
     pid, _ = yield supervisor.start(PROCESS_ARGS, started_trigger="OK")
-    reactor.callLater(0.1, Process(pid).kill)
-    yield until(supervisor.is_running, False)
-    yield until(supervisor.is_running, True)
-    assert True
+    assert supervisor.is_running()
+    Process(pid).kill()
+    yield until(lambda: supervisor.pid != pid)
+    assert supervisor.is_running()
 
 
 @inlineCallbacks


### PR DESCRIPTION
`until` polls with fairly low resolution.  If the supervisor managed to
receive exit notification and launch a new process between two consecutive
polls for `is_running() == False` the test would miss the stopped condition
entirely and never complete (or rather, time out after 10 seconds).

Now just wait for the supervisor to report the pid has changed and assert the
process ends in the desire state (running).