### PR TITLE
Try if not having a modal dialogue on quit fixes the macOS quitting issue

### DIFF
--- a/gridsync/gui/main_window.py
+++ b/gridsync/gui/main_window.py
@@ -535,6 +535,9 @@ class MainWindow(QMainWindow):
         return False
 
     def confirm_quit(self) -> None:
+        # Tryfix privatestoragedesktop/-/issues/735
+        reactor.stop()  # type: ignore
+
         msg = QMessageBox(self)
         if self._is_folder_syncing():
             msg.setIcon(QMessageBox.Warning)


### PR DESCRIPTION
When app is closed by system on shutdown on macOS, gridsync prevents shutdown.
Might be related privatestoragedesktop/-/issues/735

Create a PR to get a build out of https://buildbot.gridsync.io/artifacts/
