### PR TITLE
Declare custom "recovery" and "zkaps" help urls via `config.txt`

### DIFF
--- a/gridsync/__init__.py
+++ b/gridsync/__init__.py
@@ -83,6 +83,10 @@ RECOVERY_HELP_URL = _help_settings.get(
     "recovery_url",
     "https://github.com/gridsync/gridsync/blob/master/docs/recovery-keys.md",
 )
+ZKAPS_HELP_URL = _help_settings.get(
+    "zkaps_url",
+    "https://github.com/PrivateStorageio/ZKAPAuthorizer",
+)
 
 
 try:

--- a/gridsync/__init__.py
+++ b/gridsync/__init__.py
@@ -69,6 +69,18 @@ for envvar, value in os.environ.items():
             except KeyError:
                 settings[section] = {option: value}
 
+
+_help_settings = settings.get("help", {})
+DOCS_HELP_URL = _help_settings.get(
+    "docs_url",
+    "https://github.com/gridsync/gridsync/tree/master/docs",
+)
+ISSUES_HELP_URL = _help_settings.get(
+    "issues_url",
+    "https://github.com/gridsync/gridsync/issues",
+)
+
+
 try:
     APP_NAME = settings["application"]["name"]
 except KeyError:

--- a/gridsync/__init__.py
+++ b/gridsync/__init__.py
@@ -79,6 +79,10 @@ ISSUES_HELP_URL = _help_settings.get(
     "issues_url",
     "https://github.com/gridsync/gridsync/issues",
 )
+RECOVERY_HELP_URL = _help_settings.get(
+    "recovery_url",
+    "https://github.com/gridsync/gridsync/blob/master/docs/recovery-keys.md",
+)
 
 
 try:

--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -30,7 +30,13 @@ from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.python.failure import Failure
 
-from gridsync import APP_NAME, CONNECTION_DEFAULT_NICKNAME, features, resource
+from gridsync import (
+    APP_NAME,
+    CONNECTION_DEFAULT_NICKNAME,
+    RECOVERY_HELP_URL,
+    features,
+    resource,
+)
 from gridsync.gui.history import HistoryView
 from gridsync.gui.password import PasswordDialog
 from gridsync.gui.share import InviteReceiverDialog, InviteSenderDialog
@@ -477,9 +483,8 @@ class MainWindow(QMainWindow):
             f"{gateway.name} does not have access to your folders, and cannot "
             "restore access to them. But with a Recovery Key, you can restore "
             "access to uploaded folders in case something goes wrong (e.g., "
-            "hardware failure, accidental data-loss).<p><p><a href=https://"
-            "github.com/gridsync/gridsync/blob/master/docs/recovery-keys.md>"
-            "More information...</a>"
+            "hardware failure, accidental data-loss).<p><p>"
+            f"<a href={RECOVERY_HELP_URL}>More information...</a>"
         )
         reply = msg.exec_()
         if reply == QMessageBox.Yes:

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -9,7 +9,14 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QAction, QMenu, QMessageBox
 
-from gridsync import APP_NAME, __version__, resource, settings
+from gridsync import (
+    APP_NAME,
+    DOCS_HELP_URL,
+    ISSUES_HELP_URL,
+    __version__,
+    resource,
+    settings,
+)
 
 if TYPE_CHECKING:
     from gridsync.gui import AbstractGui
@@ -39,22 +46,20 @@ class Menu(QMenu):
 
         help_menu = QMenu(self)
         help_menu.setTitle("Help")
-        help_settings = settings.get("help")
-        if help_settings:
-            if help_settings.get("docs_url"):
-                docs_action = QAction(
-                    QIcon(""), "Browse Documentation...", self
-                )
-                docs_action.triggered.connect(
-                    lambda: webbrowser.open(settings["help"]["docs_url"])
-                )
-                help_menu.addAction(docs_action)
-            if help_settings.get("issues_url"):
-                issue_action = QAction(QIcon(""), "Report Issue...", self)
-                issue_action.triggered.connect(
-                    lambda: webbrowser.open(settings["help"]["issues_url"])
-                )
-                help_menu.addAction(issue_action)
+        if DOCS_HELP_URL:
+            docs_action = QAction(
+                QIcon(""), "Browse Documentation...", self
+            )
+            docs_action.triggered.connect(
+                lambda: webbrowser.open(DOCS_HELP_URL)
+            )
+            help_menu.addAction(docs_action)
+        if ISSUES_HELP_URL:
+            issue_action = QAction(QIcon(""), "Report Issue...", self)
+            issue_action.triggered.connect(
+                lambda: webbrowser.open(ISSUES_HELP_URL)
+            )
+            help_menu.addAction(issue_action)
         export_action = QAction(QIcon(""), "View Debug Information...", self)
         export_action.triggered.connect(self.gui.show_debug_exporter)
         help_menu.addAction(export_action)

--- a/gridsync/gui/menu.py
+++ b/gridsync/gui/menu.py
@@ -47,9 +47,7 @@ class Menu(QMenu):
         help_menu = QMenu(self)
         help_menu.setTitle("Help")
         if DOCS_HELP_URL:
