### PR TITLE
Improve language in user-facing Magic-Folder invite errors

### DIFF
--- a/gridsync/gui/usage.py
+++ b/gridsync/gui/usage.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import traceback
 import webbrowser
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -25,7 +24,7 @@ from gridsync.gui.voucher import VoucherCodeDialog
 from gridsync.gui.widgets import VSpacer
 from gridsync.msg import error
 from gridsync.types_ import TwistedDeferred
-from gridsync.util import future_date
+from gridsync.util import future_date, traceback
 
 if TYPE_CHECKING:
     from gridsync.gui import AbstractGui  # pylint: disable=cyclic-import
@@ -265,14 +264,6 @@ class UsageView(QWidget):
             )
         return added
 
-    @staticmethod
-    def _traceback(exc: Exception) -> str:
-        return "".join(
-            traceback.format_exception(
-                type(exc), value=exc, tb=exc.__traceback__
-            )
-        )
-
     @Slot()
     @inlineCallbacks
     def on_voucher_link_clicked(self) -> TwistedDeferred[None]:
@@ -285,7 +276,7 @@ class UsageView(QWidget):
             self.status_label.setText("Error adding voucher")
             self.status_label.setStyleSheet("color: red")
             reactor.callLater(5, self._reset_status)  # type: ignore
-            error(self, "Error adding voucher", str(exc), self._traceback(exc))
+            error(self, "Error adding voucher", str(exc), traceback(exc))
             return
         self.status_label.setText(
             "Voucher successfully added; token redemption should begin shortly"
@@ -300,7 +291,7 @@ class UsageView(QWidget):
             self.status_label.setText("Error adding voucher")
             self.status_label.setStyleSheet("color: red")
             reactor.callLater(5, self._reset_status)  # type: ignore
-            error(self, "Error adding voucher", str(exc), self._traceback(exc))
+            error(self, "Error adding voucher", str(exc), traceback(exc))
             return
         payment_url = self.gateway.zkapauthorizer.zkap_payment_url(voucher)
         logging.debug("Opening payment URL %s ...", payment_url)

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -64,7 +64,7 @@ from gridsync.gui.model import Model
 from gridsync.gui.pixmap import Pixmap
 from gridsync.gui.share import InviteSenderDialog
 from gridsync.gui.widgets import ClickableLabel, HSpacer, VSpacer
-from gridsync.magic_folder import MagicFolderStatus, MagicFolderWebError
+from gridsync.magic_folder import MagicFolderStatus
 from gridsync.msg import error
 from gridsync.tahoe import Tahoe
 from gridsync.types_ import TwistedDeferred

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -281,22 +281,17 @@ class View(QTreeView):
     ) -> None:
         try:
             await self._do_invite(dialog, folder_name, participant_name, mode)
-        except MagicFolderWebError as e:
+        except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
                 f"Error inviting {participant_name} to {folder_name}",
                 f'An error occurred when inviting "{participant_name}" to '
-                f'the "{folder_name}" folder: {e.reason}',
-                f"{type(e).__name__}: {str(e)}",
-            )
-        except Exception as e:  # pylint: disable=broad-except
-            logging.error("%s: %s", type(e).__name__, str(e))
-            error(
-                self,
-                f"Error inviting {participant_name} to {folder_name}",
-                f'An exception was raised when inviting "{participant_name}" '
-                f'to the "{folder_name}" folder:\n\n'
+                f'the "{folder_name}" folder: {reason}',
                 f"{type(e).__name__}: {str(e)}",
             )
 

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -284,7 +284,7 @@ class View(QTreeView):
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
             try:
-                reason = str(e.reason)
+                reason = str(e.reason)  # type: ignore[attr-defined]
             except AttributeError:
                 reason = f"{type(e).__name__}: {str(e)}"
             error(

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -344,10 +344,9 @@ class View(QTreeView):
                 self,
                 f"Error joining {folder_name}",
                 f'An error occurred when joining the "{folder_name}" folder: '
-                f'{reason}',
+                f"{reason}",
                 f"{type(e).__name__}: {str(e)}",
             )
-
 
     def open_magic_folder_join_dialog(self) -> None:
         dialog = MagicFolderJoinDialog()
@@ -380,7 +379,7 @@ class View(QTreeView):
                 self,
                 f'Error downloading "{folder_name}" folder',
                 f'An error occurred when downloading the "{folder_name}" '
