### PR TITLE
Remove unused shebang lines from python CI scripts

### DIFF
--- a/scripts/codesign.py
+++ b/scripts/codesign.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # This script assumes/requires a valid codesign certificate.
 # To add a codesign certificate programmatically:
 # 1. Unlock the login keychain:

--- a/scripts/extract_dmg.py
+++ b/scripts/extract_dmg.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import shutil
 import sys
 from pathlib import Path

--- a/scripts/get_yum_packages.py
+++ b/scripts/get_yum_packages.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import shutil
 import subprocess

--- a/scripts/gpg.py
+++ b/scripts/gpg.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 from configparser import RawConfigParser
 from pathlib import Path

--- a/scripts/irc-notify.py
+++ b/scripts/irc-notify.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Quick and dirty IRC notification script.
 

--- a/scripts/make_appimage.py
+++ b/scripts/make_appimage.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 
 try:

--- a/scripts/make_archive.py
+++ b/scripts/make_archive.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 
 try:

--- a/scripts/make_installer.py
+++ b/scripts/make_installer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import io
 import os
 import shutil

--- a/scripts/make_source_tarball.py
+++ b/scripts/make_source_tarball.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 import os
 import tarfile
 from configparser import RawConfigParser

--- a/scripts/make_zip.py
+++ b/scripts/make_zip.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 import os
 import stat
 import sys

--- a/scripts/notarize.py
+++ b/scripts/notarize.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # This script assumes/requires credentials stored in a keychain profile.
 # To store credentials in a keychain profile programmatically:
 # xcrun notarytool store-credentials <PROFILE-NAME> [--apple-id <APPLE-ID>] [--team-id <TEAM-ID>] [--password <APP-SPECIFIC-PASSWORD>]

--- a/scripts/sha256sum.py
+++ b/scripts/sha256sum.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 
 import glob

--- a/scripts/signtool.py
+++ b/scripts/signtool.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import sys
 from configparser import RawConfigParser

--- a/scripts/test_determinism.py
+++ b/scripts/test_determinism.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import hashlib
 import os
 import shutil

--- a/scripts/update-github-repo
+++ b/scripts/update-github-repo
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Update a pinned github repository.
 

--- a/scripts/update_permissions.py
+++ b/scripts/update_permissions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Some distros (ubuntu-20.04, debian-10) have a default umask of 022
 # while others (ubuntu-20.10, fedora-32) use 0002. Normalizing this
 # helps with deterministic/reproducible builds.

--- a/scripts/update_timestamps.py
+++ b/scripts/update_timestamps.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import subprocess
 import sys


### PR DESCRIPTION
The presence of `python3`-invoking shebang lines (`#!/usr/bin/env python3`) atop some of the scripts under the "scripts/" dir was causing issues for newly provisioned Windows 10 buildbot-workers (whereby the presence of the line would lead Windows to interrupt execution and ask to install Python from the Microsoft Store, even when invoking the scripts from Python itself). This appears to be a problem stemming from changes to Python 3.11's  `py` wrapper as per [this SO post](https://stackoverflow.com/questions/74349036/behavior-change-in-py-exe-on-recent-versions-of-python-for-windows) since the issue does not occur with Python 3.10's `py` wrapper. 

This PR removes the problematic lines, restoring the functionality of the scripts, even when invoked under Python 3.11.

Fikes #654 