### PR TITLE
Fix crash caused by attempting to redact/filter non-existent rootcap from logs

### DIFF
--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -218,15 +218,19 @@ class Tahoe:
         if not self.settings:
             self.load_settings()
         settings = dict(self.settings)
+
+        def _safe_del(dictionary: dict, key: str) -> None:
+            try:
+                del dictionary[key]
+            except KeyError:
+                pass
+
         if include_secrets:
             rootcap = self.get_rootcap()
             if rootcap:
                 settings["rootcap"] = diminish(rootcap)
             else:
-                try:
-                    del settings["rootcap"]
-                except KeyError:
-                    pass
+                _safe_del(settings, "rootcap")
             try:
                 settings["convergence"] = (
                     Path(self.nodedir, "private", "convergence")
@@ -234,19 +238,10 @@ class Tahoe:
                     .strip()
                 )
             except FileNotFoundError:
-                try:
-                    del settings["convergence"]
-                except KeyError:
-                    pass
+                _safe_del(settings, "convergence")
         else:
-            try:
-                del settings["rootcap"]
-            except KeyError:
-                pass
-            try:
-                del settings["convergence"]
-            except KeyError:
-                pass
+            _safe_del(settings, "rootcap")
+            _safe_del(settings, "convergence")
         return settings
 
     def export(self, dest: str, include_secrets: bool = False) -> None:

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -222,6 +222,11 @@ class Tahoe:
             rootcap = self.get_rootcap()
             if rootcap:
                 settings["rootcap"] = diminish(rootcap)
+            else:
+                try:
+                    del settings["rootcap"]
+                except KeyError:
+                    pass
             settings["convergence"] = (
                 Path(self.nodedir, "private", "convergence")
                 .read_text(encoding="utf-8")

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -219,7 +219,9 @@ class Tahoe:
             self.load_settings()
         settings = dict(self.settings)
         if include_secrets:
-            settings["rootcap"] = diminish(self.get_rootcap())
+            rootcap = self.get_rootcap()
+            if rootcap:
+                settings["rootcap"] = diminish(rootcap)
             settings["convergence"] = (
                 Path(self.nodedir, "private", "convergence")
                 .read_text(encoding="utf-8")

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -227,11 +227,17 @@ class Tahoe:
                     del settings["rootcap"]
                 except KeyError:
                     pass
-            settings["convergence"] = (
-                Path(self.nodedir, "private", "convergence")
-                .read_text(encoding="utf-8")
-                .strip()
-            )
+            try:
+                settings["convergence"] = (
+                    Path(self.nodedir, "private", "convergence")
+                    .read_text(encoding="utf-8")
+                    .strip()
+                )
+            except FileNotFoundError:
+                try:
+                    del settings["convergence"]
+                except KeyError:
+                    pass
         else:
             try:
                 del settings["rootcap"]

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -168,7 +168,17 @@ def test_get_settings(tahoe):
     assert (nickname, icon_url) == (tahoe.name, "test_url")
 
 
-def test_get_settings_does_not_include_empty_rootcap(tahoe):
+def test_get_settings_includes_diminished_rootcap(tahoe):
+    tahoe.rootcap_manager.set_rootcap(
+        "URI:DIR2:x6ciqn3dbnkslpvazwz6z7ic2q:"
+        "slkf7invl5apcabpyztxazkcufmptsclx7m3rn6hhiyuiz2hvu6a",
+        overwrite=True,
+    )
+    settings = tahoe.get_settings(include_secrets=True)
+    assert settings["rootcap"].startswith("URI:DIR2-RO:")
+
+
+def test_get_settings_omits_rootcap_if_empty(tahoe):
     tahoe.rootcap_manager.set_rootcap("", overwrite=True)
     settings = tahoe.get_settings(include_secrets=True)
     assert "rootcap" not in settings
@@ -180,6 +190,12 @@ def test_get_settings_includes_convergence_secret(tahoe):
     assert (
         tahoe.get_settings(include_secrets=True).get("convergence") == secret
     )
+
+
+def test_get_settings_omits_convergence_secret_if_file_not_found(tahoe):
+    Path(tahoe.nodedir, "private", "convergence").unlink(missing_ok=True)
+    settings = tahoe.get_settings(include_secrets=True)
+    assert "convergence" not in settings
 
 
 def test_get_settings_exclude_convergence_secret_by_default(tahoe):

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -168,6 +168,12 @@ def test_get_settings(tahoe):
     assert (nickname, icon_url) == (tahoe.name, "test_url")
 
 
+def test_get_settings_does_not_include_empty_rootcap(tahoe):
+    tahoe.rootcap_manager.set_rootcap("", overwrite=True)
+    settings = tahoe.get_settings()
+    assert "rootcap" not in settings
+
+
 def test_get_settings_includes_convergence_secret(tahoe):
     secret = randstr()
     Path(tahoe.nodedir, "private", "convergence").write_text(secret)

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -170,7 +170,7 @@ def test_get_settings(tahoe):
 
 def test_get_settings_does_not_include_empty_rootcap(tahoe):
     tahoe.rootcap_manager.set_rootcap("", overwrite=True)
-    settings = tahoe.get_settings()
+    settings = tahoe.get_settings(include_secrets=True)
     assert "rootcap" not in settings
 
 


### PR DESCRIPTION
Fixes #553