-                f'folder: {reason}',
+                f"folder: {reason}",
                 f"{type(e).__name__}: {str(e)}",
             )
             return

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import traceback
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import (
@@ -68,7 +67,7 @@ from gridsync.magic_folder import MagicFolderStatus
 from gridsync.msg import error
 from gridsync.tahoe import Tahoe
 from gridsync.types_ import TwistedDeferred
-from gridsync.util import humanized_list
+from gridsync.util import humanized_list, traceback
 
 if TYPE_CHECKING:
     from gridsync.gui import AbstractGui
@@ -171,11 +170,7 @@ class View(QTreeView):
                 self,
                 "Error creating rootcap",
                 f"Could not create rootcap: {str(exc)}",
-                "".join(
-                    traceback.format_exception(
-                        type(exc), value=exc, tb=exc.__traceback__
-                    )
-                ),
+                traceback(exc),
             )
 
     def maybe_prompt_for_recovery(self) -> None:
@@ -237,7 +232,7 @@ class View(QTreeView):
                 f'Error cancelling invite to "{folder_name}"',
                 f'An error occurred when cancelling the invite "{id_}" '
                 f'to the "{folder_name}" folder: {reason}',
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
 
     async def _do_invite(
@@ -296,7 +291,7 @@ class View(QTreeView):
                 f"Error inviting {participant_name} to {folder_name}",
                 f'An error occurred when inviting "{participant_name}" to '
                 f'the "{folder_name}" folder: {reason}',
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
 
     def open_magic_folder_invite_dialog(self, folder_name: str) -> None:
@@ -345,7 +340,7 @@ class View(QTreeView):
                 f"Error joining {folder_name}",
                 f'An error occurred when joining the "{folder_name}" folder: '
                 f"{reason}",
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
 
     def open_magic_folder_join_dialog(self) -> None:
@@ -380,7 +375,7 @@ class View(QTreeView):
                 f'Error downloading "{folder_name}" folder',
                 f'An error occurred when downloading the "{folder_name}" '
                 f"folder: {reason}",
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
             return
         logging.debug('Successfully joined folder "%s"', folder_name)
@@ -417,7 +412,7 @@ class View(QTreeView):
                 f'Error removing "{folder_name}" backup',
                 f'An error occurred when removing the "{folder_name}" backup: '
                 f"{reason}\n\nPlease try again later.",
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
             return
         self.get_model().remove_folder(folder_name)
@@ -475,7 +470,7 @@ class View(QTreeView):
                 f'Error removing "{folder_name}" folder',
                 f'An error occurred when removing the "{folder_name}" folder: '
                 f"{reason}\n\nPlease try again later.",
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
             return
         self.get_model().on_folder_removed(folder_name)
@@ -679,7 +674,7 @@ class View(QTreeView):
                 f'Error adding "{folder_name}" folder',
                 f'An error occurred when adding the "{folder_name}" folder: '
                 f"{reason}\n\nPlease try again later.",
-                f"{type(e).__name__}: {str(e)}",
+                traceback(e),
             )
             self.get_model().remove_folder(folder_name)
             return

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -332,13 +332,18 @@ class View(QTreeView):
             await self._do_join(dialog, folder_name, invite_code, local_path)
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
                 f"Error joining {folder_name}",
-                f'An exception was raised when joining the "{folder_name}" '
-                "folder:\n\n"
+                f'An error occurred when joining the "{folder_name}" folder: '
+                f'{reason}',
                 f"{type(e).__name__}: {str(e)}",
             )
+
 
     def open_magic_folder_join_dialog(self) -> None:
         dialog = MagicFolderJoinDialog()

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -228,11 +228,15 @@ class View(QTreeView):
             await self.gateway.magic_folder.invite_cancel(folder_name, id_)
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
                 f'Error cancelling invite to "{folder_name}"',
-                f'An exception was raised when cancelling the invite "{id_}" '
-                f'to the "{folder_name}" folder:\n\n'
+                f'An error occurred when cancelling the invite "{id_}" '
+                f'to the "{folder_name}" folder: {reason}',
                 f"{type(e).__name__}: {str(e)}",
             )
 
@@ -368,11 +372,16 @@ class View(QTreeView):
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
-                'Error downloading folder "{}"'.format(folder_name),
-                'An exception was raised when downloading the "{}" folder:\n\n'
-                "{}: {}".format(folder_name, type(e).__name__, str(e)),
+                f'Error downloading "{folder_name}" folder',
+                f'An error occurred when downloading the "{folder_name}" '
+                f'folder: {reason}',
+                f"{type(e).__name__}: {str(e)}",
             )
             return
         logging.debug('Successfully joined folder "%s"', folder_name)
@@ -400,13 +409,16 @@ class View(QTreeView):
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
-                'Error removing "{}" backup'.format(folder_name),
-                'An exception was raised when removing the "{}" backup:\n\n'
-                "{}: {}\n\nPlease try again later.".format(
-                    folder_name, type(e).__name__, str(e)
-                ),
+                f'Error removing "{folder_name}" backup',
+                f'An error occurred when removing the "{folder_name}" backup: '
+                f"{reason}\n\nPlease try again later.",
+                f"{type(e).__name__}: {str(e)}",
             )
             return
         self.get_model().remove_folder(folder_name)