-            docs_action = QAction(
-                QIcon(""), "Browse Documentation...", self
-            )
+            docs_action = QAction(QIcon(""), "Browse Documentation...", self)
             docs_action.triggered.connect(
                 lambda: webbrowser.open(DOCS_HELP_URL)
             )

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 
 def make_explainer_label() -> QLabel:
     explainer_label = QLabel(
-        f"The {APP_NAME} app will gradually consume your storage-time to "
-        f"keep your data saved. <a href={ZKAPS_HELP_URL}>Learn more...</a>"
+        f"<br>The {APP_NAME} app will gradually consume your storage-time to "
+        f"keep your data saved.<br><a href={ZKAPS_HELP_URL}>Learn more...</a>"
     )
     font = Font(10)
     font.setItalic(True)

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QPushButton, QWidget
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 
-from gridsync import APP_NAME, resource
+from gridsync import APP_NAME, ZKAPS_HELP_URL, resource
 from gridsync.desktop import get_browser_name
 from gridsync.gui.charts import ZKAPBarChartView
 from gridsync.gui.color import BlendedColor
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 def make_explainer_label() -> QLabel:
     explainer_label = QLabel(
         f"The {APP_NAME} app will gradually consume your storage-time to "
-        "keep your data saved."
+        f"keep your data saved. <a href={ZKAPS_HELP_URL}>Learn more...</a>"
     )
     font = Font(10)
     font.setItalic(True)
@@ -140,8 +140,9 @@ class UsageView(QWidget):
         else:
             action = "add storage-time using a voucher code"
         zkaps_required_label = QLabel(
-            "You currently have 0 GB-months available.\n\nIn order to store "
+            "You currently have 0 GB-months available.<p>In order to store "
             f"data with {self.gateway.name}, you will need to {action}."
+            f"<p><a href={ZKAPS_HELP_URL}>Learn more...</a>"
         )
         zkaps_required_label.setAlignment(Qt.AlignCenter)
         zkaps_required_label.setWordWrap(True)

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -37,6 +37,7 @@ def make_explainer_label() -> QLabel:
         f"<br>The {APP_NAME} app will gradually consume your storage-time to "
         f"keep your data saved.<br><a href={ZKAPS_HELP_URL}>Learn more...</a>"
     )
+    explainer_label.linkActivated.connect(webbrowser.open)
     font = Font(10)
     font.setItalic(True)
     explainer_label.setFont(font)
@@ -144,6 +145,7 @@ class UsageView(QWidget):
             f"data with {self.gateway.name}, you will need to {action}."
             f"<p><a href={ZKAPS_HELP_URL}>Learn more...</a>"
         )
+        zkaps_required_label.linkActivated.connect(webbrowser.open)
         zkaps_required_label.setAlignment(Qt.AlignCenter)
         zkaps_required_label.setWordWrap(True)
         zkaps_required_label.hide()

--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -314,7 +314,7 @@ class UsageView(QWidget):
             error(
                 self,
                 "Error launching browser",
-                "Could not launch webbrower. To complete payment for "
+                "Could not launch webbrowser. To complete payment for "
                 f"{self.gateway.name}, please visit the following URL:"
                 f"<p><a href={payment_url}>{payment_url}</a><br>",
             )

--- a/gridsync/resources/config.txt
+++ b/gridsync/resources/config.txt
@@ -24,6 +24,8 @@ tor = true
 [help]
 docs_url = https://github.com/gridsync/gridsync/tree/master/docs
 issues_url = https://github.com/gridsync/gridsync/issues
+recovery_url = https://github.com/gridsync/gridsync/blob/master/docs/recovery-keys.md
+zkaps_url = https://github.com/PrivateStorageio/ZKAPAuthorizer
 
 [logging]
 enabled = true

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -7,7 +7,13 @@ from importlib import reload
 import pytest
 
 import gridsync
-from gridsync import load_settings_from_cheatcode
+from gridsync import (
+    DOCS_HELP_URL,
+    ISSUES_HELP_URL,
+    RECOVERY_HELP_URL,
+    ZKAPS_HELP_URL,
+    load_settings_from_cheatcode,
+)
 
 
 def test_the_approval_of_RMS():  # :)
@@ -125,3 +131,16 @@ def test_load_settings_from_cheatcode_none(tmpdir_factory, monkeypatch):
     pkgdir = os.path.join(str(tmpdir_factory.getbasetemp()), "pkgdir-empty")
     monkeypatch.setattr("gridsync.pkgdir", pkgdir)
     assert load_settings_from_cheatcode("test-test") is None
+
+
+@pytest.mark.parametrize(
+    "url, type_",
+    [
+        (DOCS_HELP_URL, str),
+        (ISSUES_HELP_URL, str),
+        (RECOVERY_HELP_URL, str),
+        (ZKAPS_HELP_URL, str),
+    ],
+)
+def test_help_urls_declared_as_expected_type(url, type_):
+    assert isinstance(url, type_)


### PR DESCRIPTION
This PR adds support for overriding/declaring two additional "help" URLs via config.txt options as follows:

```
[help]
recovery_url = https://example.org/path/to/recovery-keys.html
zkaps_url = https://example.org/path/to/zkaps.html
```

Modifying these values will update the destination URLs of the "Learn more..." links found in the Recovery Key creation dialog/prompt and the Storage-time/usage view labels respectively.

This change is intended to support the forthcoming deployment of the [PrivateStorage](https://private.storage) service -- which wishes to specify custom locations for help documentation.