### PR TITLE
Display user-facing error messages for incompatible/out-of-date Tahoe-LAFS configurations

### DIFF
--- a/gridsync/core.py
+++ b/gridsync/core.py
@@ -71,6 +71,7 @@ from gridsync import (
     settings,
 )
 from gridsync.desktop import autostart_enable
+from gridsync.errors import UpgradeRequiredError
 from gridsync.gui import Gui
 from gridsync.lock import FilesystemLock
 from gridsync.magic_folder import MagicFolder
@@ -156,6 +157,15 @@ class Core:
     def _start_gateway(gateway: Tahoe) -> TwistedDeferred[None]:
         try:
             yield Deferred.fromCoroutine(gateway.start())
+        except UpgradeRequiredError as error:
+            msg.critical(
+                "Invalid configuration detected",
+                f"{str(error)}\n\nIn order to continue, you will need to "
+                f"either use an older version of {APP_NAME} that is "
+                "compatible with your current configuration (not recommended),"
+                " or move the existing configuration directory (located at "
+                f'"{config_dir}") to a different location and try again.',
+            )
         except Exception as e:  # pylint: disable=broad-except
             msg.critical(
                 f"Error starting Tahoe-LAFS gateway for {gateway.name}",

--- a/gridsync/tahoe.py
+++ b/gridsync/tahoe.py
@@ -39,6 +39,23 @@ def is_valid_furl(furl: str) -> bool:
     return False
 
 
+def has_legacy_magic_folder(nodedir: Path) -> bool:
+    config = Config(str(nodedir / "tahoe.cfg")).load()
+    if "magic_folder" in config:
+        return True
+    return False
+
+
+def has_legacy_zkapauthorizer(nodedir: Path) -> bool:
+    config = Config(str(nodedir / "tahoe.cfg")).load()
+    if "storageclient.plugins.privatestorageio-zkapauthz-v1" in config:
+        return True
+    storage_plugins = config.get("client", {}).get("storage.plugins")
+    if storage_plugins and "privatestorageio-zkapauthz-v1" in storage_plugins:
+        return True
+    return False
+
+
 def get_nodedirs(basedir: str) -> list:
     nodedirs = []
     try:

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -107,13 +107,11 @@ def test_has_legacy_magic_folder(tmp_path, contents, result):
     "contents, result",
     [
         (
-            "[client]\n"
-            "storage.plugins = privatestorageio-zkapauthz-v1\n",
+            "[client]\nstorage.plugins = privatestorageio-zkapauthz-v1\n",
             True,
         ),
         (
-            "[client]\n"
-            "storage.plugins = privatestorageio-zkapauthz-v2\n",
+            "[client]\nstorage.plugins = privatestorageio-zkapauthz-v2\n",
             False,
         ),
         (

--- a/tests/test_tahoe.py
+++ b/tests/test_tahoe.py
@@ -20,6 +20,8 @@ from gridsync.errors import TahoeCommandError, TahoeError, TahoeWebError
 from gridsync.tahoe import (
     Tahoe,
     get_nodedirs,
+    has_legacy_magic_folder,
+    has_legacy_zkapauthorizer,
     is_valid_furl,
     storage_options_to_config,
 )
@@ -84,6 +86,52 @@ def test_is_valid_furl_invalid_char_in_connection_hint():
 
 def test_is_valid_furl_tub_id_not_base32():
     assert not is_valid_furl("pb://abc123@example.org:12345/introducer")
+
+
+@pytest.mark.parametrize(
+    "contents, result",
+    [
+        ("[magic_folder]\nenabled = True", True),
+        ("[magic_folder]\nenabled = False", True),
+        ("[NOT_magic_folder]\nenabled = True", False),
+        ("", False),
+    ],
+)
+def test_has_legacy_magic_folder(tmp_path, contents, result):
+    tahoe_cfg = tmp_path / "tahoe.cfg"
+    tahoe_cfg.write_text(contents)
+    assert has_legacy_magic_folder(tmp_path) == result
+
+
+@pytest.mark.parametrize(
+    "contents, result",
+    [
+        (
+            "[client]\n"
+            "storage.plugins = privatestorageio-zkapauthz-v1\n",
+            True,
+        ),
+        (
+            "[client]\n"
+            "storage.plugins = privatestorageio-zkapauthz-v2\n",
+            False,
+        ),
+        (
+            "[storageclient.plugins.privatestorageio-zkapauthz-v1]\n"
+            "redeemer = ristretto",
+            True,
+        ),
+        (
+            "[storageclient.plugins.privatestorageio-zkapauthz-v2]\n"
+            "redeemer = ristretto",
+            False,
+        ),
+    ],
+)
+def test_has_legacy_zkapauthorizer(tmp_path, contents, result):
+    tahoe_cfg = tmp_path / "tahoe.cfg"
+    tahoe_cfg.write_text(contents)
+    assert has_legacy_zkapauthorizer(tmp_path) == result
 
 
 def test_get_nodedirs(tahoe, tmpdir_factory):


### PR DESCRIPTION
Recent changes in both [Magic-Folder](https://github.com/LeastAuthority/magic-folder) and [ZKAPAAuthorizer](https://github.com/PrivateStorageio/ZKAPAuthorizer) have broken compatibility with older Tahoe-LAFS and Gridsync configurations: Specifically, the "magic-folder" feature present in earlier versions of Tahoe-LAFS has been [removed as of Tahoe-LAFS version 1.15](https://github.com/tahoe-lafs/tahoe-lafs/blob/f9ddd3b3bedf692ffdf598d9def96b3c79097602/NEWS.rst#removed-features-2) (having been split off into a [standalone project](https://github.com/LeastAuthority/magic-folder) with a different configuration format), while ZKAPAuthorizer's [newer backup/restore system](https://github.com/PrivateStorageio/ZKAPAuthorizer/issues/235) has removed the older "v1" endpoints used by previous versions. Unfortunately, neither project has provided a migration path for converting an older configuration to a new one, thus leaving on-disk configurations that cannot be used with newer versions of the software.

This PR checks for such out-of-date configurations within the Gridsync configuration directory and, if found, displays a message to the user, explaining the compatibility-break and providing suggestions for how to continue.