### PR TITLE
Exclude `libwayland-client` from PyInstaller bundle

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -358,7 +358,7 @@ def finalize_gridsync_bundle():
             "libpango-1.0.so.0",  # https://github.com/gridsync/gridsync/issues/487
             "libpangocairo-1.0.so.0",
             "libpangoft2-1.0.so.0",
-            "libwayland-client.so.0",
+            "libwayland-client.so.0",  # https://github.com/gridsync/gridsync/issues/631
         ]
         for lib in bad_libs:
             paths_to_remove.append(Path(dist, lib))

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -358,6 +358,7 @@ def finalize_gridsync_bundle():
             "libpango-1.0.so.0",  # https://github.com/gridsync/gridsync/issues/487
             "libpangocairo-1.0.so.0",
             "libpangoft2-1.0.so.0",
+            "libwayland-client.so.0",
         ]
         for lib in bad_libs:
             paths_to_remove.append(Path(dist, lib))

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -107,11 +107,6 @@ for file in sorted(os.listdir(appdir_bin)):
 os.remove('build/AppDir/AppRun')
 with open('build/AppDir/AppRun', 'w') as f:
     f.write('''#!/bin/sh
-# Workaround for https://github.com/gridsync/gridsync/issues/631
-LIBWAYLAND=/usr/lib/x86_64-linux-gnu/libwayland-client.so.0
-if [ -f "$LIBWAYLAND" ]; then
-    export LD_PRELOAD="$LIBWAYLAND"
-fi
 exec "$(dirname "$(readlink -e "$0")")/usr/bin/{}" "$@"
 '''.format(name_lower)
     )


### PR DESCRIPTION
Fixes #631 