### PR TITLE
Remove deprecated `windows-2019` runner from GitHub Actions matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
   Windows:
     strategy:
       matrix:
-        os: [windows-2022]
+        os: [windows-2022 windows-2025]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
   Windows:
     strategy:
       matrix:
-        os: [windows-2022 windows-2025]
+        os: [windows-2022, windows-2025]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,9 @@ jobs:
   Windows:
     strategy:
       matrix:
-        os: [windows-2022, windows-2025]
+        # windows-2025 builds are currently failing. See
+        # https://github.com/gridsync/gridsync/issues/729
+        os: [windows-2022]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
   Windows:
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         qt: [pyqt6]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Closes https://github.com/gridsync/gridsync/issues/728