### PR TITLE
Improve "days remaining" calculation

### DIFF
--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from humanize import naturalsize

--- a/gridsync/gui/status.py
+++ b/gridsync/gui/status.py
@@ -22,6 +22,7 @@ from gridsync.gui.menu import Menu
 from gridsync.gui.pixmap import Pixmap
 from gridsync.gui.widgets import HSpacer
 from gridsync.magic_folder import MagicFolderStatus
+from gridsync.util import future_date
 
 
 class StatusPanel(QWidget):
@@ -236,16 +237,5 @@ class StatusPanel(QWidget):
 
     @Slot(object)
     def on_days_remaining_updated(self, days: int) -> None:
-        try:
-            delta = timedelta(days=days)
-        except OverflowError:  # Python int too large to convert to C int
-            delta = timedelta(days=365 * 1000)
-        expiry_date = datetime.strftime(
-            datetime.strptime(
-                datetime.isoformat(datetime.now() + delta),
-                "%Y-%m-%dT%H:%M:%S.%f",
-            ),
-            "%d %b %Y",
-        )
-        self.expires_label.setText(f"Expected expiry: {expiry_date}")
+        self.expires_label.setText(f"Expected expiry: {future_date(days)}")
         self.expires_label.show()

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import traceback
 import webbrowser
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import attr

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -25,6 +25,7 @@ from gridsync.gui.voucher import VoucherCodeDialog
 from gridsync.gui.widgets import VSpacer
 from gridsync.msg import error
 from gridsync.types import TwistedDeferred
+from gridsync.util import future_date
 
 if TYPE_CHECKING:
     from gridsync.gui import AbstractGui  # pylint: disable=cyclic-import
@@ -391,17 +392,7 @@ class UsageView(QWidget):
 
     @Slot(object)
     def on_days_remaining_updated(self, days: int) -> None:
-        try:
-            delta = timedelta(days=days)
-        except OverflowError:  # Python int too large to convert to C int
-            delta = timedelta(days=365 * 1000)
-        self._expiry_date = datetime.strftime(
-            datetime.strptime(
-                datetime.isoformat(datetime.now() + delta),
-                "%Y-%m-%dT%H:%M:%S.%f",
-            ),
-            "%d %b %Y",
-        )
+        self._expiry_date = future_date(days)
         self._update_info_label()
 
     @Slot(object)

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from binascii import hexlify, unhexlify
+from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from time import time
 from typing import TYPE_CHECKING, Callable, Coroutine, Optional, TypeVar, Union
@@ -80,6 +81,27 @@ def humanized_list(list_: list, kind: str = "files") -> Optional[str]:
     return "{}, {}, and {} other {}".format(
         list_[0], list_[1], len(list_) - 2, kind
     )
+
+
+def future_date(days_from_now: int) -> str:
+    """
+    Represent a future date as a short, human-friendlier string.
+
+    Returns "Centuries" if the date is especially far into the future.
+    """
+    days_from_now = 2**32
+    try:
+        return datetime.strftime(
+            datetime.strptime(
+                datetime.isoformat(
+                    datetime.now() + timedelta(days=days_from_now)
+                ),
+                "%Y-%m-%dT%H:%M:%S.%f",
+            ),
+            "%d %b %Y",
+        )
+    except OverflowError:  # Python int too large to convert to C int
+        return "Centuries"
 
 
 class _TagStripper(HTMLParser):  # pylint: disable=abstract-method

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -89,7 +89,6 @@ def future_date(days_from_now: int) -> str:
 
     Returns "Centuries" if the date is especially far into the future.
     """
-    days_from_now = 2**32
     try:
         return datetime.strftime(
             datetime.strptime(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ import pytest
 from gridsync.util import (
     b58decode,
     b58encode,
+    future_date,
     humanized_list,
     strip_html_tags,
     to_bool,
@@ -91,6 +92,10 @@ def test_to_bool(s, result):
 )
 def test_humanized_list(items, kind, humanized):
     assert humanized_list(items, kind) == humanized
+
+
+def test_future_date_returns_centuries_for_large_int_days():
+    assert future_date(2**32) == "Centuries"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,6 +98,10 @@ def test_future_date_returns_centuries_for_large_int_days():
     assert future_date(2**32) == "Centuries"
 
 
+def test_future_date_does_not_return_centuries_for_small_int_days():
+    assert future_date(365 * 5) != "Centuries"
+
+
 @pytest.mark.parametrize(
     "s,expected",
     [


### PR DESCRIPTION
A minor refactoring and improvement of https://github.com/gridsync/gridsync/pull/535 to display fuzzier "Centuries" label for extremely large "days remaining" / "expected expiry" values.