### PR TITLE
Ensure recreation of "resources" (sub)dir in PyInstaller bundles

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -333,6 +333,8 @@ def finalize_gridsync_bundle():
     # in `gridsync/resources/`. I'm not sure why PyInstaller does this.. :/
     for p in Path(dist, "resources").glob("*-*.json"):
         paths_to_move.append((p, Path(dist, "resources", "providers", p.name)))
+    Path(dist, "resources", "providers").mkdir(exist_ok=True)
+
     if sys.platform not in ("darwin", "win32"):
         paths_to_move.append(
             (Path(dist, app_name), Path(dist, app_name.lower()))

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -329,11 +329,14 @@ def finalize_gridsync_bundle():
             Path(dist, f"{app_name}-{magic_folder_exe}"),
         )
     )
-    # XXX Sometimes .json files from `gridsync/resources/providers/` end up
-    # in `gridsync/resources/`. I'm not sure why PyInstaller does this.. :/
+    # Sometimes PyInstaller fails to recreate the `resources/providers/`
+    # subdirectory in the bundled application, leaving .json files in
+    # `resources/` instead of (the intended) `resources/providers/`. So
+    # create the `providers/` subdir and move any lingering .json files
+    # into it. See https://github.com/gridsync/gridsync/issues/636
+    Path(dist, "resources", "providers").mkdir(exist_ok=True)
     for p in Path(dist, "resources").glob("*-*.json"):
         paths_to_move.append((p, Path(dist, "resources", "providers", p.name)))
-    Path(dist, "resources", "providers").mkdir(exist_ok=True)
 
     if sys.platform not in ("darwin", "win32"):
         paths_to_move.append(

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,3 +1,4 @@
+# vim: filetype=python
 import inspect
 import os
 import shutil

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -188,8 +188,8 @@ def analyze_gridsync():
         pathex=paths,
         binaries=None,
         datas=[
-            ("gridsync/resources/*", "resources"),
             ("gridsync/resources/providers/*", "resources/providers"),
+            ("gridsync/resources/*", "resources"),
         ],
         hiddenimports=[
 	    "cffi",


### PR DESCRIPTION
Fixes #636 