### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,6 @@ jobs:
       matrix:
         os: [macos-12, macos-13]
         qt: [pyqt6]
-      fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       QT_API: ${{ matrix.qt }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
   macOS:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14-large]
+        os: [macos-12, macos-13, macos-14]
         qt: [pyqt6]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
   macOS:
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,7 @@ jobs:
       matrix:
         os: [macos-12, macos-13, macos-14-large]
         qt: [pyqt6]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       QT_API: ${{ matrix.qt }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
   macOS:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13]
         qt: [pyqt6]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -155,7 +155,7 @@ jobs:
     - name: Make pyinstaller
       run: |
         source ~/.bashrc
-        arch -x86_64 make pyinstaller
+        make pyinstaller
         make zip
     - name: Verify
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
     - name: Make pyinstaller
       run: |
         source ~/.bashrc
-        make pyinstaller
+        arch -x86_64 make pyinstaller
         make zip
     - name: Verify
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:
@@ -115,7 +115,7 @@ jobs:
   macOS:
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-12, macos-13, macos-14-large]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:

--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,7 @@ pyinstaller-separate:
 	python3 -m tox -e pyinstaller-gridsync
 
 pyinstaller-merged:
-	@case `uname` in \
-		Darwin)	arch -x86_64 python3 -m tox -vv -e pyinstaller;; \
-		*) python3 -m tox -vv -e pyinstaller;; \
-	esac
+	python3 -m tox -vv -e pyinstaller
 
 pyinstaller:
 	$(MAKE) pyinstaller-merged

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,10 @@ pyinstaller-separate:
 	python3 -m tox -e pyinstaller-gridsync
 
 pyinstaller-merged:
-	python3 -m tox -vv -e pyinstaller
+	@case `uname` in \
+		Darwin)	arch -x86_64 python3 -m tox -vv -e pyinstaller;; \
+		*) python3 -m tox -vv -e pyinstaller;; \
+	esac
 
 pyinstaller:
 	$(MAKE) pyinstaller-merged

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ pyinstaller-separate:
 	python3 -m tox -e pyinstaller-gridsync
 
 pyinstaller-merged:
-	python3 -m tox -e pyinstaller
+	python3 -m tox -vv -e pyinstaller
 
 pyinstaller:
 	$(MAKE) pyinstaller-merged


### PR DESCRIPTION
This PR removes the deprecated `macos-11` runner from the GitHub Actions CI matrix, and adds `macos-13` and `ubuntu-24.04`.

Closes #700 