@@ -455,13 +467,16 @@ class View(QTreeView):
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
-                'Error removing folder "{}"'.format(folder_name),
-                'An exception was raised when removing the "{}" folder:\n\n'
-                "{}: {}\n\nPlease try again later.".format(
-                    folder_name, type(e).__name__, str(e)
-                ),
+                f'Error removing "{folder_name}" folder',
+                f'An error occurred when removing the "{folder_name}" folder: '
+                f"{reason}\n\nPlease try again later.",
+                f"{type(e).__name__}: {str(e)}",
             )
             return
         self.get_model().on_folder_removed(folder_name)
@@ -656,13 +671,16 @@ class View(QTreeView):
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
+            try:
+                reason = str(e.reason)  # type: ignore[attr-defined]
+            except AttributeError:
+                reason = f"{type(e).__name__}: {str(e)}"
             error(
                 self,
-                'Error adding folder "{}"'.format(folder_name),
-                'An exception was raised when adding the "{}" folder:\n\n'
-                "{}: {}\n\nPlease try again later.".format(
-                    folder_name, type(e).__name__, str(e)
-                ),
+                f'Error adding "{folder_name}" folder',
+                f'An error occurred when adding the "{folder_name}" folder: '
+                f"{reason}\n\nPlease try again later.",
+                f"{type(e).__name__}: {str(e)}",
             )
             self.get_model().remove_folder(folder_name)
             return

--- a/gridsync/gui/view.py
+++ b/gridsync/gui/view.py
@@ -64,7 +64,7 @@ from gridsync.gui.model import Model
 from gridsync.gui.pixmap import Pixmap
 from gridsync.gui.share import InviteSenderDialog
 from gridsync.gui.widgets import ClickableLabel, HSpacer, VSpacer
-from gridsync.magic_folder import MagicFolderStatus
+from gridsync.magic_folder import MagicFolderStatus, MagicFolderWebError
 from gridsync.msg import error
 from gridsync.tahoe import Tahoe
 from gridsync.types_ import TwistedDeferred
@@ -281,6 +281,15 @@ class View(QTreeView):
     ) -> None:
         try:
             await self._do_invite(dialog, folder_name, participant_name, mode)
+        except MagicFolderWebError as e:
+            logging.error("%s: %s", type(e).__name__, str(e))
+            error(
+                self,
+                f"Error inviting {participant_name} to {folder_name}",
+                f'An error occurred when inviting "{participant_name}" to '
+                f'the "{folder_name}" folder: {e.reason}',
+                f"{type(e).__name__}: {str(e)}",
+            )
         except Exception as e:  # pylint: disable=broad-except
             logging.error("%s: %s", type(e).__name__, str(e))
             error(

--- a/gridsync/util.py
+++ b/gridsync/util.py
@@ -5,6 +5,7 @@ from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from time import time
+from traceback import format_exception
 from typing import TYPE_CHECKING, Callable, Coroutine, Optional, TypeVar, Union
 
 import attr
@@ -20,6 +21,12 @@ B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 if TYPE_CHECKING:
     from gridsync.types_ import TwistedDeferred
+
+
+def traceback(exc: Exception) -> str:
+    return "".join(
+        format_exception(type(exc), value=exc, tb=exc.__traceback__)
+    )
 
 
 def b58encode(b: bytes) -> str:  # Adapted from python-bitcoinlib

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,7 @@ from gridsync.util import (
     humanized_list,
     strip_html_tags,
     to_bool,
+    traceback,
 )
 
 # From https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
@@ -111,3 +112,12 @@ def test_future_date_does_not_return_centuries_for_small_int_days():
 )
 def test_strip_html_tags(s, expected):
     assert strip_html_tags(s) == expected
+
+
+def test_traceback():
+    try:
+        raise ValueError("test")
+    except ValueError as exc:
+        tb = traceback(exc)
+    assert isinstance(tb, str)
+    assert "ValueError: test" in tb


### PR DESCRIPTION
This PR updates the language used in Magic-Folder-related error messages to be a little less technical for end-users (while still preserving technical details should they be required). Specifically:

* Language in the form of "An exception was raised..." is now "An error occurred...".
* For Magic-Folder errors that provide a `reason` field, the provided `reason` value will be now take priority and be displayed in place of the previously-shown technical information (about, e.g., which HTTP method was used, the status code, etc. for Magic-Folder web API errors).
* Full tracebacks (containing the information previously shown above) are now available via the "Show details..." button.