### PR TITLE
Support Pytest 8.2+

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,9 +1,7 @@
 # This autobahn constraint is inherited from Tahoe-LAFS:
 # https://github.com/tahoe-lafs/tahoe-lafs/blob/15c7916e0812e6baa2a931cd54b18f3382a8456e/setup.py#L119
 autobahn < 22.4.1
-# Integration tests hang/timeout with pytest version 8.2.0.
-# See https://github.com/gridsync/gridsync/issues/690
-pytest < 8.2.0
+pytest
 pytest-cov
 pytest-qt
 pytest-twisted

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -291,9 +291,9 @@ pyopenssl==24.1.0 \
     --hash=sha256:17ed5be5936449c5418d1cd269a1a9e9081bc54c17aed272b45856a3d3dc86ad \
     --hash=sha256:cabed4bfaa5df9f1a16c0ef64a0cb65318b5cd077a7eda7d6970131ca2f41a6f
     # via twisted
-pytest==8.1.2 \
-    --hash=sha256:6c06dc309ff46a05721e6fd48e492a775ed8165d2ecdf57f156a80c7e95bb142 \
-    --hash=sha256:f3c45d1d5eed96b01a2aea70dee6a4a366d51d38f9957768083e4fecfc77f3ef
+pytest==8.2.2 \
+    --hash=sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343 \
+    --hash=sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -307,9 +307,9 @@ pytest-qt==4.4.0 \
     --hash=sha256:001ed2f8641764b394cf286dc8a4203e40eaf9fff75bf0bfe5103f7f8d0c591d \
     --hash=sha256:76896142a940a4285339008d6928a36d4be74afec7e634577e842c9cc5c56844
     # via -r requirements/test.in
-pytest-twisted==1.14.1 \
-    --hash=sha256:a9b18bc9fca47d2886f8efe3fd27879a81f1c0bb49f1c560666c9e764491b632 \
-    --hash=sha256:b66554bbf03242b9e9d16226a59b4dfe5d09dc45d6e7b5b3545a8ec9fd726777
+pytest-twisted==1.14.2 \
+    --hash=sha256:6971cfe7df1b5258ca70cd4cc5aba00f6af7a056db4213ade2f06f6297e599db \
+    --hash=sha256:a9b623bcbc9951ff96a505185f8ed2e97469c7216f8593e86854a0f8e482192e
     # via -r requirements/test.in
 service-identity==24.1.0 \
     --hash=sha256:6829c9d62fb832c2e1c435629b0a8c476e1929881f28bee4d20bc24161009221 \


### PR DESCRIPTION
`pytest-twisted` 1.14.2 was just released, [fixing](https://github.com/pytest-dev/pytest-twisted/pull/178) the issue that was seemingly causing Gridsync's integration tests to hang when using pytest 8.2 under `tox`.

Closes #690 