### PR TITLE
Update `config.txt`: remove redirect in `docs_url`

### DIFF
--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -25,7 +25,7 @@ multiple_grids = true
 tor = true
 
 [help]
-docs_url = docs.gridsync.io
+docs_url = https://github.com/gridsync/gridsync/tree/master/docs
 issues_url = https://github.com/gridsync/gridsync/issues
 
 [sign]


### PR DESCRIPTION
On newer versions of macOS, the "Browse Documentation..." menu action appears to no longer be launching the web browser (while other URLs appear to be launched just fine). This may be due to the fact that the `docs_url` value specified in `config.txt` is a redirect ("docs.gridsync.io") to [the intended destination](https://github.com/gridsync/gridsync/tree/master/docs).

This PR updates `config.txt` to replace "docs.gridsync.io" with "https://github.com/gridsync/gridsync/tree/master/docs" in hopes that doing so will result in the URL being launched correctly via `webbrowser.open()` -- but, even if it doesn't, redirects/url-shorteners can become an attack vector (e.g., in the event that the gridsync.io domain name expires and is picked up by an attacker) and so should probably not be used in this case anyway.