### PR TITLE
Remove unused dependency: hyperlink

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     'distro ; sys_platform != "darwin" and sys_platform != "win32"',
     "filelock",
     "humanize",
-    "hyperlink",
     "magic-wormhole",
     "psutil",
     "PyNaCl >= 1.2.0",  # 1.2.0 adds Argon2id KDF

--- a/requirements/gridsync-base.txt
+++ b/requirements/gridsync-base.txt
@@ -238,7 +238,6 @@ hyperlink==21.0.0 \
     --hash=sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b \
     --hash=sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4
     # via
-    #   -r requirements/gridsync.in
     #   autobahn
     #   treq
     #   twisted

--- a/requirements/gridsync.in
+++ b/requirements/gridsync.in
@@ -15,7 +15,6 @@ attrs
 autobahn >= 21.11.1, != 22.5.1, != 22.4.2, != 22.4.1, < 22.4.1
 certifi
 humanize
-hyperlink
 magic-wormhole
 psutil
 # PyNaCl 1.2.0 adds Argon2id KDF


### PR DESCRIPTION
## Summary

Hello @crwood,

I hope you're doing well! I've just opened this pull request that proposes the removal of the unused `hyperlink` direct dependency from the `pyproject.toml` and `requirements/gridsync.in` configuration files. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. Your insights on this would be really valuable.

## Rationale

The `hyperlink` library was introduced  in  0a032c9. However it appears to be unused in the source code. It was added on the grounds that it was required transitively by `twisted `.

Therefore, when `gridsync` is installed through pip (e.g. `pip install -e .`), pip will automatically resolve `hyperlink` through `twisted`.

Removing this direct dependency will  mitigate potential security risks and, most importantly, simplify the dependency management process. Currently,  if `twisted` stops using `hyperlink` in the future, the project will still resolve the dependency since it is directly declared.

## Changes

- Removed the `hyperlink`  dependency from the `pyproject.toml` and `requirements/gridsync.in` file.
- Updated `.requirements/gridsync-base.txt` to reflect on this change

## Impact

- Reduced package size: Eliminating this unused dependency will decrease the overall size of the installed packages.

- Simplified dependency tree: A leaner list of dependencies aids in more straightforward project maintenance and faster installations. 

